### PR TITLE
Fix compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(
   src/GDBServer.cpp
   src/utils.cpp
   src/usb_config.cpp
-  test/tests.cpp
+  test/picorvd_tests.cpp
   bin/singlewire.pio.h
 )
 

--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -4,7 +4,7 @@
 #include "RVDebug.h"
 #include "WCHFlash.h"
 #include "SoftBreak.h"
-#include "test/tests.h"
+#include "test/picorvd_tests.h"
 #ifdef INCLUDE_BLINKY_BINARY
 #include "example/bin/blink.h"
 #endif


### PR DESCRIPTION
https://github.com/aappleby/PicoRVD/commit/ebe7221657521e5ab430cf89085dc448161bd5c7 renamed `test/tests.cpp → test/picorvd_tests.cpp yet failed to adapt the CMakeLists.txt accordingly.