### PR TITLE
Fix cmake config and compilation errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(pico_sdk_import.cmake)
 project(PicoRVD C CXX ASM)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 
 option(INCLUDE_BLINKY_BINARY "Include Blinky binary in PicoRVD" ON) 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Not all GDB remote functionality is implemented, but read/write of RAM, erasing/
 
 ## Building:
 
-Make sure PICO_SDK_PATH is set in your environment and run "build.sh" to compile.
+Make sure PICO_SDK_PATH is set in your environment for release 1.5.0 and run "build.sh" to compile.
 
 Run "upload.sh" to upload the app to your Pico if it's connected to a Pico Debug Probe, or just use the standard hold-reset-and-reboot to mount your Pico as a flash drive and then copy bin/picorvd.uf2 to it.
 


### PR DESCRIPTION
The highest CXX standard supported by the version of cmake 3.13 is 20.  I had to experiment with different versions of the Pico SDK to get this to compile, so I have added a note to the README stating to use version 1.5.0.