### PR TITLE
Add missing include

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdarg.h>
 #include <stdio.h>
+#include <cstdint>
 
 using putter = void (*)(char);
 using getter = char (*)();


### PR DESCRIPTION
Build fails with: `error: 'uint8_t' was not declared in this scope`.