### PR TITLE
Use older SDK for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout PicoRVD
@@ -14,11 +14,11 @@ jobs:
         with:
           path: PicoRVD
 
-      - name: Checkout pico-sdk/master
+      - name: Checkout pico-sdk/1.5.1
         uses: actions/checkout@v3
         with:
           repository: raspberrypi/pico-sdk
-          ref: master
+          ref: 1.5.1
           path: pico-sdk
 
       - name: Checkout pico-sdk submodules
@@ -35,16 +35,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential git cmake gcc-arm-none-eabi gcc-riscv64-unknown-elf
 
       - name: Install dependencies (Mac)
-        if: ${{ matrix.os == 'macos-13' }}
+        if: ${{ matrix.os == 'macos-14' }}
         run: |
           brew install cmake make
-          brew tap ArmMbed/homebrew-formulae
-          brew install arm-none-eabi-gcc
+          brew install gcc-arm-embedded
           brew tap riscv-software-src/riscv
           brew install riscv-tools
 
       - name: Build Project (CH32V003 Blinky)
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-14' }}
         working-directory: ${{github.workspace}}/PicoRVD
         shell: bash
         run: |

--- a/example/blink.cpp
+++ b/example/blink.cpp
@@ -1,4 +1,3 @@
-#define SYSTEM_CORE_CLOCK 48000000
 #include "ch32v003fun.h"
 
 __attribute__((noinline)) void busywait(int x) {
@@ -8,7 +7,7 @@ __attribute__((noinline)) void busywait(int x) {
 
 int main()
 {
-  SystemInit48HSI();
+  SystemInit();
 
   // Enable GPIOD.
   RCC->APB2PCENR |= RCC_APB2Periph_GPIOD;

--- a/example/ch32v003fun.c
+++ b/example/ch32v003fun.c
@@ -1,9 +1,85 @@
 // Mixture of embedlibc, and ch32v00x_startup.c
-
-
-
 // Use with newlib headers.
 // Mixture of weblibc, mini-printf and ???
+/* This file contains the following functions:
+
+// libc (via musl) mixture and miniprintf
+
+int printf( const char* format, ... )
+int vprintf(const char* format, va_list args)
+int snprintf( char * buffer, unsigned int buffer_len, const char* format, ... )
+int sprintf( char * buffer, const char * format, ... )
+size_t wcrtomb(char *restrict s, wchar_t wc, mbstate_t *restrict st)
+int wctomb(char *s, wchar_t wc)
+size_t strlen(const char *s)
+size_t strnlen(const char *s, size_t n)
+void *memset(void *dest, int c, size_t n)
+char *strcpy(char *d, const char *s)
+char *strncpy(char *d, const char *s, size_t n)
+int strcmp(const char *l, const char *r)
+int strncmp(const char *_l, const char *_r, size_t n)
+static char *twobyte_strstr(const unsigned char *h, const unsigned char *n)
+static char *threebyte_strstr(const unsigned char *h, const unsigned char *n)
+static char *fourbyte_strstr(const unsigned char *h, const unsigned char *n)
+static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
+char *strstr(const char *h, const char *n)
+char *strchr(const char *s, int c)
+void *__memrchr(const void *m, int c, size_t n)
+char *strrchr(const char *s, int c)
+void *memcpy(void *dest, const void *src, size_t n)
+int memcmp(const void *vl, const void *vr, size_t n)
+void *memmove(void *dest, const void *src, size_t n)
+void *memchr(const void *src, int c, size_t n)
+int puts(const char *s)
+int mini_itoa(long value, unsigned int radix, int uppercase, int unsig,
+	 char *buffer)
+int mini_vsnprintf(char *buffer, unsigned int buffer_len, const char *fmt, va_list va)
+int mini_vpprintf(int (*puts)(char* s, int len, void* buf), void* buf, const char *fmt, va_list va)
+int mini_snprintf(char* buffer, unsigned int buffer_len, const char *fmt, ...)
+int mini_pprintf(int (*puts)(char*s, int len, void* buf), void* buf, const char *fmt, ...)
+
+// IRQ Handling Code
+void DefaultIRQHandler( void )
+void NMI_RCC_CSS_IRQHandler( void )
+
+// Startup Code
+void InterruptVectorDefault()
+void handle_reset()
+
+// Configuration-specific I/O
+
+#if defined( FUNCONF_USE_UARTPRINTF ) && FUNCONF_USE_UARTPRINTF
+void SetupUART( int uartBRR )
+int _write(int fd, const char *buf, int size)
+int putchar(int c)
+#endif
+
+#if defined( FUNCONF_USE_DEBUGPRINTF ) && FUNCONF_USE_DEBUGPRINTF
+void handle_debug_input( int numbytes, uint8_t * data ) // You can override this!
+void poll_input()
+int _write(int fd, const char *buf, int size)
+int putchar(int c)
+void SetupDebugPrintf()
+void WaitForDebuggerToAttach()
+#endif
+
+#if (defined( FUNCONF_USE_DEBUGPRINTF ) && !FUNCONF_USE_DEBUGPRINTF) && \
+    (defined( FUNCONF_USE_UARTPRINTF ) && !FUNCONF_USE_UARTPRINTF) && \
+    (defined( FUNCONF_NULL_PRINTF ) && FUNCONF_NULL_PRINTF)
+
+int _write(int fd, const char *buf, int size)
+int putchar(int c)
+#endif
+
+void DelaySysTick( uint32_t n )
+void SystemInit()
+
+#ifdef CPLUSPLUS
+extern void __cxa_pure_virtual()
+void __libc_init_array(void)
+#endif
+
+*/
 
 #include <stdio.h>
 #include <string.h>
@@ -12,19 +88,22 @@
 #include <stdint.h>
 #include <ch32v003fun.h>
 
-int errno;
-int _write(int fd, const char *buf, int size);
+#define WEAK __attribute__((weak))
 
-int mini_vsnprintf(char *buffer, unsigned int buffer_len, const char *fmt, va_list va);
-int mini_vpprintf(int (*puts)(char* s, int len, void* buf), void* buf, const char *fmt, va_list va);
+WEAK int errno;
 
-static int __puts_uart(char *s, int len, void *buf)
+int mini_vsnprintf( char *buffer, unsigned int buffer_len, const char *fmt, va_list va );
+int mini_vpprintf( int (*puts)(char* s, int len, void* buf), void* buf, const char *fmt, va_list va );
+
+static int __puts_uart( char *s, int len, void *buf )
 {
+	(void)buf;
+
 	_write( 0, s, len );
 	return len;
 }
 
-int printf(const char* format, ...)
+WEAK int printf( const char* format, ... )
 {
 	va_list args;
 	va_start( args, format );
@@ -33,6 +112,28 @@ int printf(const char* format, ...)
 	return ret_status;
 }
 
+WEAK int vprintf(const char* format, va_list args)
+{
+	return mini_vpprintf(__puts_uart, 0, format, args);
+}
+
+WEAK int snprintf( char * buffer, unsigned int buffer_len, const char* format, ... )
+{
+	va_list args;
+	va_start( args, format );
+	int ret = mini_vsnprintf( buffer, buffer_len, format, args );
+	va_end( args );
+	return ret;
+}
+
+WEAK int sprintf( char * buffer, const char * format, ... )
+{
+	va_list args;
+	va_start( args, format );
+	int ret = mini_vsnprintf( buffer, INT_MAX, format, args );
+	va_end( args );
+	return ret;
+}
 
 /* Some stuff from MUSL
 
@@ -73,7 +174,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 typedef void * mbstate_t;
 
-size_t wcrtomb(char *restrict s, wchar_t wc, mbstate_t *restrict st)
+#ifdef UNICODE
+WEAK size_t wcrtomb(char *restrict s, wchar_t wc, mbstate_t *restrict st)
 {
 	if (!s) return 1;
 	if ((unsigned)wc < 0x80) {
@@ -105,22 +207,23 @@ size_t wcrtomb(char *restrict s, wchar_t wc, mbstate_t *restrict st)
 	errno = 0x02;//EILSEQ;
 	return -1;
 }
-int wctomb(char *s, wchar_t wc)
+WEAK int wctomb(char *s, wchar_t wc)
 {
 	if (!s) return 0;
 	return wcrtomb(s, wc, 0);
 }
-size_t strlen(const char *s) { const char *a = s;for (; *s; s++);return s-a; }
-size_t strnlen(const char *s, size_t n) { const char *p = memchr(s, 0, n); return p ? p-s : n;}
-void *memset(void *dest, int c, size_t n) { unsigned char *s = dest; for (; n; n--, s++) *s = c; return dest; }
-char *strcpy(char *d, const char *s) { for (; (*d=*s); s++, d++); return d; }
-char *strncpy(char *d, const char *s, size_t n) { for (; n && (*d=*s); n--, s++, d++); return d; }
-int strcmp(const char *l, const char *r)
+#endif
+WEAK size_t strlen(const char *s) { const char *a = s;for (; *s; s++);return s-a; }
+WEAK size_t strnlen(const char *s, size_t n) { const char *p = memchr(s, 0, n); return p ? (size_t)(p-s) : n;}
+WEAK void *memset(void *dest, int c, size_t n) { unsigned char *s = dest; for (; n; n--, s++) *s = c; return dest; }
+WEAK char *strcpy(char *d, const char *s) { for (; (*d=*s); s++, d++); return d; }
+WEAK char *strncpy(char *d, const char *s, size_t n) { for (; n && (*d=*s); n--, s++, d++); return d; }
+WEAK int strcmp(const char *l, const char *r)
 {
 	for (; *l==*r && *l; l++, r++);
 	return *(unsigned char *)l - *(unsigned char *)r;
 }
-int strncmp(const char *_l, const char *_r, size_t n)
+WEAK int strncmp(const char *_l, const char *_r, size_t n)
 {
 	const unsigned char *l=(void *)_l, *r=(void *)_r;
 	if (!n--) return 0;
@@ -222,13 +325,13 @@ static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
 	/* Search loop */
 	for (;;) {
 		/* Update incremental end-of-haystack pointer */
-		if (z-h < l) {
+		if ((size_t)(z-h) < l) {
 			/* Fast estimate for MAX(l,63) */
 			size_t grow = l | 63;
 			const unsigned char *z2 = memchr(z, 0, grow);
 			if (z2) {
 				z = z2;
-				if (z-h < l) return 0;
+				if ((size_t)(z-h) < l) return 0;
 			} else z += grow;
 		}
 
@@ -262,7 +365,15 @@ static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
 	}
 }
 
-char *strstr(const char *h, const char *n)
+WEAK char *strchr(const char *s, int c)
+{
+	c = (unsigned char)c;
+	if (!c) return (char *)s + strlen(s);
+	for (; *s && *(unsigned char *)s != c; s++);
+	return (char *)s;
+}
+
+WEAK char *strstr(const char *h, const char *n)
 {
 	/* Return immediately on empty needle */
 	if (!n[0]) return (char *)h;
@@ -280,16 +391,8 @@ char *strstr(const char *h, const char *n)
 	return twoway_strstr((void *)h, (void *)n);
 }
 
-char *strchr(const char *s, int c)
-{
-	c = (unsigned char)c;
-	if (!c) return (char *)s + strlen(s);
-	for (; *s && *(unsigned char *)s != c; s++);
-	return (char *)s;
-}
 
-
-void *__memrchr(const void *m, int c, size_t n)
+WEAK void *__memrchr(const void *m, int c, size_t n)
 {
 	const unsigned char *s = m;
 	c = (unsigned char)c;
@@ -297,12 +400,12 @@ void *__memrchr(const void *m, int c, size_t n)
 	return 0;
 }
 
-char *strrchr(const char *s, int c)
+WEAK char *strrchr(const char *s, int c)
 {
 	return __memrchr(s, c, strlen(s) + 1);
 }
 
-void *memcpy(void *dest, const void *src, size_t n)
+WEAK void *memcpy(void *dest, const void *src, size_t n)
 {
 	unsigned char *d = dest;
 	const unsigned char *s = src;
@@ -310,7 +413,7 @@ void *memcpy(void *dest, const void *src, size_t n)
 	return dest;
 }
 
-int memcmp(const void *vl, const void *vr, size_t n)
+WEAK int memcmp(const void *vl, const void *vr, size_t n)
 {
 	const unsigned char *l=vl, *r=vr;
 	for (; n && *l == *r; n--, l++, r++);
@@ -318,7 +421,7 @@ int memcmp(const void *vl, const void *vr, size_t n)
 }
 
 
-void *memmove(void *dest, const void *src, size_t n)
+WEAK void *memmove(void *dest, const void *src, size_t n)
 {
 	char *d = dest;
 	const char *s = src;
@@ -334,7 +437,7 @@ void *memmove(void *dest, const void *src, size_t n)
 
 	return dest;
 }
-void *memchr(const void *src, int c, size_t n)
+WEAK void *memchr(const void *src, int c, size_t n)
 {
 	const unsigned char *s = src;
 	c = (unsigned char)c;
@@ -342,7 +445,7 @@ void *memchr(const void *src, int c, size_t n)
 	return n ? (void *)s : 0;
 }
 
-int puts(const char *s)
+WEAK int puts(const char *s)
 {
 	int sl = strlen( s );
 	_write(0, s, sl );
@@ -354,29 +457,9 @@ int puts(const char *s)
  * The Minimal snprintf() implementation
  *
  * Copyright (c) 2013,2014 Michal Ludvig <michal@logix.cz>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the auhor nor the names of its contributors
- *       may be used to endorse or promote products derived from this software
- *       without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * Permission granted on 2024-07-13 for optional relicense under MIT license.
+ * https://github.com/mludvig/mini-printf/issues/16
  *
  * ----
  *
@@ -660,13 +743,13 @@ mini_pprintf(int (*puts)(char*s, int len, void* buf), void* buf, const char *fmt
 	Copyright 2023 Charles Lohr, under the MIT-x11 or NewBSD licenses, you choose.
 */
 
+#ifdef CPLUSPLUS
+// Method to call the C++ constructors
+void __libc_init_array(void);
+#endif
 
 int main() __attribute__((used));
 void SystemInit( void ) __attribute__((used));
-
-void InterruptVector()         __attribute__((naked)) __attribute((section(".init"))) __attribute__((used));
-void handle_reset()            __attribute__((naked)) __attribute((section(".text.handle_reset"))) __attribute__((used));
-void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) __attribute__((naked)) __attribute__((used));
 
 extern uint32_t * _sbss;
 extern uint32_t * _ebss;
@@ -679,21 +762,58 @@ extern uint32_t * _edata;
 void DefaultIRQHandler( void )
 {
 	// Infinite Loop
+#if FUNCONF_DEBUG
+	printf( "DefaultIRQHandler MSTATUS:%08x MTVAL:%08x MCAUSE:%08x MEPC:%08x\n", (int)__get_MSTATUS(), (int)__get_MTVAL(), (int)__get_MCAUSE(), (int)__get_MEPC() );
+#endif
 	asm volatile( "1: j 1b" );
 }
 
 // This makes it so that all of the interrupt handlers just alias to
 // DefaultIRQHandler unless they are individually overridden.
+
+#if defined(FUNCONF_USE_CLK_SEC) && FUNCONF_USE_CLK_SEC
+/**
+ * @brief 	Non Maskabke Interrupt handler
+ * 			Invoked when the Clock Security system
+ * 			detects the failure of the HSE oscilator.
+ * 			The sys clock is switched to HSI.
+ * 			Clears the CSSF flag in RCC->INTR
+ */
+void NMI_RCC_CSS_IRQHandler( void )
+{
+	RCC->INTR |= RCC_CSSC;	// clear the clock security int flag
+}
+
+void NMI_Handler( void ) 				 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("NMI_RCC_CSS_IRQHandler"))) __attribute__((used));
+#else
 void NMI_Handler( void )                 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
 void HardFault_Handler( void )           __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#if defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+void Ecall_M_Mode_Handler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void Ecall_U_Mode_Handler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void Break_Point_Handler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif // defined(CH32V20x) || defined(CH32V30x)
 void SysTick_Handler( void )             __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void SW_Handler( void )                  __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void WWDG_IRQHandler( void )             __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void PVD_IRQHandler( void )              __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void TAMPER_IRQHandler( void )			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void RTC_IRQHandler( void )				 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void FLASH_IRQHandler( void )            __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void RCC_IRQHandler( void )              __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#if defined(CH32V003) || defined(CH32X03x)
 void EXTI7_0_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void AWU_IRQHandler( void )              __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void EXTI0_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI1_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI2_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI3_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI4_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
 void DMA1_Channel1_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA1_Channel2_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA1_Channel3_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -701,33 +821,150 @@ void DMA1_Channel4_IRQHandler( void )    __attribute__((section(".text.vector_ha
 void DMA1_Channel5_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA1_Channel6_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA1_Channel7_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#if defined( CH32V003 ) || defined(CH32X03x)
 void ADC1_IRQHandler( void )             __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void I2C1_EV_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void I2C1_ER_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USART1_IRQHandler( void )           __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void SPI1_IRQHandler( void )             __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void ADC1_2_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
+#if defined(CH32V20x) || defined(CH32V30x)
+void USB_HP_CAN1_TX_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USB_LP_CAN1_RX0_IRQHandler( void )  __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void CAN1_RX1_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void CAN1_SCE_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif // defined(CH32V20x) || defined(CH32V30x)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void EXTI9_5_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void TIM1_BRK_IRQHandler( void )         __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_UP_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_TRG_COM_IRQHandler( void )     __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_CC_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM2_IRQHandler( void )             __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void TIM3_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM4_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void I2C1_EV_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void I2C1_ER_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#if defined( CH32V003 ) || defined( CH32X03x )
+void USART1_IRQHandler( void )           __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void SPI1_IRQHandler( void )             __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+void I2C2_EV_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void I2C2_ER_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void SPI1_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void SPI2_IRQHandler( void )			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USART1_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USART2_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USART3_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI15_10_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void RTCAlarm_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
+#if defined(CH32V10x) || defined(CH32V20x)
+void USBHD_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif // defined(CH32V10x) || defined(CH32V20x)
+#if defined(CH32V20x) || defined(CH32V30x)
+void USBHDWakeUp_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void ETH_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void ETHWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void OSC32KCal_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void OSCWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA1_Channel8_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+// This appears to be masked to USBHD
+void TIM8_BRK_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM8_UP_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM8_TRG_COM_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM8_CC_IRQHandler( void )			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void RNG_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void FSMC_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void SDIO_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM5_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void SPI3_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void UART4_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void UART5_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel1_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel2_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel3_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel4_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBHSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBHS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void UART7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void UART8_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM9_BRK_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM9_UP_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM9_TRG_COM_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM9_CC_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM10_BRK_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM10_UP_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM10_TRG_COM_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM10_CC_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel6_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel7_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel8_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel9_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel10_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA2_Channel11_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
 
-void InterruptVector()
+#if defined( CH32X03x)
+void USART2_IRQHandler( void )        __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI15_8_IRQHandler( void )      __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void EXTI25_16_IRQHandler( void )     __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USART3_IRQHandler( void ) 		  __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USART4_IRQHandler( void ) 		  __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void DMA1_Channel8_IRQHandler( void ) __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_IRQHandler( void )         __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_WakeUp_IRQHandler( void )  __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void PIOC_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void OPA_IRQHandler( void )           __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBPD_IRQHandler( void )         __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBPD_WKUP_IRQHandler( void )    __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM2_CC_IRQHandler( void )       __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM2_TRG_IRQHandler( void )      __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM2_BRK_IRQHandler( void )      __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM3_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
+
+void InterruptVector()         __attribute__((naked)) __attribute((section(".init"))) __attribute((weak,alias("InterruptVectorDefault"))) __attribute((naked));
+void InterruptVectorDefault()  __attribute__((naked)) __attribute((section(".init"))) __attribute((naked));
+void handle_reset( void ) __attribute__((section(".text.handle_reset")));
+
+#if defined( CH32V003 ) || defined( CH32X03x )
+
+void InterruptVectorDefault()
 {
 	asm volatile( "\n\
 	.align  2\n\
+	.option   push;\n\
 	.option   norvc;\n\
-	j handle_reset\n\
-	.word   0\n\
+	j handle_reset\n"
+#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
+"	.word   0\n\
 	.word   NMI_Handler               /* NMI Handler */                    \n\
 	.word   HardFault_Handler         /* Hard Fault Handler */             \n\
+	.word   0\n"
+#if defined(CH32X03x)
+"	.word   Ecall_M_Mode_Handler       /* Ecall M Mode */ \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   Ecall_U_Mode_Handler       /* Ecall U Mode */ \n\
+	.word   Break_Point_Handler        /* Break Point */ \n\
+"
+#else
+"	.word   0\n\
 	.word   0\n\
 	.word   0\n\
 	.word   0\n\
-	.word   0\n\
-	.word   0\n\
-	.word   0\n\
-	.word   0\n\
+	.word   0\n"
+#endif
+"	.word   0\n\
 	.word   0\n\
 	.word   SysTick_Handler           /* SysTick Handler */                \n\
 	.word   0\n\
@@ -756,10 +993,29 @@ void InterruptVector()
 	.word   TIM1_UP_IRQHandler        /* TIM1 Update */                    \n\
 	.word   TIM1_TRG_COM_IRQHandler   /* TIM1 Trigger and Commutation */   \n\
 	.word   TIM1_CC_IRQHandler        /* TIM1 Capture Compare */           \n\
-	.word   TIM2_IRQHandler           /* TIM2 */                           \n");
+	.word   TIM2_IRQHandler           /* TIM2 */                           \n"
+#if defined( CH32X03x )
+"	.word	USART2_IRQHandler         /* UART2 Interrupt                          */ \n\
+	.word	EXTI15_8_IRQHandler       /* External Line[8:15] Interrupt            */ \n\
+	.word	EXTI25_16_IRQHandler      /* External Line[25:16] Interrupt           */ \n\
+	.word	USART3_IRQHandler         /* UART2 Interrupt                          */ \n\
+	.word	USART4_IRQHandler         /* UART2 Interrupt                          */ \n\
+	.word	DMA1_Channel8_IRQHandler  /* DMA1 Channel 8 global Interrupt          */ \n\
+	.word	USBFS_IRQHandler          /* USB Full-Speed Interrupt                 */ \n\
+	.word	USBFS_WakeUp_IRQHandler   /* USB Full-Speed Wake-Up Interrupt         */ \n\
+	.word	PIOC_IRQHandler           /* Programmable IO Controller Interrupt     */ \n\
+	.word	OPA_IRQHandler            /* Op Amp Interrupt                         */ \n\
+	.word	USBPD_IRQHandler          /* USB Power Delivery Interrupt             */ \n\
+	.word	USBPD_WKUP_IRQHandler     /* USB Power Delivery Wake-Up Interrupt     */ \n\
+	.word	TIM2_CC_IRQHandler        /* Timer 2 Compare Global Interrupt         */ \n\
+	.word	TIM2_TRG_IRQHandler       /* Timer 2 Trigger Global Interrupt         */ \n\
+	.word	TIM2_BRK_IRQHandler       /* Timer 2 Brk Global Interrupt             */ \n\
+	.word	TIM3_IRQHandler           /* Timer 3 Global Interrupt                 */"
+#endif
+#endif
+	);
+	asm volatile( ".option   pop;\n");
 }
-
-
 
 void handle_reset()
 {
@@ -769,61 +1025,326 @@ void handle_reset()
 	la gp, __global_pointer$\n\
 .option pop\n\
 	la sp, _eusrstack\n"
+#if __GNUC__ > 10
+".option arch, +zicsr\n"
+#endif
 	// Setup the interrupt vector, processor status and INTSYSCR.
-"	li t0, 0x80\n\
-	csrw mstatus, t0\n\
-	li t0, 0x3\n\
-	csrw 0x804, t0\n\
-	la t0, InterruptVector\n\
-	ori t0, t0, 3\n\
-	csrw mtvec, t0\n"
- );
+
+#if FUNCONF_ENABLE_HPE	// Enabled nested and hardware (HPE) stack, since it's really good on the x035.
+"	li t0, 0x88\n\
+	csrs mstatus, t0\n"
+"	li t0, 0x0b\n\
+	csrw 0x804, t0\n"
+#else
+"	li a0, 0x80\n\
+	csrw mstatus, a0\n"
+#endif
+"	li a3, 0x3\n\
+	la a0, InterruptVector\n\
+	or a0, a0, a3\n\
+	csrw mtvec, a0\n" 
+	: : : "a0", "a3", "memory");
 
 	// Careful: Use registers to prevent overwriting of self-data.
 	// This clears out BSS.
-	register uint32_t * tempout = _sbss;
-	register uint32_t * tempend = _ebss;
-	while( tempout < tempend )
-		*(tempout++) = 0;
+asm volatile(
+"	la a0, _sbss\n\
+	la a1, _ebss\n\
+	li a2, 0\n\
+	bge a0, a1, 2f\n\
+1:	sw a2, 0(a0)\n\
+	addi a0, a0, 4\n\
+	blt a0, a1, 1b\n\
+2:"
+	// This loads DATA from FLASH to RAM.
+"	la a0, _data_lma\n\
+	la a1, _data_vma\n\
+	la a2, _edata\n\
+1:	beq a1, a2, 2f\n\
+	lw a3, 0(a0)\n\
+	sw a3, 0(a1)\n\
+	addi a0, a0, 4\n\
+	addi a1, a1, 4\n\
+	bne a1, a2, 1b\n\
+2:\n"
+#ifdef CPLUSPLUS
+	// Call __libc_init_array function
+"	call %0 \n\t"
+: : "i" (__libc_init_array) 
+: "a0", "a1", "a2", "a3", "a4", "a5", "t0", "t1", "t2", "memory"
+#else
+: : : "a0", "a1", "a2", "a3", "memory"
+#endif
+);
 
-	// Once we get here, it should be safe to execute regular C code.
-
-	// Load data section from flash to RAM 
-	register uint32_t * tempin = _data_lma;
-	tempout = _data_vma;
-	tempend = _edata;
-	while( tempout != tempend )
-		*(tempout++) = *(tempin++); 
-
-	asm volatile("csrw mepc, %0" : : "r"(main));
+#if defined( FUNCONF_SYSTICK_USE_HCLK ) && FUNCONF_SYSTICK_USE_HCLK
+	SysTick->CTLR = 5;
+#else
+	SysTick->CTLR = 1;
+#endif
 
 	// set mepc to be main as the root app.
-	asm volatile( "mret\n" );
+asm volatile(
+"	csrw mepc, %[main]\n"
+"	mret\n" : : [main]"r"(main) );
 }
 
-void SystemInit48HSI( void )
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+void InterruptVectorDefault()
 {
-	// Values lifted from the EVT.  There is little to no documentation on what this does.
-	RCC->CTLR  = RCC_HSION | RCC_PLLON; 				// Use HSI, but enable PLL.
-	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;	// PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
-	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;				// 1 Cycle Latency
-	RCC->INTR  = 0x009F0000;                            // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
+	asm volatile( "\n\
+	.align	1 \n\
+	.option norvc; \n\
+	j handle_reset \n"
+#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
+"	.word   0 \n\
+	.word   NMI_Handler                /* NMI */ \n\
+	.word   HardFault_Handler          /* Hard Fault */ \n\
+	.word   0 \n"
+#if !defined(CH32V10x)
+"	.word   Ecall_M_Mode_Handler       /* Ecall M Mode */ \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   Ecall_U_Mode_Handler       /* Ecall U Mode */ \n\
+	.word   Break_Point_Handler        /* Break Point */ \n\
+	.word   0 \n\
+	.word   0 \n"
+#else
+"	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n"
+#endif
+"	.word   SysTick_Handler            /* SysTick = 12 */ \n\
+	.word   0 \n\
+	.word   SW_Handler                 /* SW = 14 */ \n\
+	.word   0 \n\
+	/* External Interrupts */ \n\
+	.word   WWDG_IRQHandler            /* 16: Window Watchdog */ \n\
+	.word   PVD_IRQHandler             /* 17: PVD through EXTI Line detect */ \n\
+	.word   TAMPER_IRQHandler          /* 18: TAMPER */ \n\
+	.word   RTC_IRQHandler             /* 19: RTC */ \n\
+	.word   FLASH_IRQHandler           /* 20: Flash */ \n\
+	.word   RCC_IRQHandler             /* 21: RCC */ \n\
+	.word   EXTI0_IRQHandler           /* 22: EXTI Line 0 */ \n\
+	.word   EXTI1_IRQHandler           /* 23: EXTI Line 1 */ \n\
+	.word   EXTI2_IRQHandler           /* 24: EXTI Line 2 */ \n\
+	.word   EXTI3_IRQHandler           /* 25: EXTI Line 3 */ \n\
+	.word   EXTI4_IRQHandler           /* 26: EXTI Line 4 */ \n\
+	.word   DMA1_Channel1_IRQHandler   /* 27: DMA1 Channel 1 */ \n\
+	.word   DMA1_Channel2_IRQHandler   /* 28: DMA1 Channel 2 */ \n\
+	.word   DMA1_Channel3_IRQHandler   /* 29: DMA1 Channel 3 */ \n\
+	.word   DMA1_Channel4_IRQHandler   /* 30: DMA1 Channel 4 */ \n\
+	.word   DMA1_Channel5_IRQHandler   /* 31: DMA1 Channel 5 */ \n\
+	.word   DMA1_Channel6_IRQHandler   /* 32: DMA1 Channel 6 */ \n\
+	.word   DMA1_Channel7_IRQHandler   /* 33: DMA1 Channel 7 */ \n\
+	.word   ADC1_2_IRQHandler          /* 34: ADC1_2 */ \n"
+#if defined(CH32V20x) || defined(CH32V30x)
+"	.word   USB_HP_CAN1_TX_IRQHandler  /* 35: USB HP and CAN1 TX */ \n\
+	.word   USB_LP_CAN1_RX0_IRQHandler /* 36: USB LP and CAN1RX0 */ \n\
+	.word   CAN1_RX1_IRQHandler        /* 37: CAN1 RX1 */ \n\
+	.word   CAN1_SCE_IRQHandler        /* 38: CAN1 SCE */ \n"
+#else
+"	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n\
+	.word   0 \n"
+#endif
+"	.word   EXTI9_5_IRQHandler         /* 39: EXTI Line 9..5 */ \n\
+	.word   TIM1_BRK_IRQHandler        /* 40: TIM1 Break */ \n\
+	.word   TIM1_UP_IRQHandler         /* 41: TIM1 Update */ \n\
+	.word   TIM1_TRG_COM_IRQHandler    /* 42: TIM1 Trigger and Commutation */ \n\
+	.word   TIM1_CC_IRQHandler         /* 43: TIM1 Capture Compare */ \n\
+	.word   TIM2_IRQHandler            /* 44: TIM2 */ \n\
+	.word   TIM3_IRQHandler            /* 45: TIM3 */ \n\
+	.word   TIM4_IRQHandler            /* 46: TIM4 */ \n\
+	.word   I2C1_EV_IRQHandler         /* 47: I2C1 Event */ \n\
+	.word   I2C1_ER_IRQHandler         /* 48: I2C1 Error */ \n\
+	.word   I2C2_EV_IRQHandler         /* 49: I2C2 Event */ \n\
+	.word   I2C2_ER_IRQHandler         /* 50: I2C2 Error */ \n\
+	.word   SPI1_IRQHandler            /* 51: SPI1 */ \n\
+	.word   SPI2_IRQHandler            /* 52: SPI2 */ \n\
+	.word   USART1_IRQHandler          /* 53: USART1 */ \n\
+	.word   USART2_IRQHandler          /* 54: USART2 */ \n\
+	.word   USART3_IRQHandler          /* 55: USART3 */ \n\
+	.word   EXTI15_10_IRQHandler       /* 56: EXTI Line 15..10 */ \n\
+	.word   RTCAlarm_IRQHandler        /* 57: RTC Alarm through EXTI Line */ \n"
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+"	.word   USBWakeUp_IRQHandler       /* 58: USB Wake up from suspend */ \n"
+#if defined(CH32V20x) || defined(CH32V30x)
 
-	// From SetSysClockTo_48MHZ_HSI
-	while((RCC->CTLR & RCC_PLLRDY) == 0);														// Wait till PLL is ready
-	RCC->CFGR0 = ( RCC->CFGR0 & ((uint32_t)~(RCC_SW))) | (uint32_t)RCC_SW_PLL;					// Select PLL as system clock source
-	while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08);									// Wait till PLL is used as system clock source
+#if defined(CH32V30x)
+"   .word   TIM8_BRK_IRQHandler        /* 59: TIM8 Break == masked to USBHD? */ \n"
+#else
+"	.word   USBHD_IRQHandler           /* 59: USBHD Break */ \n"
+#endif
+"   .word   TIM8_UP_IRQHandler         /* 60: TIM8 Update */ \n\
+    .word   TIM8_TRG_COM_IRQHandler    /* 61: TIM8 Trigger and Commutation */ \n\
+    .word   TIM8_CC_IRQHandler         /* 62: TIM8 Capture Compare */ \n\
+    .word   RNG_IRQHandler             /* 63: RNG */ \n\
+    .word   FSMC_IRQHandler            /* 64: FSMC */ \n\
+    .word   SDIO_IRQHandler            /* 65: SDIO */ \n\
+    .word   TIM5_IRQHandler            /* 66: TIM5 */ \n\
+    .word   SPI3_IRQHandler            /* 67: SPI3 */ \n\
+    .word   UART4_IRQHandler           /* 68: UART4 */ \n\
+    .word   UART5_IRQHandler           /* 59: UART5 */ \n\
+    .word   TIM6_IRQHandler            /* 70: TIM6 */ \n\
+    .word   TIM7_IRQHandler            /* 71: TIM7 */ \n\
+    .word   DMA2_Channel1_IRQHandler   /* 72: DMA2 Channel 1 */ \n\
+    .word   DMA2_Channel2_IRQHandler   /* 73: DMA2 Channel 2 */ \n\
+    .word   DMA2_Channel3_IRQHandler   /* 74: DMA2 Channel 3 */ \n\
+    .word   DMA2_Channel4_IRQHandler   /* 75: DMA2 Channel 4 */ \n\
+    .word   DMA2_Channel5_IRQHandler   /* 76: DMA2 Channel 5 */ \n\
+	.word   ETH_IRQHandler             /* 77: ETH global */ \n\
+	.word   ETHWakeUp_IRQHandler       /* 78: ETH Wake up */ \n\
+    .word   0                          /* 79: CAN2_TX */ \n\
+    .word   0                          /* 80: CAN2_RX0 */ \n\
+    .word   0                          /* 81: CAN2_RX1 */ \n\
+    .word   0                          /* 82: CAN2_SCE */ \n\
+    .word   OTG_FS_IRQHandler          /* 83: OTGFS */ \n"
+#if defined(CH32V30x)
+"   .word   USBHSWakeup_IRQHandler     /* 84: USBHsWakeUp */ \n\
+    .word   USBHS_IRQHandler           /* 85: USBHS */ \n\
+    .word   DVP_IRQHandler             /* 86: DVP */ \n"
+#else
+"   .word   0                          /* 84: USBHsWakeUp */ \n\
+    .word   0                          /* 85: USBHS */ \n\
+    .word   0                          /* 86: DVP */ \n"
+#endif
+"   .word   UART6_IRQHandler           /* 87: UART6 */ \n\
+    .word   UART7_IRQHandler           /* 88: UART7 */ \n\
+    .word   UART8_IRQHandler           /* 89: UART8 */ \n\
+    .word   TIM9_BRK_IRQHandler        /* 90: TIM9 Break */ \n\
+    .word   TIM9_UP_IRQHandler         /* 91: TIM9 Update */ \n\
+    .word   TIM9_TRG_COM_IRQHandler    /* 92: TIM9 Trigger and Commutation */ \n\
+    .word   TIM9_CC_IRQHandler         /* 93: TIM9 Capture Compare */ \n\
+    .word   TIM10_BRK_IRQHandler       /* 94: TIM10 Break */ \n\
+    .word   TIM10_UP_IRQHandler        /* 95: TIM10 Update */ \n\
+    .word   TIM10_TRG_COM_IRQHandler   /* 96: TIM10 Trigger and Commutation */ \n\
+    .word   TIM10_CC_IRQHandler        /* 97: TIM10 Capture Compare */ \n\
+    .word   DMA2_Channel6_IRQHandler   /* 98: DMA2 Channel 6 */ \n\
+    .word   DMA2_Channel7_IRQHandler   /* 99: DMA2 Channel 7 */ \n\
+    .word   DMA2_Channel8_IRQHandler   /* 100: DMA2 Channel 8 */ \n\
+    .word   DMA2_Channel9_IRQHandler   /* 101: DMA2 Channel 9 */ \n\
+    .word   DMA2_Channel10_IRQHandler  /* 102: DMA2 Channel 10 */ \n\
+    .word   DMA2_Channel11_IRQHandler  /* 103: DMA2 Channel 11 */ \n"
+#endif
+#endif
+
+#endif // !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
+"	.option rvc; \n");
+
 }
 
+void handle_reset( void )
+{
+	asm volatile( "\n\
+.option push\n\
+.option norelax\n\
+	la gp, __global_pointer$\n\
+.option pop\n\
+	la sp, _eusrstack\n"
+#if __GNUC__ > 10
+  ".option arch, +zicsr\n"
+#endif
+			);
+
+	// Careful: Use registers to prevent overwriting of self-data.
+	// This clears out BSS.
+	asm volatile(
+"	la a0, _sbss\n\
+	la a1, _ebss\n\
+	bgeu a0, a1, 2f\n\
+1:	sw zero, 0(a0)\n\
+	addi a0, a0, 4\n\
+	bltu a0, a1, 1b\n\
+2:"
+	// This loads DATA from FLASH to RAM.
+"	la a0, _data_lma\n\
+	la a1, _data_vma\n\
+	la a2, _edata\n\
+	beq a1, a2, 2f\n\
+1:	lw t0, 0(a0)\n\
+	sw t0, 0(a1)\n\
+	addi a0, a0, 4\n\
+	addi a1, a1, 4\n\
+	bltu a1, a2, 1b\n\
+2:\n"
+#ifdef CPLUSPLUS
+	// Call __libc_init_array function
+"	call %0 \n\t"
+: : "i" (__libc_init_array)
+#else
+: :
+#endif
+: "a0", "a1", "a2", "a3", "memory"
+);
+
+	// Setup the interrupt vector, processor status and INTSYSCR.
+	asm volatile(
+"	li t0, 0x1f\n\
+	csrw 0xbc0, t0\n"
+
+#if defined(CH32V30x) && !defined( DISABLED_FLOAT )
+"	li t0, 0x6088\n\
+	csrs mstatus, t0\n"
+#else
+"	li t0, 0x88\n\
+	csrs mstatus, t0\n"
+#endif
+
+#if FUNCONF_ENABLE_HPE	// Enabled nested and hardware (HPE) stack, since it's really good on the x035.
+"	li t0, 0x0b\n\
+	csrw 0x804, t0\n"
+#endif
+"	la t0, InterruptVector\n\
+	ori t0, t0, 3\n\
+	csrw mtvec, t0\n"
+	: : "InterruptVector" (InterruptVector) : "t0", "memory"
+	);
+
+#if defined( FUNCONF_SYSTICK_USE_HCLK ) && FUNCONF_SYSTICK_USE_HCLK && !defined(CH32V10x)
+	SysTick->CTLR = 5;
+#else
+	SysTick->CTLR = 1;
+#endif
+
+	// set mepc to be main as the root app.
+	asm volatile(
+"	csrw mepc, %[main]\n"
+"	mret\n" : : [main]"r"(main) );
+}
+
+#endif
+
+#if defined( FUNCONF_USE_UARTPRINTF ) && FUNCONF_USE_UARTPRINTF
 void SetupUART( int uartBRR )
 {
+#ifdef CH32V003
 	// Enable GPIOD and UART.
 	RCC->APB2PCENR |= RCC_APB2Periph_GPIOD | RCC_APB2Periph_USART1;
 
 	// Push-Pull, 10MHz Output, GPIO D5, with AutoFunction
 	GPIOD->CFGLR &= ~(0xf<<(4*5));
 	GPIOD->CFGLR |= (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP_AF)<<(4*5);
-	
+#elif defined(CH32X03x)
+	RCC->APB2PCENR |= RCC_APB2Periph_GPIOB | RCC_APB2Periph_USART1;
+
+	// Push-Pull, 10MHz Output, GPIO A9, with AutoFunction
+	GPIOB->CFGHR &= ~(0xf<<(4*2));
+	GPIOB->CFGHR |= (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP_AF)<<(4*2);
+#else
+	RCC->APB2PCENR |= RCC_APB2Periph_GPIOA | RCC_APB2Periph_USART1;
+
+	// Push-Pull, 10MHz Output, GPIO A9, with AutoFunction
+	GPIOA->CFGHR &= ~(0xf<<(4*1));
+	GPIOA->CFGHR |= (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP_AF)<<(4*1);
+#endif
+
 	// 115200, 8n1.  Note if you don't specify a mode, UART remains off even when UE_Set.
 	USART1->CTLR1 = USART_WordLength_8b | USART_Parity_No | USART_Mode_Tx;
 	USART1->CTLR2 = USART_StopBits_1;
@@ -833,9 +1354,8 @@ void SetupUART( int uartBRR )
 	USART1->CTLR1 |= CTLR1_UE_Set;
 }
 
-
 // For debug writing to the UART.
-int _write(int fd, const char *buf, int size)
+WEAK int _write(int fd, const char *buf, int size)
 {
 	for(int i = 0; i < size; i++){
 	    while( !(USART1->STATR & USART_FLAG_TC));
@@ -844,12 +1364,306 @@ int _write(int fd, const char *buf, int size)
 	return size;
 }
 
+// single char to UART
+WEAK int putchar(int c)
+{
+	while( !(USART1->STATR & USART_FLAG_TC));
+	USART1->DATAR = (const char)c;
+	return 1;
+}
+#endif
+
+#if defined( FUNCONF_USE_DEBUGPRINTF ) && FUNCONF_USE_DEBUGPRINTF
+
+
+void handle_debug_input( int numbytes, uint8_t * data ) __attribute__((weak));
+void handle_debug_input( int numbytes, uint8_t * data ) { (void)numbytes; (void)data; }
+
+static void internal_handle_input( volatile uint32_t * dmdata0 )
+{
+	uint32_t dmd0 = *dmdata0;
+	int bytes = (dmd0 & 0x3f) - 4;
+	if( bytes > 0 )
+	{
+		handle_debug_input( bytes, ((uint8_t*)dmdata0) + 1 );
+	}
+}
+
+
+void poll_input()
+{
+	volatile uint32_t * dmdata0 = (volatile uint32_t *)DMDATA0;
+ 	if( ((*dmdata0) & 0x80) == 0 )
+	{
+		internal_handle_input( dmdata0 );
+		// Should be 0x80 or so, but for some reason there's a bug that retriggers.
+		*dmdata0 = 0x00;
+	}
+}
+
+
+//           MSB .... LSB
+// DMDATA0: char3 char2 char1 [status word]
+// where [status word] is:
+//   b7 = is a "printf" waiting?
+//   b0..b3 = # of bytes in printf (+4).  (5 or higher indicates a print of some kind)
+//     note: if b7 is 0 in reply, but b0..b3 have >=4 then we received data from host.
+// declare as weak to allow overriding.
+WEAK int _write(int fd, const char *buf, int size)
+{
+	(void)fd;
+
+	char buffer[4] = { 0 };
+	int place = 0;
+	uint32_t lastdmd;
+	uint32_t timeout = FUNCONF_DEBUGPRINTF_TIMEOUT; // Give up after ~40ms
+
+	if( size == 0 )
+	{
+		lastdmd = (*DMDATA0);
+		if( lastdmd && !(lastdmd&0x80) ) internal_handle_input( (uint32_t*)DMDATA0 );
+	}
+	while( place < size )
+	{
+		int tosend = size - place;
+		if( tosend > 7 ) tosend = 7;
+
+		while( ( lastdmd = (*DMDATA0) ) & 0x80 )
+			if( timeout-- == 0 ) return place;
+
+		if( lastdmd ) internal_handle_input( (uint32_t*)DMDATA0 );
+
+		timeout = FUNCONF_DEBUGPRINTF_TIMEOUT;
+
+		int t = 3;
+		while( t < tosend )
+		{
+			buffer[t-3] = buf[t+place];
+			t++;
+		}
+		*DMDATA1 = *(uint32_t*)&(buffer[0]);
+		t = 0;
+		while( t < tosend && t < 3 )
+		{
+			buffer[t+1] = buf[t+place];
+			t++;
+		}
+		buffer[0] = 0x80 | (tosend + 4);
+		*DMDATA0 = *(uint32_t*)&(buffer[0]);
+
+		//buf += tosend;
+		place += tosend;
+	}
+	return size;
+}
+
+// single to debug intf
+WEAK int putchar(int c)
+{
+	int timeout = FUNCONF_DEBUGPRINTF_TIMEOUT;
+	uint32_t lastdmd = 0;
+
+	while( ( lastdmd = (*DMDATA0) ) & 0x80 )
+		if( timeout-- == 0 ) return 0;
+
+	// Simply seeking input.
+	if( lastdmd ) internal_handle_input( (uint32_t*)DMDATA0 );
+	*DMDATA0 = 0x85 | ((const char)c<<8);
+	return 1;
+}
+
+void SetupDebugPrintf()
+{
+	// Clear out the sending flag.
+	*DMDATA1 = 0x0;
+	*DMDATA0 = 0x80;
+}
+
+void WaitForDebuggerToAttach()
+{
+	while( ((*DMDATA0) & 0x80) );
+}
+
+#endif
+
+#if (defined( FUNCONF_USE_DEBUGPRINTF ) && !FUNCONF_USE_DEBUGPRINTF) && \
+    (defined( FUNCONF_USE_UARTPRINTF ) && !FUNCONF_USE_UARTPRINTF) && \
+    (defined( FUNCONF_NULL_PRINTF ) && FUNCONF_NULL_PRINTF)
+
+WEAK int _write(int fd, const char *buf, int size)
+{
+	return size;
+}
+
+// single to debug intf
+WEAK int putchar(int c)
+{
+	return 1;
+}
+#endif
+
 void DelaySysTick( uint32_t n )
 {
-    SysTick->SR &= ~(1 << 0);
-    SysTick->CMP = n;
-    SysTick->CNT = 0; 
-    SysTick->CTLR |=(1 << 0);
-    while(!(SysTick->SR & (1 << 0)));
-    SysTick->CTLR &= ~(1 << 0);
+#ifdef CH32V003
+	uint32_t targend = SysTick->CNT + n;
+	while( ((int32_t)( SysTick->CNT - targend )) < 0 );
+#elif defined(CH32V20x) || defined(CH32V30x)
+	uint64_t targend = SysTick->CNT + n;
+	while( ((int64_t)( SysTick->CNT - targend )) < 0 );
+#elif defined(CH32V10x) || defined(CH32X03x)
+	uint32_t targend = SysTick->CNTL + n;
+	while( ((int32_t)( SysTick->CNTL - targend )) < 0 );
+#else
+	#error DelaySysTick not defined.
+#endif
 }
+
+void SystemInit()
+{
+#if defined(CH32V30x) && defined(TARGET_MCU_MEMORY_SPLIT)
+	FLASH->OBR = TARGET_MCU_MEMORY_SPLIT<<8;
+#endif
+
+#if FUNCONF_HSE_BYPASS
+	#define HSEBYP (1<<18)
+#else
+	#define HSEBYP 0
+#endif
+
+#if defined(FUNCONF_USE_CLK_SEC) && FUNCONF_USE_CLK_SEC
+#define RCC_CSS RCC_CSSON									 	// Enable clock security system
+#else
+#define RCC_CSS 0
+#endif
+
+#if defined(FUNCONF_USE_PLL) && FUNCONF_USE_PLL
+	#if defined(CH32V003)
+		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2    // HCLK = SYSCLK = APB1 And, enable PLL
+	#else
+		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV1 | RCC_PPRE1_DIV2 | PLL_MULTIPLICATION
+	#endif
+#else
+	#if defined(CH32V003) || defined(CH32X03x)
+		#define BASE_CFGR0 RCC_HPRE_DIV1     					  // HCLK = SYSCLK = APB1 And, no pll.
+	#else
+		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV1 | RCC_PPRE1_DIV1
+	#endif
+#endif
+
+// HSI always ON - needed for the Debug subsystem
+#define BASE_CTLR	(((FUNCONF_HSITRIM) << 3) | RCC_HSION | HSEBYP | RCC_CSS)
+//#define BASE_CTLR	(((FUNCONF_HSITRIM) << 3) | HSEBYP | RCC_CSS)	// disable HSI in HSE modes
+
+	// CH32V003 flash latency
+#if defined(CH32X03x)
+	FLASH->ACTLR = FLASH_ACTLR_LATENCY_2;                   // +2 Cycle Latency (Recommended per TRM)
+#elif defined(CH32V003)
+	#if FUNCONF_SYSTEM_CORE_CLOCK > 25000000
+		FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;               // +1 Cycle Latency
+	#else
+		FLASH->ACTLR = FLASH_ACTLR_LATENCY_0;               // +0 Cycle Latency
+	#endif
+#endif
+
+#if defined(FUNCONF_USE_HSI) && FUNCONF_USE_HSI
+	#if defined(CH32V30x) || defined(CH32V20x) || defined(CH32V10x)
+		EXTEN->EXTEN_CTR |= EXTEN_PLL_HSI_PRE;
+	#endif
+	#if defined(FUNCONF_USE_PLL) && FUNCONF_USE_PLL
+		RCC->CFGR0 = BASE_CFGR0;
+		RCC->CTLR  = BASE_CTLR | RCC_HSION | RCC_PLLON; 			// Use HSI, enable PLL.
+	#else
+		RCC->CFGR0 = RCC_HPRE_DIV1;                               	// PLLCLK = HCLK = SYSCLK = APB1
+		RCC->CTLR  = BASE_CTLR | RCC_HSION;     					// Use HSI, Only.
+	#endif
+
+#elif defined(FUNCONF_USE_HSE) && FUNCONF_USE_HSE
+
+	#if defined(CH32V003)
+		RCC->CTLR = BASE_CTLR | RCC_HSION | RCC_HSEON ;       		  // Keep HSI on while turning on HSE
+	#else
+		RCC->CTLR = RCC_HSEON;							  			  // Only turn on HSE.
+	#endif
+
+	// Values lifted from the EVT.  There is little to no documentation on what this does.
+	while(!(RCC->CTLR&RCC_HSERDY));
+
+	#if defined(CH32V003)
+		RCC->CFGR0 = RCC_PLLSRC_HSE_Mul2 | RCC_SW_HSE;
+	#else
+		RCC->CFGR0 = BASE_CFGR0 | RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE;
+	#endif
+
+	#if defined(FUNCONF_USE_PLL) && FUNCONF_USE_PLL
+		RCC->CTLR  = BASE_CTLR | RCC_HSEON | RCC_PLLON;            // Turn off HSI.
+	#else
+		RCC->CTLR  = RCC_HSEON | HSEBYP;                           // Turn off PLL and HSI.
+	#endif
+#endif
+
+	// CH32V10x flash prefetch buffer
+#if defined(CH32V10x)
+	// Enable Prefetch Buffer
+	FLASH->ACTLR |= FLASH_ACTLR_PRFTBE;
+#endif
+
+	// CH32V10x flash latency
+#if defined(CH32V10x)
+	#if defined(FUNCONF_USE_HSE) && FUNCONF_USE_HSE
+		#if !defined(FUNCONF_USE_PLL) || !FUNCONF_USE_PLL
+			FLASH->ACTLR = FLASH_ACTLR_LATENCY_0;           // +0 Cycle Latency
+		#else
+			#if FUNCONF_SYSTEM_CORE_CLOCK < 56000000
+				FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;       // +1 Cycle Latency
+			#else
+				FLASH->ACTLR = FLASH_ACTLR_LATENCY_2;       // +2 Cycle Latency
+			#endif
+		#endif
+	#else
+		FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;       		// +1 Cycle Latency
+	#endif
+#endif
+
+	RCC->INTR  = 0x009F0000;                               // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
+
+#if defined(FUNCONF_USE_PLL) && FUNCONF_USE_PLL
+	while((RCC->CTLR & RCC_PLLRDY) == 0);                       	// Wait till PLL is ready
+	uint32_t tmp32 = RCC->CFGR0 & ~(0x03);							// clr the SW
+	RCC->CFGR0 = tmp32 | RCC_SW_PLL;                       			// Select PLL as system clock source
+	while ((RCC->CFGR0 & (uint32_t)RCC_SWS) != (uint32_t)0x08); 	// Wait till PLL is used as system clock source
+#endif
+
+#if defined( FUNCONF_USE_UARTPRINTF ) && FUNCONF_USE_UARTPRINTF
+	SetupUART( UART_BRR );
+#endif
+#if defined( FUNCONF_USE_DEBUGPRINTF ) && FUNCONF_USE_DEBUGPRINTF
+	SetupDebugPrintf();
+#endif
+}
+
+// C++ Support
+
+#ifdef CPLUSPLUS
+// This is required to allow pure virtual functions to be defined.
+extern void __cxa_pure_virtual() { while (1); }
+
+// These magic symbols are provided by the linker.
+extern void (*__preinit_array_start[]) (void) __attribute__((weak));
+extern void (*__preinit_array_end[]) (void) __attribute__((weak));
+extern void (*__init_array_start[]) (void) __attribute__((weak));
+extern void (*__init_array_end[]) (void) __attribute__((weak));
+
+void __libc_init_array(void)
+{
+	size_t count;
+	size_t i;
+
+	count = __preinit_array_end - __preinit_array_start;
+	for (i = 0; i < count; i++)
+		__preinit_array_start[i]();
+
+	count = __init_array_end - __init_array_start;
+	for (i = 0; i < count; i++)
+		__init_array_start[i]();
+}
+#endif

--- a/example/ch32v003fun.h
+++ b/example/ch32v003fun.h
@@ -1,22 +1,232 @@
-// This contains a copy of ch32v00x.h and core_riscv.h ch32v00x_conf.h and other misc functions
+/* SPDX-License-Identifier: MIT */
+// This contains a copy of ch32v00x.h and core_riscv.h ch32v00x_conf.h and other misc functions See copyright explanation at the end of the file.
 
-/********************************** (C) COPYRIGHT  *******************************
- * File Name          : core_riscv.h
- * Author             : WCH
- * Version            : V1.0.0
- * Date               : 2022/08/08
- * Description        : RISC-V Core Peripheral Access Layer Header File
- *********************************************************************************
- * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
- *******************************************************************************/
-/*
- * NOTE: This file modified by CNLohr to be fully-header-only.
- */
- 
- 
-/* IO definitions */
+#ifndef __CH32V00x_H
+#define __CH32V00x_H
+
+#include "funconfig.h"
+
+/*****************************************************************************
+	CH32V003 BASICS
+
+	1. Be sure to see configuration section below!
+
+	2. Backend Initialization
+		SystemInit();
+
+	3. Arduino-like I/O
+		funGpioInitAll();
+		funPinMode( PA2, GPIO_CFGLR_OUT_10Mhz_PP );
+		funDigitalWrite( PA2, FUN_HIGH );
+		funDigitalWrite( PA2, FUN_HIGH );
+
+	4. Delays
+		Delay_Us(n)
+		Delay_Ms(n)
+		DelaySysTick( uint32_t n );
+
+	5. printf
+		printf, _write may be semihosted, or printed to UART.
+
+		poll_input, handle_debug_input may be used with semihsoting to accept input from host.
+
+		For UART printf, on:
+			CH32V003, Port D5, 115200 8n1
+			CH32V203, Port A9, 115200 8n1
+
+		Modifications can be made to SetupUart, or your own version as desired.
+
+    6. ISR Control Routines
+		__enable_irq();    // For global interrupt enable
+		__disable_irq();   // For global interrupt disable
+		__isenabled_irq(); // For seeing if interrupts are enabled.
+		NVIC_EnableIRQ(IRQn_Type IRQn) // To enable a specific interrupt
+
+	7. Hardware MMIO structs, i.e.
+		SysTick->CNT = current system tick counter (can be Hclk or Hclk/8)
+		TIM2->CH1CVR = direct control over a PWM output
+*/
+
+
+
+/******************************************************************************
+ * CH32V003 Fun Configs; please define any non-default options in funconfig.h *
+
+#define FUNCONF_USE_PLL 1               // Use built-in 2x PLL 
+#define FUNCONF_USE_HSI 1               // Use HSI Internal Oscillator
+#define FUNCONF_USE_HSE 0               // Use External Oscillator
+#define FUNCONF_HSITRIM 0x10            // Use factory calibration on HSI Trim.
+#define FUNCONF_SYSTEM_CORE_CLOCK 48000000  // Computed Clock in Hz (Default only for 003, other chips have other defaults)
+#define FUNCONF_HSE_BYPASS 0            // Use HSE Bypass feature (for oscillator input)
+#define FUNCONF_USE_CLK_SEC	1			// Use clock security system, enabled by default
+#define FUNCONF_USE_DEBUGPRINTF 1
+#define FUNCONF_USE_UARTPRINTF  0
+#define FUNCONF_NULL_PRINTF 0           // Have printf but direct it "nowhere"
+#define FUNCONF_SYSTICK_USE_HCLK 0      // Should systick be at 48 MHz or 6MHz?
+#define FUNCONF_TINYVECTOR 0            // If enabled, Does not allow normal interrupts.
+#define FUNCONF_UART_PRINTF_BAUD 115200 // Only used if FUNCONF_USE_UARTPRINTF is set.
+#define FUNCONF_DEBUGPRINTF_TIMEOUT 160000 // Arbitrary time units
+#define FUNCONF_ENABLE_HPE 1            // Enable hardware interrupt stack.  Very good on QingKeV4, i.e. x035, v10x, v20x, v30x, but questionable on 003.
+#define FUNCONF_USE_5V_VDD 0            // Enable this if you plan to use your part at 5V - affects USB and PD configration on the x035.
+#define FUNCONF_DEBUG      0            // Log fatal errors with "printf"
+*/
+
+// Sanity check for when porting old code.
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+	#if defined(CH32V003)
+		#error Cannot define CH32V003 and another arch.
+	#endif
+#endif
+
+#if !defined(FUNCONF_USE_DEBUGPRINTF) && !defined(FUNCONF_USE_UARTPRINTF)
+	#define FUNCONF_USE_DEBUGPRINTF 1
+#endif
+
+#if defined(FUNCONF_USE_UARTPRINTF) && FUNCONF_USE_UARTPRINTF && !defined(FUNCONF_UART_PRINTF_BAUD)
+	#define FUNCONF_UART_PRINTF_BAUD 115200
+#endif
+
+#if defined(FUNCONF_USE_DEBUGPRINTF) && FUNCONF_USE_DEBUGPRINTF && !defined(FUNCONF_DEBUGPRINTF_TIMEOUT)
+	#define FUNCONF_DEBUGPRINTF_TIMEOUT 160000
+#endif
+
+#if defined(FUNCONF_USE_HSI) && defined(FUNCONF_USE_HSE) && FUNCONF_USE_HSI && FUNCONF_USE_HSE
+       #error FUNCONF_USE_HSI and FUNCONF_USE_HSE cannot both be set
+#endif
+
+#if !defined( FUNCONF_USE_HSI ) && !defined( FUNCONF_USE_HSE )
+	#define FUNCONF_USE_HSI 1 // Default to use HSI
+	#define FUNCONF_USE_HSE 0
+#endif
+
+#if defined( CH32X03x ) && FUNCONF_USE_HSE
+	#error No HSE in CH32X03x
+#endif
+
+#if !defined( FUNCONF_USE_PLL )
+	#if defined( CH32X03x )
+		#define FUNCONF_USE_PLL 0 // No PLL on X03x
+	#else
+		#define FUNCONF_USE_PLL 1 // Default to use PLL
+	#endif
+#endif
+
+#if !defined( FUNCONF_DEBUG )
+	#define FUNCONF_DEBUG 0
+#endif
+
+#if defined( CH32X03x ) && FUNCONF_USE_PLL
+	#error No PLL on the X03x
+#endif
+
+#ifndef FUNCONF_ENABLE_HPE
+	#if defined( CH32V003 )
+		#define FUNCONF_ENABLE_HPE 0
+	#else
+		#define FUNCONF_ENABLE_HPE 1
+	#endif
+#endif
+
+
+#if !defined( FUNCONF_USE_CLK_SEC )
+	#define FUNCONF_USE_CLK_SEC  1// use clock security system by default
+#endif
+
+#ifndef HSE_VALUE
+	#if defined(CH32V003)
+		#define HSE_VALUE                 (24000000) // Value of the External oscillator in Hz, default
+	#elif defined(CH32V10x)
+		#define HSE_VALUE				  (8000000)
+	#elif defined(CH32V20x)
+		#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+		#define HSE_VALUE    			  (32000000)
+		#else
+		#define HSE_VALUE    			  (8000000)
+		#endif
+	#elif defined(CH32V30x)
+		#define HSE_VALUE				  (8000000)
+	#endif
+#endif
+
+#ifndef HSI_VALUE
+	#if defined(CH32V003)
+		#define HSI_VALUE                 (24000000) // Value of the Internal oscillator in Hz, default.
+	#elif defined(CH32X03x)
+		#define HSI_VALUE				  (48000000)
+	#elif defined(CH32V10x)
+		#define HSI_VALUE				  (8000000)
+	#elif defined(CH32V20x)
+		#define HSI_VALUE    			  (8000000)
+	#elif defined(CH32V30x)
+		#define HSI_VALUE				  (8000000)
+	#endif
+#endif
+
+#ifndef FUNCONF_HSITRIM
+	#define FUNCONF_HSITRIM 0x10  // Default (Chip default)
+#endif
+
+#ifndef FUNCONF_USE_PLL
+	#define FUNCONF_USE_PLL 1     // Default, Use PLL.
+#endif
+
+#if !defined( FUNCONF_PLL_MULTIPLIER )
+	#if defined(FUNCONF_USE_PLL) && FUNCONF_USE_PLL
+		#if defined(CH32V10x)
+			#define FUNCONF_PLL_MULTIPLIER 10	// Default: 8 * 10 = 80 MHz
+		#elif defined(CH32V20x)
+			#define FUNCONF_PLL_MULTIPLIER 18	// Default: 8 * 18 = 144 MHz
+		#elif defined(CH32V30x)
+			#define FUNCONF_PLL_MULTIPLIER 18	// Default: 8 * 18 = 144 MHz
+		#else // CH32V003
+			#define FUNCONF_PLL_MULTIPLIER 2	// Default: 24 * 2 = 48 MHz
+		#endif
+	#else
+		#define FUNCONF_PLL_MULTIPLIER 1
+	#endif
+#endif
+
+#ifndef FUNCONF_SYSTEM_CORE_CLOCK
+	#if defined(FUNCONF_USE_HSI) && FUNCONF_USE_HSI
+		#define FUNCONF_SYSTEM_CORE_CLOCK ((HSI_VALUE)*(FUNCONF_PLL_MULTIPLIER))
+	#elif defined(FUNCONF_USE_HSE) && FUNCONF_USE_HSE
+		#define FUNCONF_SYSTEM_CORE_CLOCK ((HSE_VALUE)*(FUNCONF_PLL_MULTIPLIER))
+	#else
+		#error Must define either FUNCONF_USE_HSI or FUNCONF_USE_HSE to be 1.
+	#endif
+#endif
+
+#ifndef FUNCONF_USE_5V_VDD
+	#define FUNCONF_USE_5V_VDD 0
+#endif
+
+// Default package for CH32V20x
+#if defined(CH32V20x)
+#if !defined(CH32V20x_D8W) && !defined(CH32V20x_D8) && !defined(CH32V20x_D6)
+	#define CH32V20x_D6              /* CH32V203F6-CH32V203F8-CH32V203G6-CH32V203G8-CH32V203K6-CH32V203K8-CH32V203C6-CH32V203C8 */
+	//#define CH32V20x_D8              /* CH32V203RBT6 */
+	//#define CH32V20x_D8W             /* CH32V208 */
+	#endif
+#endif
+
+// Default package for CH32V30x
+#if defined(CH32V30x)
+#if !defined(CH32V30x_D8) && !defined(CH32V30x_D8C)
+	//#define CH32V30x_D8              /* CH32V303x */
+	#define CH32V30x_D8C             /* CH32V307x-CH32V305x */
+	#endif
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// Legacy, for EVT, CMSIS
+
+#define __MPU_PRESENT             0  /* Other CH32 devices does not provide an MPU */
+#define __Vendor_SysTickConfig    0  /* Set to 1 if different SysTick Config is used */
+
+#ifndef __ASSEMBLER__  // Things before this can be used in assembly.
+
+#include <stdint.h>
+
 #ifdef __cplusplus
   #define     __I     volatile                /*!< defines 'read only' permissions      */
 #else
@@ -26,36 +236,9 @@
 #define     __IO    volatile                  /*!< defines 'read / write' permissions   */
 
 
-
-
-/********************************** (C) COPYRIGHT  *******************************
- * File Name          : ch32v00x.h
- * Author             : WCH
- * Version            : V1.0.0
- * Date               : 2022/08/08
- * Description        : CH32V00x Device Peripheral Access Layer Header File.
- *********************************************************************************
- * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
- *******************************************************************************/
-#ifndef __CH32V00x_H
-#define __CH32V00x_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define __MPU_PRESENT             0  /* Other CH32 devices does not provide an MPU */
-#define __Vendor_SysTickConfig    0  /* Set to 1 if different SysTick Config is used */
-
-#define HSE_VALUE                 ((uint32_t)24000000) /* Value of the External oscillator in Hz */
-
-/* In the following line adjust the External High Speed oscillator (HSE) Startup Timeout value */
-#define HSE_STARTUP_TIMEOUT       ((uint16_t)0x2000) /* Time out for HSE start up */
-
-#define HSI_VALUE                 ((uint32_t)24000000) /* Value of the Internal oscillator in Hz */
-
 
 /* Interrupt Number Definition, according to the selected device */
 typedef enum IRQn
@@ -63,9 +246,15 @@ typedef enum IRQn
     /******  RISC-V Processor Exceptions Numbers *******************************************************/
     NonMaskableInt_IRQn = 2, /* 2 Non Maskable Interrupt                             */
     EXC_IRQn = 3,            /* 3 Exception Interrupt                                */
+#if defined(CH32V20x) || defined(CH32V30x)
+	Ecall_M_Mode_IRQn = 5,   /* 5 Ecall M Mode Interrupt                             */
+	Ecall_U_Mode_IRQn = 8,   /* 8 Ecall U Mode Interrupt                             */
+	Break_Point_IRQn = 9,    /* 9 Break Point Interrupt                              */
+#endif
     SysTicK_IRQn = 12,       /* 12 System timer Interrupt                            */
     Software_IRQn = 14,      /* 14 software Interrupt                                */
 
+#if defined( CH32V003 ) || defined(CH32X03x)
     /******  RISC-V specific Interrupt Numbers *********************************************************/
     WWDG_IRQn = 16,          /* Window WatchDog Interrupt                            */
     PVD_IRQn = 17,           /* PVD through EXTI Line detection Interrupt            */
@@ -90,18 +279,222 @@ typedef enum IRQn
     TIM1_TRG_COM_IRQn = 36,  /* TIM1 Trigger and Commutation Interrupt               */
     TIM1_CC_IRQn = 37,       /* TIM1 Capture Compare Interrupt                       */
     TIM2_IRQn = 38,          /* TIM2 global Interrupt                                */
+#if defined(CH32X03x)
+	USART2_IRQn = 39,          /* UART2 Interrupt                          */
+	EXTI15_8_IRQn = 40,        /* External Line[8:15] Interrupt            */
+	EXTI25_16_IRQn = 41,       /* External Line[25:16] Interrupt           */
+	USART3_IRQn = 42,          /* UART2 Interrupt                          */
+	USART4_IRQn = 43,          /* UART2 Interrupt                          */
+	DMA1_Channel8_IRQn = 44,   /* DMA1 Channel 8 global Interrupt          */
+	USBFS_IRQn = 45,           /* USB Full-Speed Interrupt                 */
+	USBFS_WakeUp_IRQn = 46,    /* USB Full-Speed Wake-Up Interrupt         */
+	PIOC_IRQn = 47,            /* Programmable IO Controller Interrupt     */
+	OPA_IRQn = 48,             /* Op Amp Interrupt                         */
+	USBPD_IRQn = 49,           /* USB Power Delivery Interrupt             */
+	USBPD_WKUP_IRQn = 50,      /* USB Power Delivery Wake-Up Interrupt     */
+	TIM2_CC_IRQn = 51,         /* Timer 2 Compare Global Interrupt         */
+	TIM2_TRG_IRQn = 52,        /* Timer 2 Trigger Global Interrupt         */
+	TIM2_BRK_IRQn = 53,        /* Timer 2 Brk Global Interrupt             */
+	TIM3_IRQn = 54,            /* Timer 3 Global Interrupt                 */
+#endif
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	/******  RISC-V specific Interrupt Numbers *********************************************************/
+	WWDG_IRQn = 16,            /* Window WatchDog Interrupt                            */
+	PVD_IRQn = 17,             /* PVD through EXTI Line detection Interrupt            */
+	TAMPER_IRQn = 18,          /* Tamper Interrupt                                     */
+	RTC_IRQn = 19,             /* RTC global Interrupt                                 */
+	FLASH_IRQn = 20,           /* FLASH global Interrupt                               */
+	RCC_IRQn = 21,             /* RCC global Interrupt                                 */
+	EXTI0_IRQn = 22,           /* EXTI Line0 Interrupt                                 */
+	EXTI1_IRQn = 23,           /* EXTI Line1 Interrupt                                 */
+	EXTI2_IRQn = 24,           /* EXTI Line2 Interrupt                                 */
+	EXTI3_IRQn = 25,           /* EXTI Line3 Interrupt                                 */
+	EXTI4_IRQn = 26,           /* EXTI Line4 Interrupt                                 */
+	DMA1_Channel1_IRQn = 27,   /* DMA1 Channel 1 global Interrupt                      */
+	DMA1_Channel2_IRQn = 28,   /* DMA1 Channel 2 global Interrupt                      */
+	DMA1_Channel3_IRQn = 29,   /* DMA1 Channel 3 global Interrupt                      */
+	DMA1_Channel4_IRQn = 30,   /* DMA1 Channel 4 global Interrupt                      */
+	DMA1_Channel5_IRQn = 31,   /* DMA1 Channel 5 global Interrupt                      */
+	DMA1_Channel6_IRQn = 32,   /* DMA1 Channel 6 global Interrupt                      */
+	DMA1_Channel7_IRQn = 33,   /* DMA1 Channel 7 global Interrupt                      */
+	ADC_IRQn = 34,             /* ADC1 and ADC2 global Interrupt                       */
+#if !defined(CH32V10x) // CH32V20x/30x only
+	USB_HP_CAN1_TX_IRQn = 35,  /* USB Device High Priority or CAN1 TX Interrupts       */
+	USB_LP_CAN1_RX0_IRQn = 36, /* USB Device Low Priority or CAN1 RX0 Interrupts       */
+	CAN1_RX1_IRQn = 37,        /* CAN1 RX1 Interrupt                                   */
+	CAN1_SCE_IRQn = 38,        /* CAN1 SCE Interrupt                                   */
+#endif
+	EXTI9_5_IRQn = 39,         /* External Line[9:5] Interrupts                        */
+	TIM1_BRK_IRQn = 40,        /* TIM1 Break Interrupt                                 */
+	TIM1_UP_IRQn = 41,         /* TIM1 Update Interrupt                                */
+	TIM1_TRG_COM_IRQn = 42,    /* TIM1 Trigger and Commutation Interrupt               */
+	TIM1_CC_IRQn = 43,         /* TIM1 Capture Compare Interrupt                       */
+	TIM2_IRQn = 44,            /* TIM2 global Interrupt                                */
+	TIM3_IRQn = 45,            /* TIM3 global Interrupt                                */
+	TIM4_IRQn = 46,            /* TIM4 global Interrupt                                */
+	I2C1_EV_IRQn = 47,         /* I2C1 Event Interrupt                                 */
+	I2C1_ER_IRQn = 48,         /* I2C1 Error Interrupt                                 */
+	I2C2_EV_IRQn = 49,         /* I2C2 Event Interrupt                                 */
+	I2C2_ER_IRQn = 50,         /* I2C2 Error Interrupt                                 */
+	SPI1_IRQn = 51,            /* SPI1 global Interrupt                                */
+	SPI2_IRQn = 52,            /* SPI2 global Interrupt                                */
+	USART1_IRQn = 53,          /* USART1 global Interrupt                              */
+	USART2_IRQn = 54,          /* USART2 global Interrupt                              */
+	USART3_IRQn = 55,          /* USART3 global Interrupt                              */
+	EXTI15_10_IRQn = 56,       /* External Line[15:10] Interrupts                      */
+	RTCAlarm_IRQn = 57,        /* RTC Alarm through EXTI Line Interrupt                */
+#endif
+#if defined(CH32V10x) || defined(CH32V20x)
+	USBWakeUp_IRQn = 58,       /* USB Device WakeUp from suspend through EXTI Line Interrupt 	*/
+	USBHD_IRQn = 59,           /* USBHD global Interrupt                               */
+#endif
+#if defined(CH32V20x)
+	USBHDWakeUp_IRQn = 60,     /* USB Host/Device WakeUp Interrupt                     */
+
+#ifdef CH32V20x_D6
+	UART4_IRQn = 61,         /* UART4 global Interrupt                               */
+	DMA1_Channel8_IRQn = 62, /* DMA1 Channel 8 global Interrupt                      */
+
+#elif defined(CH32V20x_D8)
+	ETH_IRQn = 61,           /* ETH global Interrupt               	                 */
+    ETHWakeUp_IRQn = 62,     /* ETH WakeUp Interrupt                       			 */
+    TIM5_IRQn = 65,          /* TIM5 global Interrupt                                */
+    UART4_IRQn = 66,         /* UART4 global Interrupt                               */
+    DMA1_Channel8_IRQn = 67, /* DMA1 Channel 8 global Interrupt                      */
+    OSC32KCal_IRQn = 68,     /* OSC32K global Interrupt                              */
+    OSCWakeUp_IRQn = 69,     /* OSC32K WakeUp Interrupt                              */
+
+#elif defined(CH32V20x_D8W)
+    ETH_IRQn = 61,           /* ETH global Interrupt               	                 */
+    ETHWakeUp_IRQn = 62,     /* ETH WakeUp Interrupt                       			 */
+    BB_IRQn = 63,            /* BLE BB global Interrupt                              */
+    LLE_IRQn = 64,           /* BLE LLE global Interrupt                             */
+    TIM5_IRQn = 65,          /* TIM5 global Interrupt                                */
+    UART4_IRQn = 66,         /* UART4 global Interrupt                               */
+    DMA1_Channel8_IRQn = 67, /* DMA1 Channel 8 global Interrupt                      */
+    OSC32KCal_IRQn = 68,     /* OSC32K global Interrupt                              */
+    OSCWakeUp_IRQn = 69,     /* OSC32K WakeUp Interrupt                              */
+#endif
+
+#elif defined(CH32V30x)
+
+#ifdef CH32V30x_D8
+	TIM8_BRK_IRQn               = 59,      /* TIM8 Break Interrupt                                 */
+#elif defined  (CH32V30x_D8C)
+	USBWakeUp_IRQn              = 58,      /* USB Device WakeUp from suspend through EXTI Line Interrupt */
+	TIM8_BRK_IRQn               = 59,      /* TIM8 Break Interrupt                                 */
+#endif
+	TIM8_UP_IRQn                = 60,      /* TIM8 Update Interrupt                                */
+	TIM8_TRG_COM_IRQn           = 61,      /* TIM8 Trigger and Commutation Interrupt               */
+	TIM8_CC_IRQn                = 62,      /* TIM8 Capture Compare Interrupt                       */
+	RNG_IRQn                    = 63,      /* RNG global Interrupt                                 */
+	FSMC_IRQn                   = 64,      /* FSMC global Interrupt                                */
+	SDIO_IRQn                   = 65,      /* SDIO global Interrupt                                */
+	TIM5_IRQn                   = 66,      /* TIM5 global Interrupt                                */
+	SPI3_IRQn                   = 67,      /* SPI3 global Interrupt                                */
+	UART4_IRQn                  = 68,      /* UART4 global Interrupt                               */
+	UART5_IRQn                  = 69,      /* UART5 global Interrupt                               */
+#endif
+
+#if defined(CH32V30x) || defined(CH32V20x)
+	TIM6_IRQn                   = 70,      /* TIM6 global Interrupt                                */
+	TIM7_IRQn                   = 71,      /* TIM7 global Interrupt                                */
+	DMA2_Channel1_IRQn          = 72,      /* DMA2 Channel 1 global Interrupt                      */
+	DMA2_Channel2_IRQn          = 73,      /* DMA2 Channel 2 global Interrupt                      */
+	DMA2_Channel3_IRQn          = 74,      /* DMA2 Channel 3 global Interrupt                      */
+	DMA2_Channel4_IRQn          = 75,      /* DMA2 Channel 4 global Interrupt                      */
+	DMA2_Channel5_IRQn          = 76,      /* DMA2 Channel 5 global Interrupt                      */
+	OTG_FS_IRQn                 = 83,      /* OTGFS global Interrupt NOTE: THIS APPEAR TO BE INCORRECT                */
+    USBHSWakeup_IRQn            = 84,      /* USBHS Wakeup Interrupt                               */
+    USBHS_IRQn                  = 85,      /* USBHS global Interrupt                               */
+    DVP_IRQn                    = 86,      /* DVP global Interrupt                                 */
+	UART6_IRQn                  = 87,      /* UART6 global Interrupt                               */
+	UART7_IRQn                  = 88,      /* UART7 global Interrupt                               */
+	UART8_IRQn                  = 89,      /* UART8 global Interrupt                               */
+	TIM9_BRK_IRQn               = 90,      /* TIM9 Break Interrupt                                 */
+	TIM9_UP_IRQn                = 91,      /* TIM9 Update Interrupt                                */
+	TIM9_TRG_COM_IRQn           = 92,      /* TIM9 Trigger and Commutation Interrupt               */
+	TIM9_CC_IRQn                = 93,      /* TIM9 Capture Compare Interrupt                       */
+	TIM10_BRK_IRQn              = 94,      /* TIM10 Break Interrupt                                */
+	TIM10_UP_IRQn               = 95,      /* TIM10 Update Interrupt                               */
+	TIM10_TRG_COM_IRQn          = 96,      /* TIM10 Trigger and Commutation Interrupt              */
+	TIM10_CC_IRQn               = 97,      /* TIM10 Capture Compare Interrupt                      */
+	DMA2_Channel6_IRQn          = 98,      /* DMA2 Channel 6 global Interrupt                      */
+	DMA2_Channel7_IRQn          = 99,      /* DMA2 Channel 7 global Interrupt                      */
+	DMA2_Channel8_IRQn          = 100,     /* DMA2 Channel 8 global Interrupt                      */
+	DMA2_Channel9_IRQn          = 101,     /* DMA2 Channel 9 global Interrupt                      */
+	DMA2_Channel10_IRQn         = 102,     /* DMA2 Channel 10 global Interrupt                     */
+	DMA2_Channel11_IRQn         = 103,     /* DMA2 Channel 11 global Interrupt                     */
+#endif
 
 } IRQn_Type;
 
+
+#if defined (CH32V003) 
+
+/* memory mapped structure for SysTick */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t SR;
+    __IO uint32_t CNT;
+    uint32_t RESERVED0;
+    __IO uint32_t CMP;
+    uint32_t RESERVED1;
+} SysTick_Type;
+
+#elif defined(CH32V20x) || defined(CH32V30x)
+
+/* memory mapped structure for SysTick */
+typedef struct
+{
+	__IO uint32_t CTLR;
+	__IO uint32_t SR;
+	__IO uint64_t CNT;
+	__IO uint64_t CMP;
+} SysTick_Type;
+
+#elif defined(CH32X03x)
+
+/* memory mapped structure for SysTick */
+typedef struct
+{
+  __IO uint32_t CTLR;
+  __IO uint32_t SR;
+  __IO uint32_t CNTL;
+  __IO uint32_t CNTH;
+  __IO uint32_t CMPL;
+  __IO uint32_t CMPH;
+} SysTick_Type;
+
+#elif defined(CH32V10x)
+
+/* memory mapped structure for SysTick */
+typedef struct
+{
+  __IO uint32_t CTLR;
+  __IO uint32_t CNTL;
+  __IO uint32_t CNTH;
+  __IO uint32_t CMPL;
+  __IO uint32_t CMPH;
+} SysTick_Type;
+
+#endif
+
+#endif /* __ASSEMBLER__*/
+
 #define HardFault_IRQn    EXC_IRQn
 
-#include <stdint.h>
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+	#define ADC1_2_IRQn       ADC_IRQn
+#endif
 
 /* Standard Peripheral Library old definitions (maintained for legacy purpose) */
 #define HSI_Value             HSI_VALUE
 #define HSE_Value             HSE_VALUE
 #define HSEStartUp_TimeOut    HSE_STARTUP_TIMEOUT
 
+#ifndef __ASSEMBLER__
 /* Analog to Digital Converter */
 typedef struct
 {
@@ -125,8 +518,197 @@ typedef struct
     __IO uint32_t IDATAR3;
     __IO uint32_t IDATAR4;
     __IO uint32_t RDATAR;
+#if defined(CH32V20x)
     __IO uint32_t DLYR;
+#elif defined(CH32X03x)
+    __IO uint32_t CTLR3;
+    __IO uint32_t WDTR1;
+    __IO uint32_t WDTR2;
+    __IO uint32_t WDTR3;
+#endif
 } ADC_TypeDef;
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/* Backup Registers */
+typedef struct
+{
+	uint32_t      RESERVED0;
+	__IO uint16_t DATAR1;
+	uint16_t      RESERVED1;
+	__IO uint16_t DATAR2;
+	uint16_t      RESERVED2;
+	__IO uint16_t DATAR3;
+	uint16_t      RESERVED3;
+	__IO uint16_t DATAR4;
+	uint16_t      RESERVED4;
+	__IO uint16_t DATAR5;
+	uint16_t      RESERVED5;
+	__IO uint16_t DATAR6;
+	uint16_t      RESERVED6;
+	__IO uint16_t DATAR7;
+	uint16_t      RESERVED7;
+	__IO uint16_t DATAR8;
+	uint16_t      RESERVED8;
+	__IO uint16_t DATAR9;
+	uint16_t      RESERVED9;
+	__IO uint16_t DATAR10;
+	uint16_t      RESERVED10;
+	__IO uint16_t OCTLR;
+	uint16_t      RESERVED11;
+	__IO uint16_t TPCTLR;
+	uint16_t      RESERVED12;
+	__IO uint16_t TPCSR;
+	uint16_t      RESERVED13[5];
+	__IO uint16_t DATAR11;
+	uint16_t      RESERVED14;
+	__IO uint16_t DATAR12;
+	uint16_t      RESERVED15;
+	__IO uint16_t DATAR13;
+	uint16_t      RESERVED16;
+	__IO uint16_t DATAR14;
+	uint16_t      RESERVED17;
+	__IO uint16_t DATAR15;
+	uint16_t      RESERVED18;
+	__IO uint16_t DATAR16;
+	uint16_t      RESERVED19;
+	__IO uint16_t DATAR17;
+	uint16_t      RESERVED20;
+	__IO uint16_t DATAR18;
+	uint16_t      RESERVED21;
+	__IO uint16_t DATAR19;
+	uint16_t      RESERVED22;
+	__IO uint16_t DATAR20;
+	uint16_t      RESERVED23;
+	__IO uint16_t DATAR21;
+	uint16_t      RESERVED24;
+	__IO uint16_t DATAR22;
+	uint16_t      RESERVED25;
+	__IO uint16_t DATAR23;
+	uint16_t      RESERVED26;
+	__IO uint16_t DATAR24;
+	uint16_t      RESERVED27;
+	__IO uint16_t DATAR25;
+	uint16_t      RESERVED28;
+	__IO uint16_t DATAR26;
+	uint16_t      RESERVED29;
+	__IO uint16_t DATAR27;
+	uint16_t      RESERVED30;
+	__IO uint16_t DATAR28;
+	uint16_t      RESERVED31;
+	__IO uint16_t DATAR29;
+	uint16_t      RESERVED32;
+	__IO uint16_t DATAR30;
+	uint16_t      RESERVED33;
+	__IO uint16_t DATAR31;
+	uint16_t      RESERVED34;
+	__IO uint16_t DATAR32;
+	uint16_t      RESERVED35;
+	__IO uint16_t DATAR33;
+	uint16_t      RESERVED36;
+	__IO uint16_t DATAR34;
+	uint16_t      RESERVED37;
+	__IO uint16_t DATAR35;
+	uint16_t      RESERVED38;
+	__IO uint16_t DATAR36;
+	uint16_t      RESERVED39;
+	__IO uint16_t DATAR37;
+	uint16_t      RESERVED40;
+	__IO uint16_t DATAR38;
+	uint16_t      RESERVED41;
+	__IO uint16_t DATAR39;
+	uint16_t      RESERVED42;
+	__IO uint16_t DATAR40;
+	uint16_t      RESERVED43;
+	__IO uint16_t DATAR41;
+	uint16_t      RESERVED44;
+	__IO uint16_t DATAR42;
+	uint16_t      RESERVED45;
+} BKP_TypeDef;
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+/* Controller Area Network TxMailBox */
+typedef struct
+{
+	__IO uint32_t TXMIR;
+	__IO uint32_t TXMDTR;
+	__IO uint32_t TXMDLR;
+	__IO uint32_t TXMDHR;
+} CAN_TxMailBox_TypeDef;
+
+/* Controller Area Network FIFOMailBox */
+typedef struct
+{
+	__IO uint32_t RXMIR;
+	__IO uint32_t RXMDTR;
+	__IO uint32_t RXMDLR;
+	__IO uint32_t RXMDHR;
+} CAN_FIFOMailBox_TypeDef;
+
+/* Controller Area Network FilterRegister */
+typedef struct
+{
+	__IO uint32_t FR1;
+	__IO uint32_t FR2;
+} CAN_FilterRegister_TypeDef;
+
+/* Controller Area Network */
+typedef struct
+{
+	__IO uint32_t              CTLR;
+	__IO uint32_t              STATR;
+	__IO uint32_t              TSTATR;
+	__IO uint32_t              RFIFO0;
+	__IO uint32_t              RFIFO1;
+	__IO uint32_t              INTENR;
+	__IO uint32_t              ERRSR;
+	__IO uint32_t              BTIMR;
+	uint32_t                   RESERVED0[88];
+	CAN_TxMailBox_TypeDef      sTxMailBox[3];
+	CAN_FIFOMailBox_TypeDef    sFIFOMailBox[2];
+	uint32_t                   RESERVED1[12];
+	__IO uint32_t              FCTLR;
+	__IO uint32_t              FMCFGR;
+	uint32_t                   RESERVED2;
+	__IO uint32_t              FSCFGR;
+	uint32_t                   RESERVED3;
+	__IO uint32_t              FAFIFOR;
+	uint32_t                   RESERVED4;
+	__IO uint32_t              FWR;
+	uint32_t                   RESERVED5[8];
+	CAN_FilterRegister_TypeDef sFilterRegister[28];
+} CAN_TypeDef;
+#endif
+
+/* CRC Calculation Unit */
+typedef struct
+{
+	__IO uint32_t DATAR;
+	__IO uint8_t  IDATAR;
+	uint8_t       RESERVED0;
+	uint16_t      RESERVED1;
+	__IO uint32_t CTLR;
+} CRC_TypeDef;
+
+#if defined(CH32V10x) || defined(CH32V30x)
+/* Digital to Analog Converter */
+typedef struct
+{
+  __IO uint32_t CTLR;
+  __IO uint32_t SWTR;
+  __IO uint32_t R12BDHR1;
+  __IO uint32_t L12BDHR1;
+  __IO uint32_t R8BDHR1;
+  __IO uint32_t R12BDHR2;
+  __IO uint32_t L12BDHR2;
+  __IO uint32_t R8BDHR2;
+  __IO uint32_t RD12BDHR;
+  __IO uint32_t LD12BDHR;
+  __IO uint32_t RD8BDHR;
+  __IO uint32_t DOR1;
+  __IO uint32_t DOR2;
+} DAC_TypeDef;
+#endif
 
 /* Debug MCU */
 typedef struct
@@ -174,7 +756,9 @@ typedef struct
     __IO uint32_t OBR;
     __IO uint32_t WPR;
     __IO uint32_t MODEKEYR;
+#ifdef CH32V003
     __IO uint32_t BOOT_MODEKEYR;
+#endif
 } FLASH_TypeDef;
 
 /* Option Bytes Registers */
@@ -186,26 +770,202 @@ typedef struct
     __IO uint16_t Data1;
     __IO uint16_t WRPR0;
     __IO uint16_t WRPR1;
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	__IO uint16_t WRPR2;
+	__IO uint16_t WRPR3;
+#endif
 } OB_TypeDef;
 
-/* General Purpose I/O */
 typedef struct
 {
-    __IO uint32_t CFGLR;
-    __IO uint32_t CFGHR;
-    __IO uint32_t INDR;
-    __IO uint32_t OUTDR;
-    __IO uint32_t BSHR;
-    __IO uint32_t BCR;
-    __IO uint32_t LCKR;
+	__IO uint16_t CAP;
+	__IO uint16_t RES1;
+	__IO uint32_t RES2;
+	__IO uint32_t UID0;
+	__IO uint32_t UID1;
+	__IO uint32_t UID2;
+	__IO uint32_t RES3;
+} ESG_TypeDef;
+
+#if defined(CH32V30x)
+/* FSMC Bank1 Registers */
+typedef struct
+{
+  __IO uint32_t BTCR[8];
+} FSMC_Bank1_TypeDef;
+
+/* FSMC Bank1E Registers */
+typedef struct
+{
+  __IO uint32_t BWTR[7];
+} FSMC_Bank1E_TypeDef;
+
+/* FSMC Bank2 Registers */
+typedef struct
+{
+  __IO uint32_t PCR2;
+  __IO uint32_t SR2;
+  __IO uint32_t PMEM2;
+  __IO uint32_t PATT2;
+  uint32_t  RESERVED0;
+  __IO uint32_t ECCR2;
+} FSMC_Bank2_TypeDef;
+#endif
+
+/* General Purpose I/O */
+typedef enum
+{
+	GPIO_CFGLR_IN_ANALOG = 0,
+	GPIO_CFGLR_IN_FLOAT = 4,
+	GPIO_CFGLR_IN_PUPD = 8,
+	GPIO_CFGLR_OUT_10Mhz_PP = 1,
+	GPIO_CFGLR_OUT_2Mhz_PP = 2,
+	GPIO_CFGLR_OUT_50Mhz_PP = 3,
+	GPIO_CFGLR_OUT_10Mhz_OD = 5,
+	GPIO_CFGLR_OUT_2Mhz_OD = 6,
+	GPIO_CFGLR_OUT_50Mhz_OD = 7,
+	GPIO_CFGLR_OUT_10Mhz_AF_PP = 9,
+	GPIO_CFGLR_OUT_2Mhz_AF_PP = 10,
+	GPIO_CFGLR_OUT_50Mhz_AF_PP = 11,
+	GPIO_CFGLR_OUT_10Mhz_AF_OD = 13,
+	GPIO_CFGLR_OUT_2Mhz_AF_OD = 14,
+	GPIO_CFGLR_OUT_50Mhz_AF_OD = 15,
+} GPIO_CFGLR_PIN_MODE_Typedef;
+
+typedef union {
+	uint32_t __FULL;
+	struct {
+		GPIO_CFGLR_PIN_MODE_Typedef PIN0 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN1 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN2 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN3 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN4 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN5 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN6 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN7 :4;
+	};
+} GPIO_CFGLR_t;
+typedef union {
+	uint32_t __FULL;
+	const struct {
+		uint32_t IDR0 :1;
+		uint32_t IDR1 :1;
+		uint32_t IDR2 :1;
+		uint32_t IDR3 :1;
+		uint32_t IDR4 :1;
+		uint32_t IDR5 :1;
+		uint32_t IDR6 :1;
+		uint32_t IDR7 :1;
+		uint32_t :24;
+	};
+} GPIO_INDR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t ODR0 :1;
+		uint32_t ODR1 :1;
+		uint32_t ODR2 :1;
+		uint32_t ODR3 :1;
+		uint32_t ODR4 :1;
+		uint32_t ODR5 :1;
+		uint32_t ODR6 :1;
+		uint32_t ODR7 :1;
+		uint32_t :24;
+	};
+} GPIO_OUTDR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t BS0 :1;
+		uint32_t BS1 :1;
+		uint32_t BS2 :1;
+		uint32_t BS3 :1;
+		uint32_t BS4 :1;
+		uint32_t BS5 :1;
+		uint32_t BS6 :1;
+		uint32_t BS7 :1;
+		uint32_t :8;
+		uint32_t BR0 :1;
+		uint32_t BR1 :1;
+		uint32_t BR2 :1;
+		uint32_t BR3 :1;
+		uint32_t BR4 :1;
+		uint32_t BR5 :1;
+		uint32_t BR6 :1;
+		uint32_t BR7 :1;
+		uint32_t :8;
+	};
+} GPIO_BSHR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t BR0 :1;
+		uint32_t BR1 :1;
+		uint32_t BR2 :1;
+		uint32_t BR3 :1;
+		uint32_t BR4 :1;
+		uint32_t BR5 :1;
+		uint32_t BR6 :1;
+		uint32_t BR7 :1;
+		uint32_t :24;
+	};
+} GPIO_BCR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t LCK0 :1;
+		uint32_t LCK1 :1;
+		uint32_t LCK2 :1;
+		uint32_t LCK3 :1;
+		uint32_t LCK4 :1;
+		uint32_t LCK5 :1;
+		uint32_t LCK6 :1;
+		uint32_t LCK7 :1;
+		uint32_t LCKK :1;
+		uint32_t :23;
+	};
+} GPIO_LCKR_t;
+typedef struct
+{
+	__IO uint32_t CFGLR;
+	__IO uint32_t CFGHR;
+	__I  uint32_t INDR;
+	__IO uint32_t OUTDR;
+	__IO uint32_t BSHR;
+	__IO uint32_t BCR;
+	__IO uint32_t LCKR;
+#ifdef CH32X03x
+	__IO uint32_t CFGXR;
+	__IO uint32_t BSXR;
+#endif
 } GPIO_TypeDef;
+
+#define DYN_GPIO_READ(gpio, field) ((GPIO_##field##_t) { .__FULL = gpio->field })
+#define DYN_GPIO_WRITE(gpio, field, ...) gpio->field = ((const GPIO_##field##_t) __VA_ARGS__).__FULL
+#define DYN_GPIO_MOD(gpio, field, reg, val) {GPIO_##field##_t tmp; tmp.__FULL = gpio->field; tmp.reg = val; gpio->field = tmp.__FULL;}
 
 /* Alternate Function I/O */
 typedef struct
 {
+#ifdef CH32V003
     uint32_t RESERVED0;
     __IO uint32_t PCFR1;
     __IO uint32_t EXTICR;
+#elif defined(CH32X03x)
+    uint32_t RESERVED0;
+    __IO uint32_t PCFR1;
+    __IO uint32_t EXTICR1;
+    __IO uint32_t EXTICR2;
+    uint32_t RESERVED1;
+    uint32_t RESERVED2;
+    __IO uint32_t CTLR;
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	__IO uint32_t ECR;
+	__IO uint32_t PCFR1;
+	__IO uint32_t EXTICR[4];
+	uint32_t      RESERVED0;
+	__IO uint32_t PCFR2;
+#endif
 } AFIO_TypeDef;
 
 /* Inter Integrated Circuit Interface */
@@ -227,6 +987,10 @@ typedef struct
     uint16_t      RESERVED6;
     __IO uint16_t CKCFGR;
     uint16_t      RESERVED7;
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	__IO uint16_t RTR;
+	uint16_t      RESERVED8;
+#endif
 } I2C_TypeDef;
 
 /* Independent WatchDog */
@@ -243,9 +1007,11 @@ typedef struct
 {
     __IO uint32_t CTLR;
     __IO uint32_t CSR;
+#ifdef CH32V003	// AWU is CH32V003-only
     __IO uint32_t AWUCSR;
     __IO uint32_t AWUWR;
     __IO uint32_t AWUPSC;
+#endif
 } PWR_TypeDef;
 
 /* Reset and Clock Control */
@@ -259,9 +1025,71 @@ typedef struct
     __IO uint32_t AHBPCENR;
     __IO uint32_t APB2PCENR;
     __IO uint32_t APB1PCENR;
+#ifdef CH32V003
     __IO uint32_t RESERVED0;
-    __IO uint32_t RSTSCKR;
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	__IO uint32_t BDCTLR;
+#endif
+	__IO uint32_t RSTSCKR;
+#if defined(CH32V20x) || defined(CH32V30x)
+	__IO uint32_t AHBRSTR;
+	__IO uint32_t CFGR2;
+#endif
 } RCC_TypeDef;
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/* Real-Time Clock */
+typedef struct
+{
+	__IO uint16_t CTLRH;
+	uint16_t      RESERVED0;
+	__IO uint16_t CTLRL;
+	uint16_t      RESERVED1;
+	__IO uint16_t PSCRH;
+	uint16_t      RESERVED2;
+	__IO uint16_t PSCRL;
+	uint16_t      RESERVED3;
+	__IO uint16_t DIVH;
+	uint16_t      RESERVED4;
+	__IO uint16_t DIVL;
+	uint16_t      RESERVED5;
+	__IO uint16_t CNTH;
+	uint16_t      RESERVED6;
+	__IO uint16_t CNTL;
+	uint16_t      RESERVED7;
+	__IO uint16_t ALRMH;
+	uint16_t      RESERVED8;
+	__IO uint16_t ALRML;
+	uint16_t      RESERVED9;
+} RTC_TypeDef;
+#endif
+
+#if defined(CH32V30x)
+/* SDIO Registers */
+typedef struct
+{
+  __IO uint32_t POWER;
+  __IO uint32_t CLKCR;
+  __IO uint32_t ARG;
+  __IO uint32_t CMD;
+  __I uint32_t RESPCMD;
+  __I uint32_t RESP1;
+  __I uint32_t RESP2;
+  __I uint32_t RESP3;
+  __I uint32_t RESP4;
+  __IO uint32_t DTIMER;
+  __IO uint32_t DLEN;
+  __IO uint32_t DCTRL;
+  __I uint32_t DCOUNT;
+  __I uint32_t STA;
+  __IO uint32_t ICR;
+  __IO uint32_t MASK;
+  uint32_t  RESERVED0[2];
+  __I uint32_t FIFOCNT;
+  uint32_t  RESERVED1[13];
+  __IO uint32_t FIFO;
+} SDIO_TypeDef;
+#endif
 
 /* Serial Peripheral Interface */
 typedef struct
@@ -280,10 +1108,19 @@ typedef struct
     uint16_t      RESERVED5;
     __IO uint16_t TCRCR;
     uint16_t      RESERVED6;
+#ifdef CH32V003
     uint32_t      RESERVED7;
-    uint32_t      RESERVED8;
+	uint32_t      RESERVED8;
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	__IO uint16_t I2SCFGR;
+	uint16_t      RESERVED7;
+	__IO uint16_t I2SPR;
+	uint16_t      RESERVED8;
+#endif
+#if !defined(CH32V10x)
     __IO uint16_t HSCR;
     uint16_t      RESERVED9;
+#endif
 } SPI_TypeDef;
 
 /* TIM */
@@ -315,6 +1152,7 @@ typedef struct
     uint16_t      RESERVED11;
     __IO uint16_t RPTCR;
     uint16_t      RESERVED12;
+#ifdef CH32V003
     __IO uint32_t CH1CVR;
     __IO uint32_t CH2CVR;
     __IO uint32_t CH3CVR;
@@ -325,6 +1163,35 @@ typedef struct
     uint16_t      RESERVED14;
     __IO uint16_t DMAADR;
     uint16_t      RESERVED15;
+#elif defined( CH32X03x )
+    __IO uint32_t CH1CVR;
+    __IO uint32_t CH2CVR;
+    __IO uint32_t CH3CVR;
+    __IO uint32_t CH4CVR;
+    __IO uint16_t BDTR;
+    uint16_t      RESERVED13;
+    __IO uint16_t DMACFGR;
+    uint16_t      RESERVED14;
+    __IO uint16_t DMAADR;
+    uint16_t      RESERVED15;
+    __IO uint16_t SPEC;
+    uint16_t      RESERVED16;
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	__IO uint16_t CH1CVR;
+	uint16_t      RESERVED13;
+	__IO uint16_t CH2CVR;
+	uint16_t      RESERVED14;
+	__IO uint16_t CH3CVR;
+	uint16_t      RESERVED15;
+	__IO uint16_t CH4CVR;
+	uint16_t      RESERVED16;
+	__IO uint16_t BDTR;
+	uint16_t      RESERVED17;
+	__IO uint16_t DMACFGR;
+	uint16_t      RESERVED18;
+	__IO uint16_t DMAADR;
+	uint16_t      RESERVED19;
+#endif
 } TIM_TypeDef;
 
 /* Universal Synchronous Asynchronous Receiver Transmitter */
@@ -360,30 +1227,1183 @@ typedef struct
     __IO uint32_t EXTEN_CTR;
 } EXTEN_TypeDef;
 
+#if defined(CH32V20x) || defined(CH32V30x)
+/* OPA Registers */
+typedef struct
+{
+	__IO uint32_t CR;
+} OPA_TypeDef;
+
+#if defined(CH32V30x)
+/* RNG Registers */
+typedef struct
+{
+  __IO uint32_t CR;
+  __IO uint32_t SR;
+  __IO uint32_t DR;
+} RNG_TypeDef;
+
+/* DVP Registers */
+typedef struct
+{
+  __IO uint8_t CR0;
+  __IO uint8_t CR1;
+  __IO uint8_t IER;
+  __IO uint8_t Reserved0;
+  __IO uint16_t ROW_NUM;
+  __IO uint16_t COL_NUM;
+  __IO uint32_t DMA_BUF0;
+  __IO uint32_t DMA_BUF1;
+  __IO uint8_t IFR;
+  __IO uint8_t STATUS;
+  __IO uint16_t Reserved1;
+  __IO uint16_t ROW_CNT;
+  __IO uint16_t Reserved2;
+  __IO uint16_t HOFFCNT;
+  __IO uint16_t VST;
+  __IO uint16_t CAPCNT;
+  __IO uint16_t VLINE;
+  __IO uint32_t DR;
+} DVP_TypeDef;
+
+/* USBHS Registers */
+typedef struct
+{
+  __IO uint8_t  CONTROL;
+  __IO uint8_t  HOST_CTRL;
+  __IO uint8_t  INT_EN;
+  __IO uint8_t  DEV_AD;
+  __IO uint16_t FRAME_NO;
+  __IO uint8_t  SUSPEND;
+  __IO uint8_t  RESERVED0;
+  __IO uint8_t  SPEED_TYPE;
+  __IO uint8_t  MIS_ST;
+  __IO uint8_t  INT_FG;
+  __IO uint8_t  INT_ST;
+  __IO uint16_t RX_LEN;
+  __IO uint16_t RESERVED1;
+  __IO uint32_t ENDP_CONFIG;
+  __IO uint32_t ENDP_TYPE;
+  __IO uint32_t BUF_MODE;
+  __IO uint32_t UEP0_DMA;
+  __IO uint32_t UEP1_RX_DMA;
+  __IO uint32_t UEP2_RX_DMA;
+  __IO uint32_t UEP3_RX_DMA;
+  __IO uint32_t UEP4_RX_DMA;
+  __IO uint32_t UEP5_RX_DMA;
+  __IO uint32_t UEP6_RX_DMA;
+  __IO uint32_t UEP7_RX_DMA;
+  __IO uint32_t UEP8_RX_DMA;
+  __IO uint32_t UEP9_RX_DMA;
+  __IO uint32_t UEP10_RX_DMA;
+  __IO uint32_t UEP11_RX_DMA;
+  __IO uint32_t UEP12_RX_DMA;
+  __IO uint32_t UEP13_RX_DMA;
+  __IO uint32_t UEP14_RX_DMA;
+  __IO uint32_t UEP15_RX_DMA;
+  __IO uint32_t UEP1_TX_DMA;
+  __IO uint32_t UEP2_TX_DMA;
+  __IO uint32_t UEP3_TX_DMA;
+  __IO uint32_t UEP4_TX_DMA;
+  __IO uint32_t UEP5_TX_DMA;
+  __IO uint32_t UEP6_TX_DMA;
+  __IO uint32_t UEP7_TX_DMA;
+  __IO uint32_t UEP8_TX_DMA;
+  __IO uint32_t UEP9_TX_DMA;
+  __IO uint32_t UEP10_TX_DMA;
+  __IO uint32_t UEP11_TX_DMA;
+  __IO uint32_t UEP12_TX_DMA;
+  __IO uint32_t UEP13_TX_DMA;
+  __IO uint32_t UEP14_TX_DMA;
+  __IO uint32_t UEP15_TX_DMA;
+  __IO uint16_t UEP0_MAX_LEN;
+  __IO uint16_t RESERVED2;
+  __IO uint16_t UEP1_MAX_LEN;
+  __IO uint16_t RESERVED3;
+  __IO uint16_t UEP2_MAX_LEN;
+  __IO uint16_t RESERVED4;
+  __IO uint16_t UEP3_MAX_LEN;
+  __IO uint16_t RESERVED5;
+  __IO uint16_t UEP4_MAX_LEN;
+  __IO uint16_t RESERVED6;
+  __IO uint16_t UEP5_MAX_LEN;
+  __IO uint16_t RESERVED7;
+  __IO uint16_t UEP6_MAX_LEN;
+  __IO uint16_t RESERVED8;
+  __IO uint16_t UEP7_MAX_LEN;
+  __IO uint16_t RESERVED9;
+  __IO uint16_t UEP8_MAX_LEN;
+  __IO uint16_t RESERVED10;
+  __IO uint16_t UEP9_MAX_LEN;
+  __IO uint16_t RESERVED11;
+  __IO uint16_t UEP10_MAX_LEN;
+  __IO uint16_t RESERVED12;
+  __IO uint16_t UEP11_MAX_LEN;
+  __IO uint16_t RESERVED13;
+  __IO uint16_t UEP12_MAX_LEN;
+  __IO uint16_t RESERVED14;
+  __IO uint16_t UEP13_MAX_LEN;
+  __IO uint16_t RESERVED15;
+  __IO uint16_t UEP14_MAX_LEN;
+  __IO uint16_t RESERVED16;
+  __IO uint16_t UEP15_MAX_LEN;
+  __IO uint16_t RESERVED17;
+  __IO uint16_t UEP0_TX_LEN;
+  __IO uint8_t  UEP0_TX_CTRL;
+  __IO uint8_t  UEP0_RX_CTRL;
+  __IO uint16_t UEP1_TX_LEN;
+  __IO uint8_t  UEP1_TX_CTRL;
+  __IO uint8_t  UEP1_RX_CTRL;
+  __IO uint16_t UEP2_TX_LEN;
+  __IO uint8_t  UEP2_TX_CTRL;
+  __IO uint8_t  UEP2_RX_CTRL;
+  __IO uint16_t UEP3_TX_LEN;
+  __IO uint8_t  UEP3_TX_CTRL;
+  __IO uint8_t  UEP3_RX_CTRL;
+  __IO uint16_t UEP4_TX_LEN;
+  __IO uint8_t  UEP4_TX_CTRL;
+  __IO uint8_t  UEP4_RX_CTRL;
+  __IO uint16_t UEP5_TX_LEN;
+  __IO uint8_t  UEP5_TX_CTRL;
+  __IO uint8_t  UEP5_RX_CTRL;
+  __IO uint16_t UEP6_TX_LEN;
+  __IO uint8_t  UEP6_TX_CTRL;
+  __IO uint8_t  UEP6_RX_CTRL;
+  __IO uint16_t UEP7_TX_LEN;
+  __IO uint8_t  UEP7_TX_CTRL;
+  __IO uint8_t  UEP7_RX_CTRL;
+  __IO uint16_t UEP8_TX_LEN;
+  __IO uint8_t  UEP8_TX_CTRL;
+  __IO uint8_t  UEP8_RX_CTRL;
+  __IO uint16_t UEP9_TX_LEN;
+  __IO uint8_t  UEP9_TX_CTRL;
+  __IO uint8_t  UEP9_RX_CTRL;
+  __IO uint16_t UEP10_TX_LEN;
+  __IO uint8_t  UEP10_TX_CTRL;
+  __IO uint8_t  UEP10_RX_CTRL;
+  __IO uint16_t UEP11_TX_LEN;
+  __IO uint8_t  UEP11_TX_CTRL;
+  __IO uint8_t  UEP11_RX_CTRL;
+  __IO uint16_t UEP12_TX_LEN;
+  __IO uint8_t  UEP12_TX_CTRL;
+  __IO uint8_t  UEP12_RX_CTRL;
+  __IO uint16_t UEP13_TX_LEN;
+  __IO uint8_t  UEP13_TX_CTRL;
+  __IO uint8_t  UEP13_RX_CTRL;
+  __IO uint16_t UEP14_TX_LEN;
+  __IO uint8_t  UEP14_TX_CTRL;
+  __IO uint8_t  UEP14_RX_CTRL;
+  __IO uint16_t UEP15_TX_LEN;
+  __IO uint8_t  UEP15_TX_CTRL;
+  __IO uint8_t  UEP15_RX_CTRL;
+} USBHSD_TypeDef;
+
+typedef struct  __attribute__((packed))
+{
+    __IO uint8_t  CONTROL;
+    __IO uint8_t  HOST_CTRL;
+    __IO uint8_t  INT_EN;
+    __IO uint8_t  DEV_AD;
+    __IO uint16_t FRAME_NO;
+    __IO uint8_t  SUSPEND;
+    __IO uint8_t  RESERVED0;
+    __IO uint8_t  SPEED_TYPE;
+    __IO uint8_t  MIS_ST;
+    __IO uint8_t  INT_FG;
+    __IO uint8_t  INT_ST;
+    __IO uint16_t RX_LEN;
+    __IO uint16_t RESERVED1;
+    __IO uint32_t HOST_EP_CONFIG;
+    __IO uint32_t HOST_EP_TYPE;
+    __IO uint32_t RESERVED2;
+    __IO uint32_t RESERVED3;
+    __IO uint32_t RESERVED4;
+    __IO uint32_t HOST_RX_DMA;
+    __IO uint32_t RESERVED5;
+    __IO uint32_t RESERVED6;
+    __IO uint32_t RESERVED7;
+    __IO uint32_t RESERVED8;
+    __IO uint32_t RESERVED9;
+    __IO uint32_t RESERVED10;
+    __IO uint32_t RESERVED11;
+    __IO uint32_t RESERVED12;
+    __IO uint32_t RESERVED13;
+    __IO uint32_t RESERVED14;
+    __IO uint32_t RESERVED15;
+    __IO uint32_t RESERVED16;
+    __IO uint32_t RESERVED17;
+    __IO uint32_t RESERVED18;
+    __IO uint32_t RESERVED19;
+    __IO uint32_t HOST_TX_DMA;
+    __IO uint32_t RESERVED20;
+    __IO uint32_t RESERVED21;
+    __IO uint32_t RESERVED22;
+    __IO uint32_t RESERVED23;
+    __IO uint32_t RESERVED24;
+    __IO uint32_t RESERVED25;
+    __IO uint32_t RESERVED26;
+    __IO uint32_t RESERVED27;
+    __IO uint32_t RESERVED28;
+    __IO uint32_t RESERVED29;
+    __IO uint32_t RESERVED30;
+    __IO uint32_t RESERVED31;
+    __IO uint32_t RESERVED32;
+    __IO uint32_t RESERVED33;
+    __IO uint16_t HOST_RX_MAX_LEN;
+    __IO uint16_t RESERVED34;
+    __IO uint32_t RESERVED35;
+    __IO uint32_t RESERVED36;
+    __IO uint32_t RESERVED37;
+    __IO uint32_t RESERVED38;
+    __IO uint32_t RESERVED39;
+    __IO uint32_t RESERVED40;
+    __IO uint32_t RESERVED41;
+    __IO uint32_t RESERVED42;
+    __IO uint32_t RESERVED43;
+    __IO uint32_t RESERVED44;
+    __IO uint32_t RESERVED45;
+    __IO uint32_t RESERVED46;
+    __IO uint32_t RESERVED47;
+    __IO uint32_t RESERVED48;
+    __IO uint32_t RESERVED49;
+    __IO uint8_t  HOST_EP_PID;
+    __IO uint8_t  RESERVED50;
+    __IO uint8_t  RESERVED51;
+    __IO uint8_t  HOST_RX_CTRL;
+    __IO uint16_t HOST_TX_LEN;
+    __IO uint8_t  HOST_TX_CTRL;
+    __IO uint8_t  RESERVED52;
+    __IO uint16_t HOST_SPLIT_DATA;
+} USBHSH_TypeDef;
+
+#endif	// #if defined(CH32V30x)
+
+/* USBD Full-Speed Device, Chapter 21.
+ NOTE: USBD and CAN controller share a dedicated 512-byte SRAM area for data
+ transmission and reception in the design, so when using USBD and CAN functions
+ at the same time, this shared area needs to be allocated reasonably to prevent
+ data conflicts. */
+
+typedef struct 
+{
+	__IO uint32_t ADDn_TX;
+	__IO uint32_t COUNTn_TX;
+	__IO uint32_t ADDn_RX;
+	__IO uint32_t COUNTn_RX;
+} USBD_BTABLE_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t EPR[8];
+	__IO uint32_t RESERVED[8];
+	__IO uint32_t CNTR;
+	__IO uint32_t ISTR;
+	__IO uint32_t FNR;
+	__IO uint32_t DADDR;
+	__IO uint32_t BTABLE;
+} USBD_TypeDef;
+
+#define CAN_USBD_SHARED_BASE   ((PERIPH_BASE + 0x6000))
+#define USBD_BASE              ((PERIPH_BASE + 0x5C00))
+
+/* USBD_CNTR */
+#define USBD_CTRM      (1<<15)
+#define USBD_PMAOVRM   (1<<14)
+#define USBD_ERRM      (1<<13)
+#define USBD_WKUPM     (1<<12)
+#define USBD_SUSPM     (1<<11)
+#define USBD_RESETM    (1<<10)
+#define USBD_SOFM      (1<<9)
+#define USBD_ESOFM     (1<<8)
+#define USBD_RESUME    (1<<4)
+#define USBD_FSUP      (1<<3)
+#define USBD_LPMODE    (1<<2)
+#define USBD_PDWN      (1<<1)
+#define USBD_FRES      (1<<0)
+
+/* USBD_ISTR */
+#define USBD_CTR       (1<<15)
+#define USBD_PMAOVR    (1<<14)
+#define USBD_ERR       (1<<13)
+#define USBD_WKUP      (1<<12)
+#define USBD_SUSP      (1<<11)
+#define USBD_RESET     (1<<10)
+#define USBD_SOF       (1<<9)
+#define USBD_ESOF      (1<<8)
+#define USBD_DIR       (1<<4)
+#define USBD_EP_ID     (0xf)
+
+/* USBD_FNR */
+#define USBD_RXDP      (1<<15)
+#define USBD_RXDM      (1<<14)
+#define USBD_LCK       (1<<13)
+#define USBD_LSOF      (3<<11)
+#define USBD_FN        (0x7ff)
+
+/* USBD_DADDR */
+#define USBD_EF        (1<<7)
+#define USBD_ADD       (0x7f)
+
+/* USBD_EPRx */
+#define USBD_CTR_RX    (1<<15)
+#define USBD_DTOG_RX   (1<<14)
+#define USBD_STAT_RX   (3<<12)
+#define USBD_SETUP     (1<<11)
+#define USBD_EPTYPE    (3<<9)
+#define USBD_EPKIND    (1<<8)
+#define USBD_CTR_TX    (1<<7)
+#define USBD_DTOG_TX   (1<<6)
+#define USBD_STAT_TX   (3<<4)
+#define USBD_EA        (0xf)
+
+/* USBD_COUNTx_RX */
+#define USBD_BLSIZE    (1<<15)
+#define USBD_NUM_BLOCK (0x1f<<10)
+#define USBD_COUNTx_RX 0x2ff
+
+
+#define USBD           ((USBD_TypeDef *) USBD_BASE)
+
+/* USB-FS-OTG Registers, Chapter 23. */
+typedef struct
+{
+	__IO uint8_t  BASE_CTRL;
+	__IO uint8_t  UDEV_CTRL;
+	__IO uint8_t  INT_EN;
+	__IO uint8_t  DEV_ADDR;
+	__IO uint8_t  Reserve0;
+	__IO uint8_t  MIS_ST;
+	__IO uint8_t  INT_FG; // "Combined" register in some situations. (ST_FG)
+	__IO uint8_t  INT_ST;
+	__IO uint32_t RX_LEN;
+	__IO uint8_t  UEP4_1_MOD;
+	__IO uint8_t  UEP2_3_MOD;
+	__IO uint8_t  UEP5_6_MOD;
+	__IO uint8_t  UEP7_MOD;
+	__IO uint32_t UEP0_DMA;
+	__IO uint32_t UEP1_DMA;
+	__IO uint32_t UEP2_DMA;
+	__IO uint32_t UEP3_DMA;
+	__IO uint32_t UEP4_DMA;
+	__IO uint32_t UEP5_DMA;
+	__IO uint32_t UEP6_DMA;
+	__IO uint32_t UEP7_DMA;
+	__IO uint16_t UEP0_TX_LEN;
+	__IO uint8_t  UEP0_TX_CTRL;
+	__IO uint8_t  UEP0_RX_CTRL;
+	__IO uint16_t UEP1_TX_LEN;
+	__IO uint8_t  UEP1_TX_CTRL;
+	__IO uint8_t  UEP1_RX_CTRL;
+	__IO uint16_t UEP2_TX_LEN;
+	__IO uint8_t  UEP2_TX_CTRL;
+	__IO uint8_t  UEP2_RX_CTRL;
+	__IO uint16_t UEP3_TX_LEN;
+	__IO uint8_t  UEP3_TX_CTRL;
+	__IO uint8_t  UEP3_RX_CTRL;
+	__IO uint16_t UEP4_TX_LEN;
+	__IO uint8_t  UEP4_TX_CTRL;
+	__IO uint8_t  UEP4_RX_CTRL;
+	__IO uint16_t UEP5_TX_LEN;
+	__IO uint8_t  UEP5_TX_CTRL;
+	__IO uint8_t  UEP5_RX_CTRL;
+	__IO uint16_t UEP6_TX_LEN;
+	__IO uint8_t  UEP6_TX_CTRL;
+	__IO uint8_t  UEP6_RX_CTRL;
+	__IO uint16_t UEP7_TX_LEN;
+	__IO uint8_t  UEP7_TX_CTRL;
+	__IO uint8_t  UEP7_RX_CTRL;
+	__IO uint32_t Reserve1;
+	__IO uint32_t OTG_CR;
+	__IO uint32_t OTG_SR;
+} USBOTG_FS_TypeDef;
+
+/* R8_USB_CTRL */
+#define USBOTG_UC_HOST_MODE         (1<<7)
+#define USBOTG_UC_LOW_SPEED         (1<<6)
+#define USBOTG_UC_DEV_PU_EN         (1<<5)
+#define USBOTG_UC_SYS_CTRL          (1<<4)
+#define USBOTG_UC_INT_BUSY          (1<<3)
+#define USBOTG_UC_RESET_SIE         (1<<2)
+#define USBOTG_UC_CLR_ALL           (1<<1)
+#define USBOTG_UC_DMA_EN            (1<<0)
+
+/* R8_USB_INT_EN */
+#define USBOTG_UIE_DEV_NAK          (1<<6)
+#define USBOTG_UIE_FIFO_OV          (1<<4)
+#define USBOTG_UIE_HST_SOF          (1<<3)
+#define USBOTG_UIE_SUSPEND          (1<<2)
+#define USBOTG_UIE_TRANSFER         (1<<1)
+#define USBOTG_UIE_DETECT           (1<<0)
+#define USBOTG_UIE_BUS_RST          (1<<0)
+
+/* R8_USB_DEV_AD */
+#define USBOTG_UDA_GP_BIT           (1<<7)
+#define USBOTG_USB_ADDR             (1<<6)
+
+/* R8_USB_MIS_ST */
+#define USBOTG_UMS_SOF_PRES         (1<<7)
+#define USBOTG_UMS_SOF_ACT          (1<<6)
+#define USBOTG_UMS_SIE_FREE         (1<<5)
+#define USBOTG_UMS_R_FIFO_RDY       (1<<4)
+#define USBOTG_UMS_BUS_RESET        (1<<3)
+#define USBOTG_UMS_SUSPEND          (1<<2)
+#define USBOTG_UMS_DM_LEVEL         (1<<1)
+#define USBOTG_UMS_DEV_ATTACH       (1<<0)
+
+/* R8_USB_INT_FG */
+#define USBOTG_U_IS_NAK             (1<<7)
+#define USBOTG_U_TOG_OK             (1<<6)
+#define USBOTG_U_SIE_FREE           (1<<5)
+#define USBOTG_UIF_FIFO_OV          (1<<4)
+#define USBOTG_UIF_HST_SOF          (1<<3)
+#define USBOTG_UIF_SUSPEND          (1<<2)
+#define USBOTG_UIF_TRANSFER         (1<<1)
+#define USBOTG_UIF_DETECT           (1<<0)
+#define USBOTG_UIF_BUS_RST          (1<<0)
+
+/* R8_USB_INT_ST */
+#define USBOTG_UIS_IS_NAK           (1<<7)
+#define USBOTG_UIS_TOG_OK           (1<<6)
+#define USBOTG_UIS_TOKEN            (3<<4)
+#define USBOTG_UIS_ENDP             0xf
+#define USBOTG_UIS_H_RES            0xf
+
+/* R32_USB_OTG_CR */
+#define USBOTG_CR_SESS_VTH          (1<<5)
+#define USBOTG_CR_VBUS_VTH          (1<<4)
+#define USBOTG_CR_OTG_EN            (1<<3)
+#define USBOTG_CR_IDPU              (1<<2)
+#define USBOTG_CR_CHARGE_VBUS       (1<<1)
+#define USBOTG_CR_DISCHAR_VBUS      (1<<0)
+
+/* R32_USB_OTG_SR */
+#define USBOTG_SR_ID_DIG            (1<<3)
+#define USBOTG_SR_SESS_END          (1<<2)
+#define USBOTG_SR_SESS_VLD          (1<<1)
+#define USBOTG_SR_VBUS_VLD          (1<<0)
+
+/* R8_UEPn_TX_CTRL */
+#define USBOTG_UEP_T_AUTO_TOG       (1<<3)
+#define USBOTG_UEP_T_TOG            (1<<2)
+#define USBOTG_UEP_T_RES_MASK       (3<<0)      // bit mask of handshake response type for USB endpoint X transmittal (IN)
+#define USBOTG_UEP_T_RES_ACK        (0<<1)
+#define USBOTG_UEP_T_RES_NONE       (1<<0)
+#define USBOTG_UEP_T_RES_NAK        (1<<1)
+#define USBOTG_UEP_T_RES_STALL      (3<<0)
+
+#define USBOTG_UEP_R_AUTO_TOG       (1<<3)      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBOTG_UEP_R_TOG            (1<<2)      // expected data toggle flag of USB endpoint X receiving (OUT): 0=DATA0, 1=DATA1
+#define USBOTG_UEP_R_RES_MASK       (3<<0)      // bit mask of handshake response type for USB endpoint X receiving (OUT)
+#define USBOTG_UEP_R_RES_ACK        (0<<1)
+#define USBOTG_UEP_R_RES_NONE       (1<<0)
+#define USBOTG_UEP_R_RES_NAK        (1<<1)
+#define USBOTG_UEP_R_RES_STALL      (3<<0)
+
+
+
+/* R8_UEPn_ RX_CTRL */
+#define USBOTG_UEP_R_AUTO_TOG       (1<<3)
+#define USBOTG_UEP_R_TOG            (1<<2)
+#define USBOTG_UEP_R_RES            (3<<0)
+
+/* R8_UEP7_MOD */
+#define USBOTG_UEP7_RX_EN           (1<<3)
+#define USBOTG_UEP7_TX_EN           (1<<2)
+#define USBOTG_UEP7_BUF_MOD         (1<<0)
+
+/* R8_UEP5_6_MOD */
+#define USBOTG_UEP6_RX_EN           (1<<7)
+#define USBOTG_UEP6_TX_EN           (1<<6)
+#define USBOTG_UEP6_BUF_MOD         (1<<4)
+#define USBOTG_UEP5_RX_EN           (1<<3)
+#define USBOTG_UEP5_TX_EN           (1<<2)
+#define USBOTG_UEP5_BUF_MOD         (1<<0)
+
+/* R8_UEP2_3_MOD */
+#define USBOTG_UEP3_RX_EN           (1<<7)
+#define USBOTG_UEP3_TX_EN           (1<<6)
+#define USBOTG_UEP3_BUF_MOD         (1<<4)
+#define USBOTG_UEP2_RX_EN           (1<<3)
+#define USBOTG_UEP2_TX_EN           (1<<2)
+#define USBOTG_UEP2_BUF_MOD         (1<<0)
+
+/* R8_UEP4_1_MOD */
+#define USBOTG_UEP1_RX_EN           (1<<7)
+#define USBOTG_UEP1_TX_EN           (1<<6)
+#define USBOTG_UEP1_BUF_MOD         (1<<4)
+#define USBOTG_UEP4_RX_EN           (1<<3)
+#define USBOTG_UEP4_TX_EN           (1<<2)
+#define USBOTG_UEP4_BUF_MOD         (1<<0)
+
+/* R8_UDEV_CTRL */
+#define USBOTG_UD_PD_DIS            (1<<7)
+#define USBOTG_UD_DP_PIN            (1<<5)
+#define USBOTG_UD_DM_PIN            (1<<4)
+#define USBOTG_UD_LOW_SPEED         (1<<2)
+#define USBOTG_UD_GP_BIT            (1<<1)
+#define USBOTG_UD_PORT_EN           (1<<0)
+
+
+#define USBFS_UDA_GP_BIT            0x80
+#define USBFS_USB_ADDR_MASK         0x7F
+
+#define DEF_USBD_UEP0_SIZE		   64	 /* usb hs/fs device end-point 0 size */
+#define UEP_SIZE 64
+
+#define DEF_UEP_IN                  0x80
+#define DEF_UEP_OUT                 0x00
+#define DEF_UEP_BUSY                0x01
+#define DEF_UEP_FREE                0x00
+
+#define DEF_UEP0 0
+#define DEF_UEP1 1
+#define DEF_UEP2 2
+#define DEF_UEP3 3
+#define DEF_UEP4 4
+#define DEF_UEP5 5
+#define DEF_UEP6 6
+#define DEF_UEP7 7
+#define UNUM_EP 8
+
+typedef struct
+{
+	__IO uint8_t   BASE_CTRL;
+	__IO uint8_t   HOST_CTRL;
+	__IO uint8_t   INT_EN;
+	__IO uint8_t   DEV_ADDR;
+	__IO uint8_t   Reserve0;
+	__IO uint8_t   MIS_ST;
+	__IO uint8_t   INT_FG;
+	__IO uint8_t   INT_ST;
+	__IO uint16_t  RX_LEN;
+	__IO uint16_t  Reserve1;
+	__IO uint8_t   Reserve2;
+	__IO uint8_t   HOST_EP_MOD;
+	__IO uint16_t  Reserve3;
+	__IO uint32_t  Reserve4;
+	__IO uint32_t  Reserve5;
+	__IO uint32_t  HOST_RX_DMA;
+	__IO uint32_t  HOST_TX_DMA;
+	__IO uint32_t  Reserve6;
+	__IO uint32_t  Reserve7;
+	__IO uint32_t  Reserve8;
+	__IO uint32_t  Reserve9;
+	__IO uint32_t  Reserve10;
+	__IO uint16_t  Reserve11;
+	__IO uint16_t  HOST_SETUP;
+	__IO uint8_t   HOST_EP_PID;
+	__IO uint8_t   Reserve12;
+	__IO uint8_t   Reserve13;
+	__IO uint8_t   HOST_RX_CTRL;
+	__IO uint16_t  HOST_TX_LEN;
+	__IO uint8_t   HOST_TX_CTRL;
+	__IO uint8_t   Reserve14;
+	__IO uint32_t  Reserve15;
+	__IO uint32_t  Reserve16;
+	__IO uint32_t  Reserve17;
+	__IO uint32_t  Reserve18;
+	__IO uint32_t  Reserve19;
+	__IO uint32_t  OTG_CR;
+	__IO uint32_t  OTG_SR;
+} USBOTG_FS_HOST_TypeDef;
+
+/* R8_UHOST_CTRL */
+#define USBOTG_UH_PD_DIS       (1<<7)
+#define USBOTG_UH_DP_PIN       (1<<5)
+#define USBOTG_UH_DM_PIN       (1<<4)
+#define USBOTG_UH_LOW_SPEED    (1<<2)
+#define USBOTG_UH_BUS_RESET    (1<<1)
+#define USBOTG_UH_PORT_EN      (1<<0)
+
+/* R32_UH_EP_MOD */
+#define USBOTG_UH_EP_TX_EN     (1<<6)
+#define USBOTG_UH_EP_TBUF_MOD  (1<<4)
+#define USBOTG_UH_EP_RX_EN     (1<<3)
+#define USBOTG_UH_EP_RBUF_MOD  (1<<0)
+
+/* R16_UH_SETUP */
+#define USBOTG_UH_PRE_PID_EN   (1<<10)
+#define USBOTG_UH_SOF_EN       (1<<2)
+
+/* R8_UH_EP_PID */
+#define USBOTG_UH_TOKEN        (0xf<<4)
+#define USBOTG_UH_ENDP         (0xf<<0)
+
+/* R8_UH_RX_CTRL */
+#define USBOTG_UH_R_AUTO_TOG   (1<<3)
+#define USBOTG_UH_R_TOG        (1<<2)
+#define USBOTG_UH_R_RES        (1<<0)
+
+/* R8_UH_TX_CTRL */
+#define USBOTG_UH_T_AUTO_TOG   (1<<3)
+#define USBOTG_UH_T_TOG        (1<<2)
+#define USBOTG_UH_T_RES        (1<<0)
+
+
+
+#if defined(CH32V30x)
+/* Ethernet MAC */
+typedef struct
+{
+  __IO uint32_t MACCR;
+  __IO uint32_t MACFFR;
+  __IO uint32_t MACHTHR;
+  __IO uint32_t MACHTLR;
+  __IO uint32_t MACMIIAR;
+  __IO uint32_t MACMIIDR;
+  __IO uint32_t MACFCR;
+  __IO uint32_t MACVLANTR;
+       uint32_t RESERVED0[2];
+  __IO uint32_t MACRWUFFR;
+  __IO uint32_t MACPMTCSR;
+       uint32_t RESERVED1[2];
+  __IO uint32_t MACSR;
+  __IO uint32_t MACIMR;
+  __IO uint32_t MACA0HR;
+  __IO uint32_t MACA0LR;
+  __IO uint32_t MACA1HR;
+  __IO uint32_t MACA1LR;
+  __IO uint32_t MACA2HR;
+  __IO uint32_t MACA2LR;
+  __IO uint32_t MACA3HR;
+  __IO uint32_t MACA3LR;
+       uint32_t RESERVED2[40];
+  __IO uint32_t MMCCR;
+  __IO uint32_t MMCRIR;
+  __IO uint32_t MMCTIR;
+  __IO uint32_t MMCRIMR;
+  __IO uint32_t MMCTIMR;
+       uint32_t RESERVED3[14];
+  __IO uint32_t MMCTGFSCCR;
+  __IO uint32_t MMCTGFMSCCR;
+       uint32_t RESERVED4[5];
+  __IO uint32_t MMCTGFCR;
+       uint32_t RESERVED5[10];
+  __IO uint32_t MMCRFCECR;
+  __IO uint32_t MMCRFAECR;
+       uint32_t RESERVED6[10];
+  __IO uint32_t MMCRGUFCR;
+       uint32_t RESERVED7[334];
+  __IO uint32_t PTPTSCR;
+  __IO uint32_t PTPSSIR;
+  __IO uint32_t PTPTSHR;
+  __IO uint32_t PTPTSLR;
+  __IO uint32_t PTPTSHUR;
+  __IO uint32_t PTPTSLUR;
+  __IO uint32_t PTPTSAR;
+  __IO uint32_t PTPTTHR;
+  __IO uint32_t PTPTTLR;
+       uint32_t RESERVED8[567];
+  __IO uint32_t DMABMR;
+  __IO uint32_t DMATPDR;
+  __IO uint32_t DMARPDR;
+  __IO uint32_t DMARDLAR;
+  __IO uint32_t DMATDLAR;
+  __IO uint32_t DMASR;
+  __IO uint32_t DMAOMR;
+  __IO uint32_t DMAIER;
+  __IO uint32_t DMAMFBOCR;
+       uint32_t RESERVED9[9];
+  __IO uint32_t DMACHTDR;
+  __IO uint32_t DMACHRDR;
+  __IO uint32_t DMACHTBAR;
+  __IO uint32_t DMACHRBAR;
+} ETH_TypeDef;
+#endif // #if defined(CH32V30x)
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+/* ETH10M Registers */
+typedef struct
+{
+    __IO uint8_t reserved1;
+    __IO uint8_t reserved2;
+    __IO uint8_t reserved3;
+    __IO uint8_t EIE;
+
+    __IO uint8_t EIR;
+    __IO uint8_t ESTAT;
+    __IO uint8_t ECON2;
+    __IO uint8_t ECON1;
+
+    __IO uint16_t ETXST;
+    __IO uint16_t ETXLN;
+
+    __IO uint16_t ERXST;
+    __IO uint16_t ERXLN;
+
+    __IO uint32_t HTL;
+    __IO uint32_t HTH;
+
+    __IO uint8_t ERXFON;
+    __IO uint8_t MACON1;
+    __IO uint8_t MACON2;
+    __IO uint8_t MABBIPG;
+
+    __IO uint16_t EPAUS;
+    __IO uint16_t MAMXFL;
+
+    __IO uint16_t MIRD;
+    __IO uint16_t reserved4;
+
+    __IO uint8_t MIERGADR;
+    __IO uint8_t MISTAT;
+    __IO uint16_t MIWR;
+
+    __IO uint32_t MAADRL;
+
+    __IO uint16_t MAADRH;
+    __IO uint16_t reserved5;
+} ETH10M_TypeDef;
+#endif
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+/* OSC Registers */
+typedef struct
+{
+    __IO uint32_t HSE_CAL_CTRL;
+    __IO uint32_t Reserve0;
+    __IO uint16_t Reserve1;
+    __IO uint16_t LSI32K_TUNE;
+    __IO uint32_t Reserve2;
+    __IO uint32_t Reserve3;
+    __IO uint32_t Reserve4;
+    __IO uint32_t Reserve5;
+    __IO uint8_t  Reserve6;
+    __IO uint8_t  LSI32K_CAL_CFG;
+    __IO uint16_t Reserve7;
+    __IO uint16_t LSI32K_CAL_STATR;
+    __IO uint8_t  LSI32K_CAL_OV_CNT;
+    __IO uint8_t  LSI32K_CAL_CTRL;
+} OSC_TypeDef;
+
+#endif
+
+#endif // #if defined(CH32V20x) || defined(CH32V30x)
+
+
+#if defined(CH32X03x)
+/* Touch Sensor, Mirrors Analog to Digital Converter */
+typedef struct
+{
+	__IO uint32_t RESERVED0[3];
+	__IO uint32_t CHARGE1;
+	__IO uint32_t CHARGE2;
+	__IO uint32_t RESERVED1[10];
+	__IO uint32_t CHGOFFSET;
+	__IO uint32_t RESERVED2[3];
+	__IO uint32_t DR_ACT_DCG;
+} TKEY_TypeDef;
+
+/* Op amp / comparator */
+typedef struct
+{
+	__IO uint16_t CFGR1;
+	__IO uint16_t CFGR2;
+	__IO uint32_t CTLR1;
+	__IO uint32_t CTLR2;
+	__IO uint32_t OPA_KEY;
+	__IO uint32_t CMP_KEY;
+	__IO uint32_t POLL_KEY;
+} OPACMP_TypeDef;
+
+/* USB Full Speed Device Mode */
+typedef struct
+{
+	__IO uint8_t BASE_CTRL; //XXX (spelling)
+	__IO uint8_t UDEV_CTRL; // or host ctlr
+	__IO uint8_t INT_EN;
+	__IO uint8_t DEV_ADDR;
+	__IO uint8_t RESERVED0;
+	__IO uint8_t MIS_ST;
+	__IO uint8_t INT_FG;
+	__IO uint8_t INT_ST;
+	__IO uint16_t RX_LEN;
+	__IO uint16_t RESERVED1;
+	__IO uint8_t UEP4_1_MOD;
+	__IO uint8_t UEP2_3_MOD; // Also HOST_EP_MOD
+	__IO uint8_t UEP567_MOD;
+	__IO uint8_t RESERVED2;
+
+	__IO uint32_t UEP0_DMA;
+	__IO uint32_t UEP1_DMA;
+	__IO uint32_t UEP2_DMA; // Also HOST_RX_DMA
+	__IO uint32_t UEP3_DMA; // Also HOST_TX_DMA
+
+	//__IO uint32_t UEP0_CTRL;
+	__IO uint16_t UEP0_TX_LEN;
+	__IO uint16_t UEP0_CTRL_H;
+
+	//__IO uint32_t UEP1_CTRL;
+	__IO uint16_t UEP1_TX_LEN;
+	__IO uint16_t UEP1_CTRL_H; // Also HOST_SETUP
+
+	//__IO uint32_t UEP2_CTRL;
+	__IO uint16_t UEP2_TX_LEN; // Also HOST_PID
+	__IO uint16_t UEP2_CTRL_H; // Also HOST_RX_CTL
+
+	//__IO uint32_t UEP3_CTRL;
+	__IO uint16_t UEP3_TX_LEN; // Also HOST_TX_LEN
+	__IO uint16_t UEP3_CTRL_H; // Also HOST_TX_CTL
+
+	//__IO uint32_t UEP4_CTRL;
+	__IO uint16_t UEP4_TX_LEN;
+	__IO uint16_t UEP4_CTRL_H;
+
+	__IO uint32_t RESERVED3[8];
+
+	__IO uint32_t UEP5_DMA;
+	__IO uint32_t UEP6_DMA;
+	__IO uint32_t UEP7_DMA;
+
+	__IO uint32_t RESERVED4;
+
+	//__IO uint32_t UEP5_CTRL;
+	__IO uint16_t UEP5_TX_LEN;
+	__IO uint16_t UEP5_CTRL_H;
+
+	//__IO uint32_t UEP6_CTRL;
+	__IO uint16_t UEP6_TX_LEN;
+	__IO uint16_t UEP6_CTRL_H;
+
+	//__IO uint32_t UEP7_CTRL;
+	__IO uint16_t UEP7_TX_LEN;
+	__IO uint16_t UEP7_CTRL_H;
+
+	__IO uint32_t UEPX_MOD;
+} USBFS_TypeDef;
+
+
+
+#define USB_PHY_V33 (1<<6)
+#define USB_IOEN (1<<7)
+
+
+#define USBFSD_UEP_MOD_BASE         0x4002340C
+#define USBFSD_UEP_DMA_BASE         0x40023410
+#define USBFSD_UEP_LEN_BASE         0x40023420
+#define USBFSD_UEP_CTL_BASE         0x40023422
+#define USBFSD_UEP_RX_EN            0x08
+#define USBFSD_UEP_TX_EN            0x04
+#define USBFSD_UEP_BUF_MOD          0x01
+#define USBFSD_UEP_MOD( N )         (*((volatile uint8_t *)( USBFSD_UEP_MOD_BASE + N )))
+#define USBFSD_UEP_TX_CTRL( N )     (*((volatile uint8_t *)( USBFSD_UEP_CTL_BASE + N * 0x04 )))
+#define USBFSD_UEP_RX_CTRL( N )     (*((volatile uint8_t *)( USBFSD_UEP_CTL_BASE + N * 0x04 )))
+#define USBFSD_UEP_DMA( N )         (*((volatile uint32_t *)( USBFSD_UEP_DMA_BASE + N * 0x04 )))
+#define USBFSD_UEP_BUF( N )         ((uint8_t *)(*((volatile uint32_t *)( USBFSD_UEP_DMA_BASE + N * 0x04 ))) + 0x20000000)
+#define USBFSD_UEP_TLEN( N )        (*((volatile uint16_t *)( USBFSD_UEP_LEN_BASE + N * 0x04 )))
+
+/* R8_UEPn_TX_CTRL */
+#define USBFS_UEP_T_AUTO_TOG        (1<<4)      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBFS_UEP_T_TOG             (1<<6)      // prepared data toggle flag of USB endpoint X transmittal (IN): 0=DATA0, 1=DATA1
+#define USBFS_UEP_T_RES_MASK        (3<<0)      // bit mask of handshake response type for USB endpoint X transmittal (IN)
+#define USBFS_UEP_T_RES_ACK         (0<<1)
+#define USBFS_UEP_T_RES_NONE        (1<<0)
+#define USBFS_UEP_T_RES_NAK         (1<<1)
+#define USBFS_UEP_T_RES_STALL       (3<<0)
+// bUEP_T_RES1 & bUEP_T_RES0: handshake response type for USB endpoint X transmittal (IN)
+//   00: DATA0 or DATA1 then expecting ACK (ready)
+//   01: DATA0 or DATA1 then expecting no response, time out from host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+// host aux setup
+
+/* R8_UEPn_RX_CTRL, n=0-7 */
+#define USBFS_UEP_R_AUTO_TOG        (1<<4)      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBFS_UEP_R_TOG             (1<<7)      // expected data toggle flag of USB endpoint X receiving (OUT): 0=DATA0, 1=DATA1
+#define USBFS_UEP_R_RES_MASK        (3<<2)      // bit mask of handshake response type for USB endpoint X receiving (OUT)
+#define USBFS_UEP_R_RES_ACK         (0<<3)
+#define USBFS_UEP_R_RES_NONE        (1<<2)
+#define USBFS_UEP_R_RES_NAK         (1<<3)
+#define USBFS_UEP_R_RES_STALL       (3<<2)
+
+
+#define EP1_T_EN					(1<<6)
+#define EP2_T_EN					(1<<2)
+#define EP3_T_EN					(1<<6)
+#define EP4_T_EN					(1<<2)
+#define EP1_R_EN					(1<<7)
+#define EP2_R_EN					(1<<3)
+#define EP3_R_EN					(1<<7)
+#define EP4_R_EN					(1<<3)
+
+
+/* R8_USB_CTRL */
+#define USBFS_UC_HOST_MODE          0x80
+#define USBFS_UC_LOW_SPEED          0x40
+#define USBFS_UC_DEV_PU_EN          0x20
+#define USBFS_UC_SYS_CTRL_MASK      0x30
+#define USBFS_UC_SYS_CTRL0          0x00
+#define USBFS_UC_SYS_CTRL1          0x10
+#define USBFS_UC_SYS_CTRL2          0x20
+#define USBFS_UC_SYS_CTRL3          0x30
+#define USBFS_UC_INT_BUSY           0x08
+#define USBFS_UC_RESET_SIE          0x04
+#define USBFS_UC_CLR_ALL            0x02
+#define USBFS_UC_DMA_EN             0x01
+
+/* R8_USB_INT_EN */
+#define USBFS_UIE_DEV_SOF           0x80
+#define USBFS_UIE_DEV_NAK           0x40
+#define USBFS_UIE_FIFO_OV           0x10
+#define USBFS_UIE_HST_SOF           0x08
+#define USBFS_UIE_SUSPEND           0x04
+#define USBFS_UIE_TRANSFER          0x02
+#define USBFS_UIE_DETECT            0x01
+#define USBFS_UIE_BUS_RST           0x01
+
+/* R8_USB_DEV_AD */
+#define USBFS_UDA_GP_BIT            0x80
+#define USBFS_USB_ADDR_MASK         0x7F
+
+/* R8_USB_MIS_ST */
+#define USBFS_UMS_SOF_PRES          0x80
+#define USBFS_UMS_SOF_ACT           0x40
+#define USBFS_UMS_SIE_FREE          0x20
+#define USBFS_UMS_R_FIFO_RDY        0x10
+#define USBFS_UMS_BUS_RESET         0x08
+#define USBFS_UMS_SUSPEND           0x04
+#define USBFS_UMS_DM_LEVEL          0x02
+#define USBFS_UMS_DEV_ATTACH        0x01
+
+
+
+
+#define USBFS_UDA_GP_BIT            0x80
+#define USBFS_USB_ADDR_MASK         0x7F
+
+#define DEF_USBD_UEP0_SIZE		   64	 /* usb hs/fs device end-point 0 size */
+#define UEP_SIZE 64
+
+#define DEF_UEP_IN                  0x80
+#define DEF_UEP_OUT                 0x00
+#define DEF_UEP_BUSY                0x01
+#define DEF_UEP_FREE                0x00
+
+#define DEF_UEP0 0
+#define DEF_UEP1 1
+#define DEF_UEP2 2
+#define DEF_UEP3 3
+#define DEF_UEP4 4
+#define DEF_UEP5 5
+#define DEF_UEP6 6
+#define DEF_UEP7 7
+#define UNUM_EP 8
+
+
+
+/* USB Host Mode */
+
+typedef struct
+{
+	__IO uint8_t RESERVED0;
+	__IO uint8_t HOST_CTRL;
+	__IO uint8_t RESERVED1;
+	__IO uint8_t RESERVED2;
+	__IO uint8_t RESERVED3;
+	__IO uint8_t RESERVED4;
+	__IO uint8_t RESERVED5;
+	__IO uint8_t RESERVED6;
+	__IO uint16_t RESERVED7;
+	__IO uint16_t RESERVED8;
+	__IO uint8_t RESERVED9;
+	__IO uint8_t HOST_EP_MOD;
+	__IO uint8_t RESERVED10;
+	__IO uint8_t RESERVED11;
+
+	__IO uint32_t RESERVED12;
+	__IO uint32_t RESERVED13;
+	__IO uint32_t HOST_RX_DMA;
+	__IO uint32_t HOST_TX_DMA;
+
+	__IO uint16_t RESERVED14;
+	__IO uint16_t RESERVED15;
+	__IO uint16_t RESERVED16;
+
+	__IO uint16_t HOST_SETUP;
+	__IO uint16_t HOST_EP_PID;
+	__IO uint16_t HOST_RX_CTL;
+	__IO uint16_t HOST_TX_LEN;
+	__IO uint16_t HOST_TX_CTL;
+
+	__IO uint16_t RESERVED20;
+	__IO uint16_t RESERVED21;
+
+	__IO uint32_t RESERVED22[8];
+
+	__IO uint32_t RESERVED23;
+	__IO uint32_t RESERVED24;
+	__IO uint32_t RESERVED25;
+
+	__IO uint32_t RESERVED26;
+
+	__IO uint16_t RESERVED27;
+	__IO uint16_t RESERVED28;
+
+	__IO uint16_t RESERVED29;
+	__IO uint16_t RESERVED30;
+
+	__IO uint16_t RESERVED31;
+	__IO uint16_t RESERVED32;
+
+	__IO uint32_t RESERVED33;
+} USBDH_TypeDef;
+
+
+/* USB Power Delivery */
+typedef struct
+{
+	__IO uint32_t CONFIG;
+	__IO uint32_t CONTROL;
+	__IO uint32_t STATUS;
+	__IO uint32_t PORT;
+	__IO uint32_t DMA;
+} USBPD_TypeDef;
+
+
+/* USB Power Delivery */
+typedef struct
+{
+	__IO uint16_t CONFIG;
+	__IO uint16_t BCM_CLK_CNT;
+
+	__IO uint8_t CONTROL;
+	__IO uint8_t TX_SEL;
+	__IO uint16_t BMC_TX_SZ;
+
+	__IO uint8_t DATA_BUF;
+	__IO uint8_t STATUS;
+	__IO uint16_t BMC_BYTE_CNT;
+
+	__IO uint16_t PORT_CC1;
+	__IO uint16_t PORT_CC2;
+
+	__IO uint32_t USBPD_DMA;
+} USBPD_DETAILED_TypeDef;
+
+#endif // #if defined(CH32X03x)
+
+
+#endif
+
 /* Peripheral memory map */
+#ifdef __ASSEMBLER__
+#define FLASH_BASE                              (0x08000000) /* FLASH base address in the alias region */
+#define SRAM_BASE                               (0x20000000) /* SRAM base address in the alias region */
+#define PERIPH_BASE                             (0x40000000) /* Peripheral base address in the alias region */
+#define CORE_PERIPH_BASE                        (0xE0000000) /* System peripherals base address in the alias region */
+#else
 #define FLASH_BASE                              ((uint32_t)0x08000000) /* FLASH base address in the alias region */
 #define SRAM_BASE                               ((uint32_t)0x20000000) /* SRAM base address in the alias region */
 #define PERIPH_BASE                             ((uint32_t)0x40000000) /* Peripheral base address in the alias region */
+#define CORE_PERIPH_BASE                        ((uint32_t)0xE0000000) /* System peripherals base address in the alias region */
+#endif
+
+#if defined(CH32V30x)
+#ifdef __ASSEMBLER__
+#define FSMC_R_BASE           					(b 0xA0000000) /* FSMC registers base address */
+#else
+#define FSMC_R_BASE           					((uint32_t)0xA0000000) /* FSMC registers base address */
+#endif
+#endif
 
 #define APB1PERIPH_BASE                         (PERIPH_BASE)
 #define APB2PERIPH_BASE                         (PERIPH_BASE + 0x10000)
 #define AHBPERIPH_BASE                          (PERIPH_BASE + 0x20000)
 
 #define TIM2_BASE                               (APB1PERIPH_BASE + 0x0000)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+#define TIM3_BASE                               (APB1PERIPH_BASE + 0x0400)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define TIM4_BASE                               (APB1PERIPH_BASE + 0x0800)
+#define TIM5_BASE                               (APB1PERIPH_BASE + 0x0C00)
+#endif // CH32V10x, CH32V20x, CH32V30x
+#if defined(CH32V30x)	// CH32V30x
+#define TIM6_BASE             					(APB1PERIPH_BASE + 0x1000)
+#define TIM7_BASE             					(APB1PERIPH_BASE + 0x1400)
+#define UART6_BASE            					(APB1PERIPH_BASE + 0x1800)
+#define UART7_BASE            					(APB1PERIPH_BASE + 0x1C00)
+#define UART8_BASE            					(APB1PERIPH_BASE + 0x2000)
+#endif					// CH32V30x
+#if defined(CH32V10x)	// CH32V10x
+#define TIM6_BASE                               (APB1PERIPH_BASE + 0x1000)
+#define TIM7_BASE                               (APB1PERIPH_BASE + 0x1400)
+#define TIM12_BASE                              (APB1PERIPH_BASE + 0x1800)
+#define TIM13_BASE                              (APB1PERIPH_BASE + 0x1C00)
+#define TIM14_BASE                              (APB1PERIPH_BASE + 0x2000)
+#endif					// CH32V10x
+#if defined(CH32V003) || defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define RTC_BASE                                (APB1PERIPH_BASE + 0x2800)
+#endif
+#endif
 #define WWDG_BASE                               (APB1PERIPH_BASE + 0x2C00)
 #define IWDG_BASE                               (APB1PERIPH_BASE + 0x3000)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define SPI2_BASE                               (APB1PERIPH_BASE + 0x3800)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define SPI3_BASE             					(APB1PERIPH_BASE + 0x3C00)
+#endif // defined(CH32V30x) || defined(CH32V10x)
+#endif
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+#define USART2_BASE                             (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE                             (APB1PERIPH_BASE + 0x4800)
+#define UART4_BASE                              (APB1PERIPH_BASE + 0x4C00)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define UART5_BASE            					(APB1PERIPH_BASE + 0x5000)
+#endif // defined(CH32V30x) || defined(CH32V10x)
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 #define I2C1_BASE                               (APB1PERIPH_BASE + 0x5400)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define I2C2_BASE                               (APB1PERIPH_BASE + 0x5800)
+#endif
+#if defined(CH32V20x) || defined(CH32V30x)
+#define CAN1_BASE                               (APB1PERIPH_BASE + 0x6400)
+#endif
+#if defined(CH32V30x)
+#define CAN2_BASE             (APB1PERIPH_BASE + 0x6800)
+#endif
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define BKP_BASE                                (APB1PERIPH_BASE + 0x6C00)
+#endif
 #define PWR_BASE                                (APB1PERIPH_BASE + 0x7000)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DAC_BASE              					(APB1PERIPH_BASE + 0x7400)
+#endif
 
 #define AFIO_BASE                               (APB2PERIPH_BASE + 0x0000)
 #define EXTI_BASE                               (APB2PERIPH_BASE + 0x0400)
 #define GPIOA_BASE                              (APB2PERIPH_BASE + 0x0800)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+#define GPIOB_BASE                              (APB2PERIPH_BASE + 0x0C00)
+#endif
 #define GPIOC_BASE                              (APB2PERIPH_BASE + 0x1000)
 #define GPIOD_BASE                              (APB2PERIPH_BASE + 0x1400)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define GPIOE_BASE                              (APB2PERIPH_BASE + 0x1800)
+#define GPIOF_BASE                              (APB2PERIPH_BASE + 0x1C00)
+#define GPIOG_BASE                              (APB2PERIPH_BASE + 0x2000)
+#endif
 #define ADC1_BASE                               (APB2PERIPH_BASE + 0x2400)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC2_BASE                               (APB2PERIPH_BASE + 0x2800)
+#endif
 #define TIM1_BASE                               (APB2PERIPH_BASE + 0x2C00)
 #define SPI1_BASE                               (APB2PERIPH_BASE + 0x3000)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define TIM8_BASE             					(APB2PERIPH_BASE + 0x3400)
+#endif
 #define USART1_BASE                             (APB2PERIPH_BASE + 0x3800)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define ADC3_BASE             					(APB2PERIPH_BASE + 0x3C00)
+#define TIM15_BASE            					(APB2PERIPH_BASE + 0x4000)
+#define TIM16_BASE            					(APB2PERIPH_BASE + 0x4400)
+#define TIM17_BASE            					(APB2PERIPH_BASE + 0x4800)
+#define TIM9_BASE             					(APB2PERIPH_BASE + 0x4C00)
+#define TIM10_BASE            					(APB2PERIPH_BASE + 0x5000)
+#define TIM11_BASE           					(APB2PERIPH_BASE + 0x5400)
+#endif
+#if defined(CH32V30x)
+#define SDIO_BASE            					(APB2PERIPH_BASE + 0x8000)
+#endif
 
 #define DMA1_BASE                               (AHBPERIPH_BASE + 0x0000)
 #define DMA1_Channel1_BASE                      (AHBPERIPH_BASE + 0x0008)
@@ -393,27 +2413,304 @@ typedef struct
 #define DMA1_Channel5_BASE                      (AHBPERIPH_BASE + 0x0058)
 #define DMA1_Channel6_BASE                      (AHBPERIPH_BASE + 0x006C)
 #define DMA1_Channel7_BASE                      (AHBPERIPH_BASE + 0x0080)
+#if defined(CH32V20x)
+#define DMA1_Channel8_BASE                      (AHBPERIPH_BASE + 0x0094)
+#endif
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DMA2_BASE             					(AHBPERIPH_BASE + 0x0400)
+#define DMA2_Channel1_BASE    					(AHBPERIPH_BASE + 0x0408)
+#define DMA2_Channel2_BASE    					(AHBPERIPH_BASE + 0x041C)
+#define DMA2_Channel3_BASE    					(AHBPERIPH_BASE + 0x0430)
+#define DMA2_Channel4_BASE    					(AHBPERIPH_BASE + 0x0444)
+#define DMA2_Channel5_BASE    					(AHBPERIPH_BASE + 0x0458)
+#if defined(CH32V30x)
+#define DMA2_Channel6_BASE    					(AHBPERIPH_BASE + 0x046C)
+#define DMA2_Channel7_BASE    					(AHBPERIPH_BASE + 0x0480)
+#define DMA2_Channel8_BASE    					(AHBPERIPH_BASE + 0x0490)
+#define DMA2_Channel9_BASE    					(AHBPERIPH_BASE + 0x04A0)
+#define DMA2_Channel10_BASE   					(AHBPERIPH_BASE + 0x04B0)
+#define DMA2_Channel11_BASE   					(AHBPERIPH_BASE + 0x04C0)
+#define DMA2_EXTEN_BASE       					(AHBPERIPH_BASE + 0x04D0)
+#endif // defined(CH32V30x)
+#endif
 #define RCC_BASE                                (AHBPERIPH_BASE + 0x1000)
 
 #define FLASH_R_BASE                            (AHBPERIPH_BASE + 0x2000) /* Flash registers base address */
+
+#if defined(CH32V20x)
+#define CRC_BASE                                (AHBPERIPH_BASE + 0x3000)
+#define OPA_BASE                                (AHBPERIPH_BASE + 0x3804)
+#define ETH10M_BASE                             (AHBPERIPH_BASE + 0x8000)
+
+#define USBFS_BASE                              ((uint32_t)0x50000000)
+#elif defined(CH32X03x)
+
+#define OPA_BASE                                (AHBPERIPH_BASE + 0x6000)
+#define USBFS_BASE                              (AHBPERIPH_BASE + 0x3400)
+#define USBPD_BASE                              (AHBPERIPH_BASE + 0x7000)
+
+#elif defined(CH32V30x)
+#define CRC_BASE              					(AHBPERIPH_BASE + 0x3000)
+#define USBHS_BASE            					(AHBPERIPH_BASE + 0x3400)
+#define OPA_BASE              					(AHBPERIPH_BASE + 0x3804)
+#define RNG_BASE              					(AHBPERIPH_BASE + 0x3C00)
+
+#define ETH_BASE              					(AHBPERIPH_BASE + 0x8000)
+#define ETH_MAC_BASE          					(ETH_BASE)
+#define ETH_MMC_BASE          					(ETH_BASE + 0x0100)
+#define ETH_PTP_BASE          					(ETH_BASE + 0x0700)
+#define ETH_DMA_BASE          					(ETH_BASE + 0x1000)
+
+#define USBFS_BASE            					((uint32_t)0x50000000)
+#define DVP_BASE              					((uint32_t)0x50050000)
+
+#define FSMC_Bank1_R_BASE     					(FSMC_R_BASE + 0x0000)
+#define FSMC_Bank1E_R_BASE    					(FSMC_R_BASE + 0x0104)
+#define FSMC_Bank2_R_BASE     					(FSMC_R_BASE + 0x0060)
+#elif defined(CH32V10x)
+#define CRC_BASE                                (AHBPERIPH_BASE + 0x3000)
+#define DBGMCU_BASE                             ((uint32_t)0xE000D000)
+#endif
+
 #define OB_BASE                                 ((uint32_t)0x1FFFF800)    /* Flash Option Bytes base address */
+#define ESIG_BASE                               ((uint32_t)0x1FFFF7E0)
+
+#if defined(CH32V003) || defined(CH32V10x)
 #define EXTEN_BASE                              ((uint32_t)0x40023800)
+#elif defined(CH32V20x) || defined(CH32V30x)
+#define EXTEN_BASE                              (AHBPERIPH_BASE + 0x3800)
+#endif
+
+#define PFIC_BASE    (CORE_PERIPH_BASE + 0xE000)
+#define SysTick_BASE    (CORE_PERIPH_BASE + 0xF000)
+
+#if defined(CH32V20x)
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+#define OSC_BASE                                (AHBPERIPH_BASE + 0x202C)
+#endif
+#endif
+
+
+
+// AFIO CTLR Bits
+#define PB6_FILT_EN    (1<<27)
+#define PB5_FILT_EN    (1<<26)
+#define PA4_FILT_EN    (1<<25)
+#define PA3_FILT_EN    (1<<24)
+#define UDM_BC_CMPO	   (1<<19)
+#define UDP_BC_CMPO    (1<<17)
+#define UDM_BC_VSRC    (1<<17)
+#define UDP_BC_VSRC    (1<<16)
+#define USBPD_IN_HVT   (1<<9)
+#define USBPD_PHY_V33  (1<<8)
+#define USB_IOEN       (1<<7)
+#define USB_PHY_V33    (1<<6)
+#define UDP_PUE_00     (0b00<<2)
+#define UDP_PUE_01     (0b01<<2)
+#define UDP_PUE_10     (0b10<<2)
+#define UDP_PUE_11     (0b11<<2)
+#define UDM_PUE_00     (0b00<<0)
+#define UDM_PUE_01     (0b01<<0)
+#define UDM_PUE_10     (0b10<<0)
+#define UDM_PUE_11     (0b11<<0)
+#define UDP_PUE_MASK                0x0000000C
+#define UDP_PUE_DISABLE             0x00000000
+#define UDP_PUE_35UA                0x00000004
+#define UDP_PUE_10K                 0x00000008
+#define UDP_PUE_1K5                 0x0000000C
+#define UDM_PUE_MASK                0x00000003
+#define UDM_PUE_DISABLE             0x00000000
+#define UDM_PUE_35UA                0x00000001
+#define UDM_PUE_10K                 0x00000002
+#define UDM_PUE_1K5                 0x00000003
+
+
+// USB PD Bits
+#define IE_TX_END      (1<<15)
+#define IE_RX_RESET    (1<<14)
+#define IE_RX_ACT      (1<<13)
+#define IE_RX_BYTE     (1<<12)
+#define IE_RX_BIT      (1<<11)
+#define IE_PD_IO       (1<<10)
+#define WAKE_POLAR     (1<<5)
+#define PD_RST_EN      (1<<4)
+#define PD_DMA_EN      (1<<3)
+#define CC_SEL         (1<<2)
+#define PD_ALL_CLR     (1<<1)
+#define PD_FILT_EN     (1<<0)
+#define BMC_CLK_CNT_MASK  (0xff)
+
+//R8_CONTROL
+#define BMC_BYTE_HI    (1<<7)
+#define TX_BIT_BACK    (1<<6)
+#define DATA_FLAG      (1<<5)
+#define RX_STATE_MASK  (0x7<<2)
+#define RX_STATE_0     (1<<2)
+#define RX_STATE_1     (1<<3)
+#define RX_STATE_2     (1<<4)
+#define BMC_START      (1<<1)
+#define PD_TX_EN       (1<<0)
+
+#define TX_SEL4_MASK   (3<<6)
+#define TX_SEL4_0      (1<<6)
+#define TX_SEL4_1      (1<<7)
+
+#define TX_SEL3_MASK   (3<<4)
+#define TX_SEL3_0      (1<<4)
+#define TX_SEL3_1      (1<<5)
+
+#define TX_SEL2_MASK   (3<<2)
+#define TX_SEL2_0      (1<<2)
+#define TX_SEL2_1      (1<<3)
+
+#define TX_SEL1        (1<<0)
+
+#define BMC_TX_SZ_MASK (0x1ff)
+
+//R8_STATUS
+#define IF_TX_END      (1<<7)
+#define IF_RX_RESET    (1<<6)
+#define IF_RX_ACT      (1<<5)
+#define IF_RX_BYTE     (1<<4)
+#define IF_RX_BIT      (1<<3)
+#define IFBUF_ERR      (1<<2)
+#define BMC_AUX_MASK   (3<<0)
+#define BMC_AUX_1      (1<<1)
+#define BMC_AUX_0      (1<<0)
+
+// PORT CC1
+#define CC1_CE_MASK    (7<<5)
+#define CC1_CE_0       (1<<5)
+#define CC1_CE_1       (2<<5)
+#define CC1_CE_2       (4<<5)
+
+#define CC1_LVE        (1<<4)
+#define CC1_PU_MASK    (3<<2)
+#define CC1_PU_DISABLE (0<<2)
+#define CC1_PU_330uA   (1<<2)
+#define CC1_PU_180uA   (2<<2)
+#define CC1_PU_80uA    (3<<2)
+#define PA_CC1_AI      (1<<0)
+
+#define CC2_CE_MASK    (7<<5)
+#define CC2_CE_0       (1<<5)
+#define CC2_CE_1       (2<<5)
+#define CC2_CE_2       (4<<5)
+
+#define CC2_LVE        (1<<4)
+#define CC2_PU_MASK    (3<<2)
+#define CC2_PU_DISABLE (0<<2)
+#define CC2_PU_330uA   (1<<2)
+#define CC2_PU_180uA   (2<<2)
+#define CC2_PU_80uA    (3<<2)
+#define PA_CC2_AI      (1<<0)
+
+
 
 /* Peripheral declaration */
 #define TIM2                                    ((TIM_TypeDef *)TIM2_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define TIM3                                    ((TIM_TypeDef *)TIM3_BASE)
+#define TIM4                                    ((TIM_TypeDef *)TIM4_BASE)
+#define TIM5                                    ((TIM_TypeDef *)TIM5_BASE)
+#if defined(CH32V30x)
+#define TIM6                					((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                					((TIM_TypeDef *) TIM7_BASE)
+#define UART6               					((USART_TypeDef *) UART6_BASE)
+#define UART7               					((USART_TypeDef *) UART7_BASE)
+#define UART8               					((USART_TypeDef *) UART8_BASE)
+#endif // defined(CH32V30x)
+#if defined(CH32V10x)
+#define TIM6                                    ((TIM_TypeDef *)TIM6_BASE)
+#define TIM7                                    ((TIM_TypeDef *)TIM7_BASE)
+#define TIM12                                   ((TIM_TypeDef *)TIM12_BASE)
+#define TIM13                                   ((TIM_TypeDef *)TIM13_BASE)
+#define TIM14                                   ((TIM_TypeDef *)TIM14_BASE)
+#endif // defined(CH32V10x)
+#define RTC                                     ((RTC_TypeDef *)RTC_BASE)
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 #define WWDG                                    ((WWDG_TypeDef *)WWDG_BASE)
 #define IWDG                                    ((IWDG_TypeDef *)IWDG_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define SPI2                                    ((SPI_TypeDef *)SPI2_BASE)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define SPI3                					((SPI_TypeDef *) SPI3_BASE)
+#endif
+#define USART2                                  ((USART_TypeDef *)USART2_BASE)
+#define USART3                                  ((USART_TypeDef *)USART3_BASE)
+#define UART4                                   ((USART_TypeDef *)UART4_BASE)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define UART5               					((USART_TypeDef *) UART5_BASE)
+#endif
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 #define I2C1                                    ((I2C_TypeDef *)I2C1_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define I2C2                                    ((I2C_TypeDef *)I2C2_BASE)
+#endif
+#if defined(CH32V20x) || defined(CH32V30x)
+#define CAN1                                    ((CAN_TypeDef *)CAN1_BASE)
+#endif
+#if defined(CH32V30x)
+#define CAN2                					((CAN_TypeDef *) CAN2_BASE)
+#endif
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define BKP                                     ((BKP_TypeDef *)BKP_BASE)
+#endif
 #define PWR                                     ((PWR_TypeDef *)PWR_BASE)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DAC                 					((DAC_TypeDef *) DAC_BASE)
+#endif
+
 #define AFIO                                    ((AFIO_TypeDef *)AFIO_BASE)
 #define EXTI                                    ((EXTI_TypeDef *)EXTI_BASE)
 #define GPIOA                                   ((GPIO_TypeDef *)GPIOA_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+#define GPIOB                                   ((GPIO_TypeDef *)GPIOB_BASE)
+#endif
 #define GPIOC                                   ((GPIO_TypeDef *)GPIOC_BASE)
 #define GPIOD                                   ((GPIO_TypeDef *)GPIOD_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define GPIOE                                   ((GPIO_TypeDef *)GPIOE_BASE)
+#define GPIOF                                   ((GPIO_TypeDef *)GPIOF_BASE)
+#define GPIOG                                   ((GPIO_TypeDef *)GPIOG_BASE)
+#endif
 #define ADC1                                    ((ADC_TypeDef *)ADC1_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC2                                    ((ADC_TypeDef *)ADC2_BASE)
+#endif
+#ifdef CH32X03x
+#define TIM3                                    ((TIM_TypeDef *)TIM3_BASE)
+#define TKey                                    ((TKEY_TypeDef *)ADC1_BASE)
+#define OPA										((OPACMP_TypeDef *)OPA_BASE)
+#define USBFS									((USBFS_TypeDef *)USBFS_BASE)
+#define USBPDWORD								((USBPD_TypeDef *)USBPD_BASE)
+#define USBPD									((USBPD_DETAILED_TypeDef *)USBPD_BASE)
+#define USBDH									((USBDH_TypeDef *)USBFS_BASE)
+
+#endif
+#if defined(CH32V20x) || defined(CH32V30x)
+#define TKey1                                   ((ADC_TypeDef *)ADC1_BASE)
+#define TKey2                                   ((ADC_TypeDef *)ADC2_BASE)
+#endif
 #define TIM1                                    ((TIM_TypeDef *)TIM1_BASE)
 #define SPI1                                    ((SPI_TypeDef *)SPI1_BASE)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define TIM8                					((TIM_TypeDef *) TIM8_BASE)
+#endif
 #define USART1                                  ((USART_TypeDef *)USART1_BASE)
+#if defined(CH32V10x) || defined(CH32V30x)
+#define ADC3                					((ADC_TypeDef *) ADC3_BASE)
+#define TIM15               					((TIM_TypeDef *) TIM15_BASE)
+#define TIM16               					((TIM_TypeDef *) TIM16_BASE)
+#define TIM17               					((TIM_TypeDef *) TIM17_BASE)
+#define TIM9                					((TIM_TypeDef *) TIM9_BASE)
+#define TIM10               					((TIM_TypeDef *) TIM10_BASE)
+#define TIM11               					((TIM_TypeDef *) TIM11_BASE)
+#endif // defined(CH32V10x) || defined(CH32V30x)
+#if defined(CH32V30x)
+#define SDIO                					((SDIO_TypeDef *) SDIO_BASE)
+#endif
+
 #define DMA1                                    ((DMA_TypeDef *)DMA1_BASE)
 #define DMA1_Channel1                           ((DMA_Channel_TypeDef *)DMA1_Channel1_BASE)
 #define DMA1_Channel2                           ((DMA_Channel_TypeDef *)DMA1_Channel2_BASE)
@@ -422,10 +2719,67 @@ typedef struct
 #define DMA1_Channel5                           ((DMA_Channel_TypeDef *)DMA1_Channel5_BASE)
 #define DMA1_Channel6                           ((DMA_Channel_TypeDef *)DMA1_Channel6_BASE)
 #define DMA1_Channel7                           ((DMA_Channel_TypeDef *)DMA1_Channel7_BASE)
+#if defined(CH32V20x) || defined(CH32X03x)
+#define DMA1_Channel8                           ((DMA_Channel_TypeDef *)DMA1_Channel8_BASE)
+#endif
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DMA2                					((DMA_TypeDef *) DMA2_BASE)
+#define DMA2_EXTEN          					((DMA_TypeDef *) DMA2_EXTEN_BASE)
+#define DMA2_Channel1       					((DMA_Channel_TypeDef *) DMA2_Channel1_BASE)
+#define DMA2_Channel2       					((DMA_Channel_TypeDef *) DMA2_Channel2_BASE)
+#define DMA2_Channel3       					((DMA_Channel_TypeDef *) DMA2_Channel3_BASE)
+#define DMA2_Channel4       					((DMA_Channel_TypeDef *) DMA2_Channel4_BASE)
+#define DMA2_Channel5       					((DMA_Channel_TypeDef *) DMA2_Channel5_BASE)
+#if defined(CH32V30x)
+#define DMA2_Channel6       					((DMA_Channel_TypeDef *) DMA2_Channel6_BASE)
+#define DMA2_Channel7       					((DMA_Channel_TypeDef *) DMA2_Channel7_BASE)
+#define DMA2_Channel8       					((DMA_Channel_TypeDef *) DMA2_Channel8_BASE)
+#define DMA2_Channel9       					((DMA_Channel_TypeDef *) DMA2_Channel9_BASE)
+#define DMA2_Channel10      					((DMA_Channel_TypeDef *) DMA2_Channel10_BASE)
+#define DMA2_Channel11      					((DMA_Channel_TypeDef *) DMA2_Channel11_BASE)
+#endif // defined(CH32V30x)
+#endif // defined(CH32V10x) || defined(CH32V30x)
 #define RCC                                     ((RCC_TypeDef *)RCC_BASE)
 #define FLASH                                   ((FLASH_TypeDef *)FLASH_R_BASE)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define CRC                                     ((CRC_TypeDef *)CRC_BASE)
+#endif
+#if defined(CH32V20x) || defined(CH32V30x)
+#if defined(CH32V30x)
+#define USBHSD              					((USBHSD_TypeDef *) USBHS_BASE)
+#define USBHSH              					((USBHSH_TypeDef *) USBHS_BASE)
+#endif // defined(CH32V30x)
+#define USBOTG_FS                               ((USBOTG_FS_TypeDef *)USBFS_BASE)
+#define USBOTG_H_FS                             ((USBOTG_FS_HOST_TypeDef *)USBFS_BASE)
+#define OPA                                     ((OPA_TypeDef *)OPA_BASE)
+#if defined(CH32V20x)
+#define ETH10M                                  ((ETH10M_TypeDef *)ETH10M_BASE)
+#elif defined(CH32V30x)
+#define RNG                 					((RNG_TypeDef *) RNG_BASE)
+#define ETH                 					((ETH_TypeDef *) ETH_BASE)
+#endif
+#endif // defined(CH32V20x) || defined(CH32V30x)
 #define OB                                      ((OB_TypeDef *)OB_BASE)
+#define ESIG                                    ((ESG_TypeDef *)ESIG_BASE)
 #define EXTEN                                   ((EXTEN_TypeDef *)EXTEN_BASE)
+
+#if defined(CH32V20x)
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+#define OSC                                     ((OSC_TypeDef *)OSC_BASE)
+#endif
+#endif
+
+#if defined(CH32V30x)
+#define DVP                 					((DVP_TypeDef *) DVP_BASE)
+
+#define FSMC_Bank1          					((FSMC_Bank1_TypeDef *) FSMC_Bank1_R_BASE)
+#define FSMC_Bank1E         					((FSMC_Bank1E_TypeDef *) FSMC_Bank1E_R_BASE)
+#define FSMC_Bank2          					((FSMC_Bank2_TypeDef *) FSMC_Bank2_R_BASE)
+#endif
+
+#if defined(CH32V10x)
+#define DBGMCU                                  ((DBGMCU_TypeDef *)DBGMCU_BASE)
+#endif
 
 /******************************************************************************/
 /*                         Peripheral Registers Bits Definition               */
@@ -778,6 +3132,1500 @@ typedef struct
 #define ADC_RDATAR_DATA                         ((uint32_t)0x0000FFFF) /* Regular data */
 #define ADC_RDATAR_ADC2DATA                     ((uint32_t)0xFFFF0000) /* ADC2 data */
 
+#if defined(CH32V20x) || defined(CH32V30x)
+/******************************************************************************/
+/*                            Backup registers                                */
+/******************************************************************************/
+
+/*******************  Bit definition for BKP_DATAR1 register  ********************/
+#define BKP_DATAR1_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR2 register  ********************/
+#define BKP_DATAR2_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR3 register  ********************/
+#define BKP_DATAR3_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR4 register  ********************/
+#define BKP_DATAR4_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR5 register  ********************/
+#define BKP_DATAR5_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR6 register  ********************/
+#define BKP_DATAR6_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR7 register  ********************/
+#define BKP_DATAR7_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR8 register  ********************/
+#define BKP_DATAR8_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR9 register  ********************/
+#define BKP_DATAR9_D                            ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR10 register  *******************/
+#define BKP_DATAR10_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR11 register  *******************/
+#define BKP_DATAR11_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR12 register  *******************/
+#define BKP_DATAR12_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR13 register  *******************/
+#define BKP_DATAR13_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR14 register  *******************/
+#define BKP_DATAR14_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR15 register  *******************/
+#define BKP_DATAR15_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR16 register  *******************/
+#define BKP_DATAR16_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR17 register  *******************/
+#define BKP_DATAR17_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/******************  Bit definition for BKP_DATAR18 register  ********************/
+#define BKP_DATAR18_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR19 register  *******************/
+#define BKP_DATAR19_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR20 register  *******************/
+#define BKP_DATAR20_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR21 register  *******************/
+#define BKP_DATAR21_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR22 register  *******************/
+#define BKP_DATAR22_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR23 register  *******************/
+#define BKP_DATAR23_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR24 register  *******************/
+#define BKP_DATAR24_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR25 register  *******************/
+#define BKP_DATAR25_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR26 register  *******************/
+#define BKP_DATAR26_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR27 register  *******************/
+#define BKP_DATAR27_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR28 register  *******************/
+#define BKP_DATAR28_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR29 register  *******************/
+#define BKP_DATAR29_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR30 register  *******************/
+#define BKP_DATAR30_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR31 register  *******************/
+#define BKP_DATAR31_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR32 register  *******************/
+#define BKP_DATAR32_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR33 register  *******************/
+#define BKP_DATAR33_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR34 register  *******************/
+#define BKP_DATAR34_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR35 register  *******************/
+#define BKP_DATAR35_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR36 register  *******************/
+#define BKP_DATAR36_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR37 register  *******************/
+#define BKP_DATAR37_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR38 register  *******************/
+#define BKP_DATAR38_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR39 register  *******************/
+#define BKP_DATAR39_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR40 register  *******************/
+#define BKP_DATAR40_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR41 register  *******************/
+#define BKP_DATAR41_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/*******************  Bit definition for BKP_DATAR42 register  *******************/
+#define BKP_DATAR42_D                           ((uint16_t)0xFFFF) /* Backup data */
+
+/******************  Bit definition for BKP_OCTLR register  *******************/
+#define BKP_CAL                                 ((uint16_t)0x007F) /* Calibration value */
+#define BKP_CCO                                 ((uint16_t)0x0080) /* Calibration Clock Output */
+#define BKP_ASOE                                ((uint16_t)0x0100) /* Alarm or Second Output Enable */
+#define BKP_ASOS                                ((uint16_t)0x0200) /* Alarm or Second Output Selection */
+
+/********************  Bit definition for BKP_TPCTLR register  ********************/
+#define BKP_TPE                                 ((uint8_t)0x01) /* TAMPER pin enable */
+#define BKP_TPAL                                ((uint8_t)0x02) /* TAMPER pin active level */
+
+/*******************  Bit definition for BKP_TPCSR register  ********************/
+#define BKP_CTE                                 ((uint16_t)0x0001) /* Clear Tamper event */
+#define BKP_CTI                                 ((uint16_t)0x0002) /* Clear Tamper Interrupt */
+#define BKP_TPIE                                ((uint16_t)0x0004) /* TAMPER Pin interrupt enable */
+#define BKP_TEF                                 ((uint16_t)0x0100) /* Tamper Event Flag */
+#define BKP_TIF                                 ((uint16_t)0x0200) /* Tamper Interrupt Flag */
+
+/******************************************************************************/
+/*                         Controller Area Network                            */
+/******************************************************************************/
+
+/*******************  Bit definition for CAN_CTLR register  ********************/
+#define CAN_CTLR_INRQ                           ((uint16_t)0x0001) /* Initialization Request */
+#define CAN_CTLR_SLEEP                          ((uint16_t)0x0002) /* Sleep Mode Request */
+#define CAN_CTLR_TXFP                           ((uint16_t)0x0004) /* Transmit FIFO Priority */
+#define CAN_CTLR_RFLM                           ((uint16_t)0x0008) /* Receive FIFO Locked Mode */
+#define CAN_CTLR_NART                           ((uint16_t)0x0010) /* No Automatic Retransmission */
+#define CAN_CTLR_AWUM                           ((uint16_t)0x0020) /* Automatic Wakeup Mode */
+#define CAN_CTLR_ABOM                           ((uint16_t)0x0040) /* Automatic Bus-Off Management */
+#define CAN_CTLR_TTCM                           ((uint16_t)0x0080) /* Time Triggered Communication Mode */
+#define CAN_CTLR_RESET                          ((uint16_t)0x8000) /* CAN software master reset */
+
+/*******************  Bit definition for CAN_STATR register  ********************/
+#define CAN_STATR_INAK                          ((uint16_t)0x0001) /* Initialization Acknowledge */
+#define CAN_STATR_SLAK                          ((uint16_t)0x0002) /* Sleep Acknowledge */
+#define CAN_STATR_ERRI                          ((uint16_t)0x0004) /* Error Interrupt */
+#define CAN_STATR_WKUI                          ((uint16_t)0x0008) /* Wakeup Interrupt */
+#define CAN_STATR_SLAKI                         ((uint16_t)0x0010) /* Sleep Acknowledge Interrupt */
+#define CAN_STATR_TXM                           ((uint16_t)0x0100) /* Transmit Mode */
+#define CAN_STATR_RXM                           ((uint16_t)0x0200) /* Receive Mode */
+#define CAN_STATR_SAMP                          ((uint16_t)0x0400) /* Last Sample Point */
+#define CAN_STATR_RX                            ((uint16_t)0x0800) /* CAN Rx Signal */
+
+/*******************  Bit definition for CAN_TSTATR register  ********************/
+#define CAN_TSTATR_RQCP0                        ((uint32_t)0x00000001) /* Request Completed Mailbox0 */
+#define CAN_TSTATR_TXOK0                        ((uint32_t)0x00000002) /* Transmission OK of Mailbox0 */
+#define CAN_TSTATR_ALST0                        ((uint32_t)0x00000004) /* Arbitration Lost for Mailbox0 */
+#define CAN_TSTATR_TERR0                        ((uint32_t)0x00000008) /* Transmission Error of Mailbox0 */
+#define CAN_TSTATR_ABRQ0                        ((uint32_t)0x00000080) /* Abort Request for Mailbox0 */
+#define CAN_TSTATR_RQCP1                        ((uint32_t)0x00000100) /* Request Completed Mailbox1 */
+#define CAN_TSTATR_TXOK1                        ((uint32_t)0x00000200) /* Transmission OK of Mailbox1 */
+#define CAN_TSTATR_ALST1                        ((uint32_t)0x00000400) /* Arbitration Lost for Mailbox1 */
+#define CAN_TSTATR_TERR1                        ((uint32_t)0x00000800) /* Transmission Error of Mailbox1 */
+#define CAN_TSTATR_ABRQ1                        ((uint32_t)0x00008000) /* Abort Request for Mailbox 1 */
+#define CAN_TSTATR_RQCP2                        ((uint32_t)0x00010000) /* Request Completed Mailbox2 */
+#define CAN_TSTATR_TXOK2                        ((uint32_t)0x00020000) /* Transmission OK of Mailbox 2 */
+#define CAN_TSTATR_ALST2                        ((uint32_t)0x00040000) /* Arbitration Lost for mailbox 2 */
+#define CAN_TSTATR_TERR2                        ((uint32_t)0x00080000) /* Transmission Error of Mailbox 2 */
+#define CAN_TSTATR_ABRQ2                        ((uint32_t)0x00800000) /* Abort Request for Mailbox 2 */
+#define CAN_TSTATR_CODE                         ((uint32_t)0x03000000) /* Mailbox Code */
+
+#define CAN_TSTATR_TME                          ((uint32_t)0x1C000000) /* TME[2:0] bits */
+#define CAN_TSTATR_TME0                         ((uint32_t)0x04000000) /* Transmit Mailbox 0 Empty */
+#define CAN_TSTATR_TME1                         ((uint32_t)0x08000000) /* Transmit Mailbox 1 Empty */
+#define CAN_TSTATR_TME2                         ((uint32_t)0x10000000) /* Transmit Mailbox 2 Empty */
+
+#define CAN_TSTATR_LOW                          ((uint32_t)0xE0000000) /* LOW[2:0] bits */
+#define CAN_TSTATR_LOW0                         ((uint32_t)0x20000000) /* Lowest Priority Flag for Mailbox 0 */
+#define CAN_TSTATR_LOW1                         ((uint32_t)0x40000000) /* Lowest Priority Flag for Mailbox 1 */
+#define CAN_TSTATR_LOW2                         ((uint32_t)0x80000000) /* Lowest Priority Flag for Mailbox 2 */
+
+/*******************  Bit definition for CAN_RFIFO0 register  *******************/
+#define CAN_RFIFO0_FMP0                         ((uint8_t)0x03) /* FIFO 0 Message Pending */
+#define CAN_RFIFO0_FULL0                        ((uint8_t)0x08) /* FIFO 0 Full */
+#define CAN_RFIFO0_FOVR0                        ((uint8_t)0x10) /* FIFO 0 Overrun */
+#define CAN_RFIFO0_RFOM0                        ((uint8_t)0x20) /* Release FIFO 0 Output Mailbox */
+
+/*******************  Bit definition for CAN_RFIFO1 register  *******************/
+#define CAN_RFIFO1_FMP1                         ((uint8_t)0x03) /* FIFO 1 Message Pending */
+#define CAN_RFIFO1_FULL1                        ((uint8_t)0x08) /* FIFO 1 Full */
+#define CAN_RFIFO1_FOVR1                        ((uint8_t)0x10) /* FIFO 1 Overrun */
+#define CAN_RFIFO1_RFOM1                        ((uint8_t)0x20) /* Release FIFO 1 Output Mailbox */
+
+/********************  Bit definition for CAN_INTENR register  *******************/
+#define CAN_INTENR_TMEIE                        ((uint32_t)0x00000001) /* Transmit Mailbox Empty Interrupt Enable */
+#define CAN_INTENR_FMPIE0                       ((uint32_t)0x00000002) /* FIFO Message Pending Interrupt Enable */
+#define CAN_INTENR_FFIE0                        ((uint32_t)0x00000004) /* FIFO Full Interrupt Enable */
+#define CAN_INTENR_FOVIE0                       ((uint32_t)0x00000008) /* FIFO Overrun Interrupt Enable */
+#define CAN_INTENR_FMPIE1                       ((uint32_t)0x00000010) /* FIFO Message Pending Interrupt Enable */
+#define CAN_INTENR_FFIE1                        ((uint32_t)0x00000020) /* FIFO Full Interrupt Enable */
+#define CAN_INTENR_FOVIE1                       ((uint32_t)0x00000040) /* FIFO Overrun Interrupt Enable */
+#define CAN_INTENR_EWGIE                        ((uint32_t)0x00000100) /* Error Warning Interrupt Enable */
+#define CAN_INTENR_EPVIE                        ((uint32_t)0x00000200) /* Error Passive Interrupt Enable */
+#define CAN_INTENR_BOFIE                        ((uint32_t)0x00000400) /* Bus-Off Interrupt Enable */
+#define CAN_INTENR_LECIE                        ((uint32_t)0x00000800) /* Last Error Code Interrupt Enable */
+#define CAN_INTENR_ERRIE                        ((uint32_t)0x00008000) /* Error Interrupt Enable */
+#define CAN_INTENR_WKUIE                        ((uint32_t)0x00010000) /* Wakeup Interrupt Enable */
+#define CAN_INTENR_SLKIE                        ((uint32_t)0x00020000) /* Sleep Interrupt Enable */
+
+/********************  Bit definition for CAN_ERRSR register  *******************/
+#define CAN_ERRSR_EWGF                          ((uint32_t)0x00000001) /* Error Warning Flag */
+#define CAN_ERRSR_EPVF                          ((uint32_t)0x00000002) /* Error Passive Flag */
+#define CAN_ERRSR_BOFF                          ((uint32_t)0x00000004) /* Bus-Off Flag */
+
+#define CAN_ERRSR_LEC                           ((uint32_t)0x00000070) /* LEC[2:0] bits (Last Error Code) */
+#define CAN_ERRSR_LEC_0                         ((uint32_t)0x00000010) /* Bit 0 */
+#define CAN_ERRSR_LEC_1                         ((uint32_t)0x00000020) /* Bit 1 */
+#define CAN_ERRSR_LEC_2                         ((uint32_t)0x00000040) /* Bit 2 */
+
+#define CAN_ERRSR_TEC                           ((uint32_t)0x00FF0000) /* Least significant byte of the 9-bit Transmit Error Counter */
+#define CAN_ERRSR_REC                           ((uint32_t)0xFF000000) /* Receive Error Counter */
+
+/*******************  Bit definition for CAN_BTIMR register  ********************/
+#define CAN_BTIMR_BRP                           ((uint32_t)0x000003FF) /* Baud Rate Prescaler */
+#define CAN_BTIMR_TS1                           ((uint32_t)0x000F0000) /* Time Segment 1 */
+#define CAN_BTIMR_TS2                           ((uint32_t)0x00700000) /* Time Segment 2 */
+#define CAN_BTIMR_SJW                           ((uint32_t)0x03000000) /* Resynchronization Jump Width */
+#define CAN_BTIMR_LBKM                          ((uint32_t)0x40000000) /* Loop Back Mode (Debug) */
+#define CAN_BTIMR_SILM                          ((uint32_t)0x80000000) /* Silent Mode */
+
+/******************  Bit definition for CAN_TXMI0R register  ********************/
+#define CAN_TXMI0R_TXRQ                         ((uint32_t)0x00000001) /* Transmit Mailbox Request */
+#define CAN_TXMI0R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_TXMI0R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_TXMI0R_EXID                         ((uint32_t)0x001FFFF8) /* Extended Identifier */
+#define CAN_TXMI0R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/******************  Bit definition for CAN_TXMDT0R register  *******************/
+#define CAN_TXMDT0R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_TXMDT0R_TGT                         ((uint32_t)0x00000100) /* Transmit Global Time */
+#define CAN_TXMDT0R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/******************  Bit definition for CAN_TXMDL0R register  *******************/
+#define CAN_TXMDL0R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_TXMDL0R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_TXMDL0R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_TXMDL0R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/******************  Bit definition for CAN_TXMDH0R register  *******************/
+#define CAN_TXMDH0R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_TXMDH0R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_TXMDH0R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_TXMDH0R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_TXMI1R register  *******************/
+#define CAN_TXMI1R_TXRQ                         ((uint32_t)0x00000001) /* Transmit Mailbox Request */
+#define CAN_TXMI1R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_TXMI1R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_TXMI1R_EXID                         ((uint32_t)0x001FFFF8) /* Extended Identifier */
+#define CAN_TXMI1R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TXMDT1R register  ******************/
+#define CAN_TXMDT1R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_TXMDT1R_TGT                         ((uint32_t)0x00000100) /* Transmit Global Time */
+#define CAN_TXMDT1R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_TXMDL1R register  ******************/
+#define CAN_TXMDL1R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_TXMDL1R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_TXMDL1R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_TXMDL1R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_TXMDH1R register  ******************/
+#define CAN_TXMDH1R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_TXMDH1R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_TXMDH1R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_TXMDH1R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_TXMI2R register  *******************/
+#define CAN_TXMI2R_TXRQ                         ((uint32_t)0x00000001) /* Transmit Mailbox Request */
+#define CAN_TXMI2R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_TXMI2R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_TXMI2R_EXID                         ((uint32_t)0x001FFFF8) /* Extended identifier */
+#define CAN_TXMI2R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_TXMDT2R register  ******************/
+#define CAN_TXMDT2R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_TXMDT2R_TGT                         ((uint32_t)0x00000100) /* Transmit Global Time */
+#define CAN_TXMDT2R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_TXMDL2R register  ******************/
+#define CAN_TXMDL2R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_TXMDL2R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_TXMDL2R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_TXMDL2R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_TXMDH2R register  ******************/
+#define CAN_TXMDH2R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_TXMDH2R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_TXMDH2R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_TXMDH2R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_RXMI0R register  *******************/
+#define CAN_RXMI0R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_RXMI0R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_RXMI0R_EXID                         ((uint32_t)0x001FFFF8) /* Extended Identifier */
+#define CAN_RXMI0R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RXMDT0R register  ******************/
+#define CAN_RXMDT0R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_RXMDT0R_FMI                         ((uint32_t)0x0000FF00) /* Filter Match Index */
+#define CAN_RXMDT0R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_RXMDL0R register  ******************/
+#define CAN_RXMDL0R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_RXMDL0R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_RXMDL0R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_RXMDL0R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_RXMDH0R register  ******************/
+#define CAN_RXMDH0R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_RXMDH0R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_RXMDH0R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_RXMDH0R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_RXMI1R register  *******************/
+#define CAN_RXMI1R_RTR                          ((uint32_t)0x00000002) /* Remote Transmission Request */
+#define CAN_RXMI1R_IDE                          ((uint32_t)0x00000004) /* Identifier Extension */
+#define CAN_RXMI1R_EXID                         ((uint32_t)0x001FFFF8) /* Extended identifier */
+#define CAN_RXMI1R_STID                         ((uint32_t)0xFFE00000) /* Standard Identifier or Extended Identifier */
+
+/*******************  Bit definition for CAN_RXMDT1R register  ******************/
+#define CAN_RXMDT1R_DLC                         ((uint32_t)0x0000000F) /* Data Length Code */
+#define CAN_RXMDT1R_FMI                         ((uint32_t)0x0000FF00) /* Filter Match Index */
+#define CAN_RXMDT1R_TIME                        ((uint32_t)0xFFFF0000) /* Message Time Stamp */
+
+/*******************  Bit definition for CAN_RXMDL1R register  ******************/
+#define CAN_RXMDL1R_DATA0                       ((uint32_t)0x000000FF) /* Data byte 0 */
+#define CAN_RXMDL1R_DATA1                       ((uint32_t)0x0000FF00) /* Data byte 1 */
+#define CAN_RXMDL1R_DATA2                       ((uint32_t)0x00FF0000) /* Data byte 2 */
+#define CAN_RXMDL1R_DATA3                       ((uint32_t)0xFF000000) /* Data byte 3 */
+
+/*******************  Bit definition for CAN_RXMDH1R register  ******************/
+#define CAN_RXMDH1R_DATA4                       ((uint32_t)0x000000FF) /* Data byte 4 */
+#define CAN_RXMDH1R_DATA5                       ((uint32_t)0x0000FF00) /* Data byte 5 */
+#define CAN_RXMDH1R_DATA6                       ((uint32_t)0x00FF0000) /* Data byte 6 */
+#define CAN_RXMDH1R_DATA7                       ((uint32_t)0xFF000000) /* Data byte 7 */
+
+/*******************  Bit definition for CAN_FCTLR register  ********************/
+#define CAN_FCTLR_FINIT                         ((uint8_t)0x01) /* Filter Init Mode */
+
+/*******************  Bit definition for CAN_FMCFGR register  *******************/
+#define CAN_FMCFGR_FBM                          ((uint16_t)0x3FFF) /* Filter Mode */
+#define CAN_FMCFGR_FBM0                         ((uint16_t)0x0001) /* Filter Init Mode bit 0 */
+#define CAN_FMCFGR_FBM1                         ((uint16_t)0x0002) /* Filter Init Mode bit 1 */
+#define CAN_FMCFGR_FBM2                         ((uint16_t)0x0004) /* Filter Init Mode bit 2 */
+#define CAN_FMCFGR_FBM3                         ((uint16_t)0x0008) /* Filter Init Mode bit 3 */
+#define CAN_FMCFGR_FBM4                         ((uint16_t)0x0010) /* Filter Init Mode bit 4 */
+#define CAN_FMCFGR_FBM5                         ((uint16_t)0x0020) /* Filter Init Mode bit 5 */
+#define CAN_FMCFGR_FBM6                         ((uint16_t)0x0040) /* Filter Init Mode bit 6 */
+#define CAN_FMCFGR_FBM7                         ((uint16_t)0x0080) /* Filter Init Mode bit 7 */
+#define CAN_FMCFGR_FBM8                         ((uint16_t)0x0100) /* Filter Init Mode bit 8 */
+#define CAN_FMCFGR_FBM9                         ((uint16_t)0x0200) /* Filter Init Mode bit 9 */
+#define CAN_FMCFGR_FBM10                        ((uint16_t)0x0400) /* Filter Init Mode bit 10 */
+#define CAN_FMCFGR_FBM11                        ((uint16_t)0x0800) /* Filter Init Mode bit 11 */
+#define CAN_FMCFGR_FBM12                        ((uint16_t)0x1000) /* Filter Init Mode bit 12 */
+#define CAN_FMCFGR_FBM13                        ((uint16_t)0x2000) /* Filter Init Mode bit 13 */
+
+/*******************  Bit definition for CAN_FSCFGR register  *******************/
+#define CAN_FSCFGR_FSC                          ((uint16_t)0x3FFF) /* Filter Scale Configuration */
+#define CAN_FSCFGR_FSC0                         ((uint16_t)0x0001) /* Filter Scale Configuration bit 0 */
+#define CAN_FSCFGR_FSC1                         ((uint16_t)0x0002) /* Filter Scale Configuration bit 1 */
+#define CAN_FSCFGR_FSC2                         ((uint16_t)0x0004) /* Filter Scale Configuration bit 2 */
+#define CAN_FSCFGR_FSC3                         ((uint16_t)0x0008) /* Filter Scale Configuration bit 3 */
+#define CAN_FSCFGR_FSC4                         ((uint16_t)0x0010) /* Filter Scale Configuration bit 4 */
+#define CAN_FSCFGR_FSC5                         ((uint16_t)0x0020) /* Filter Scale Configuration bit 5 */
+#define CAN_FSCFGR_FSC6                         ((uint16_t)0x0040) /* Filter Scale Configuration bit 6 */
+#define CAN_FSCFGR_FSC7                         ((uint16_t)0x0080) /* Filter Scale Configuration bit 7 */
+#define CAN_FSCFGR_FSC8                         ((uint16_t)0x0100) /* Filter Scale Configuration bit 8 */
+#define CAN_FSCFGR_FSC9                         ((uint16_t)0x0200) /* Filter Scale Configuration bit 9 */
+#define CAN_FSCFGR_FSC10                        ((uint16_t)0x0400) /* Filter Scale Configuration bit 10 */
+#define CAN_FSCFGR_FSC11                        ((uint16_t)0x0800) /* Filter Scale Configuration bit 11 */
+#define CAN_FSCFGR_FSC12                        ((uint16_t)0x1000) /* Filter Scale Configuration bit 12 */
+#define CAN_FSCFGR_FSC13                        ((uint16_t)0x2000) /* Filter Scale Configuration bit 13 */
+
+/******************  Bit definition for CAN_FAFIFOR register  *******************/
+#define CAN_FAFIFOR_FFA                         ((uint16_t)0x3FFF) /* Filter FIFO Assignment */
+#define CAN_FAFIFOR_FFA0                        ((uint16_t)0x0001) /* Filter FIFO Assignment for Filter 0 */
+#define CAN_FAFIFOR_FFA1                        ((uint16_t)0x0002) /* Filter FIFO Assignment for Filter 1 */
+#define CAN_FAFIFOR_FFA2                        ((uint16_t)0x0004) /* Filter FIFO Assignment for Filter 2 */
+#define CAN_FAFIFOR_FFA3                        ((uint16_t)0x0008) /* Filter FIFO Assignment for Filter 3 */
+#define CAN_FAFIFOR_FFA4                        ((uint16_t)0x0010) /* Filter FIFO Assignment for Filter 4 */
+#define CAN_FAFIFOR_FFA5                        ((uint16_t)0x0020) /* Filter FIFO Assignment for Filter 5 */
+#define CAN_FAFIFOR_FFA6                        ((uint16_t)0x0040) /* Filter FIFO Assignment for Filter 6 */
+#define CAN_FAFIFOR_FFA7                        ((uint16_t)0x0080) /* Filter FIFO Assignment for Filter 7 */
+#define CAN_FAFIFOR_FFA8                        ((uint16_t)0x0100) /* Filter FIFO Assignment for Filter 8 */
+#define CAN_FAFIFOR_FFA9                        ((uint16_t)0x0200) /* Filter FIFO Assignment for Filter 9 */
+#define CAN_FAFIFOR_FFA10                       ((uint16_t)0x0400) /* Filter FIFO Assignment for Filter 10 */
+#define CAN_FAFIFOR_FFA11                       ((uint16_t)0x0800) /* Filter FIFO Assignment for Filter 11 */
+#define CAN_FAFIFOR_FFA12                       ((uint16_t)0x1000) /* Filter FIFO Assignment for Filter 12 */
+#define CAN_FAFIFOR_FFA13                       ((uint16_t)0x2000) /* Filter FIFO Assignment for Filter 13 */
+
+/*******************  Bit definition for CAN_FWR register  *******************/
+#define CAN_FWR_FACT                            ((uint16_t)0x3FFF) /* Filter Active */
+#define CAN_FWR_FACT0                           ((uint16_t)0x0001) /* Filter 0 Active */
+#define CAN_FWR_FACT1                           ((uint16_t)0x0002) /* Filter 1 Active */
+#define CAN_FWR_FACT2                           ((uint16_t)0x0004) /* Filter 2 Active */
+#define CAN_FWR_FACT3                           ((uint16_t)0x0008) /* Filter 3 Active */
+#define CAN_FWR_FACT4                           ((uint16_t)0x0010) /* Filter 4 Active */
+#define CAN_FWR_FACT5                           ((uint16_t)0x0020) /* Filter 5 Active */
+#define CAN_FWR_FACT6                           ((uint16_t)0x0040) /* Filter 6 Active */
+#define CAN_FWR_FACT7                           ((uint16_t)0x0080) /* Filter 7 Active */
+#define CAN_FWR_FACT8                           ((uint16_t)0x0100) /* Filter 8 Active */
+#define CAN_FWR_FACT9                           ((uint16_t)0x0200) /* Filter 9 Active */
+#define CAN_FWR_FACT10                          ((uint16_t)0x0400) /* Filter 10 Active */
+#define CAN_FWR_FACT11                          ((uint16_t)0x0800) /* Filter 11 Active */
+#define CAN_FWR_FACT12                          ((uint16_t)0x1000) /* Filter 12 Active */
+#define CAN_FWR_FACT13                          ((uint16_t)0x2000) /* Filter 13 Active */
+
+/*******************  Bit definition for CAN_F0R1 register  *******************/
+#define CAN_F0R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F0R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F0R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F0R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F0R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F0R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F0R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F0R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F0R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F0R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F0R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F0R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F0R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F0R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F0R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F0R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F0R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F0R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F0R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F0R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F0R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F0R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F0R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F0R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F0R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F0R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F0R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F0R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F0R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F0R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F0R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F0R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R1 register  *******************/
+#define CAN_F1R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F1R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F1R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F1R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F1R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F1R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F1R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F1R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F1R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F1R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F1R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F1R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F1R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F1R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F1R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F1R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F1R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F1R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F1R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F1R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F1R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F1R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F1R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F1R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F1R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F1R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F1R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F1R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F1R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F1R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F1R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F1R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R1 register  *******************/
+#define CAN_F2R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F2R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F2R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F2R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F2R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F2R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F2R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F2R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F2R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F2R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F2R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F2R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F2R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F2R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F2R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F2R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F2R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F2R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F2R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F2R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F2R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F2R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F2R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F2R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F2R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F2R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F2R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F2R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F2R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F2R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F2R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F2R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R1 register  *******************/
+#define CAN_F3R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F3R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F3R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F3R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F3R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F3R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F3R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F3R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F3R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F3R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F3R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F3R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F3R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F3R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F3R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F3R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F3R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F3R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F3R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F3R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F3R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F3R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F3R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F3R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F3R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F3R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F3R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F3R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F3R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F3R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F3R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F3R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R1 register  *******************/
+#define CAN_F4R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F4R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F4R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F4R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F4R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F4R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F4R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F4R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F4R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F4R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F4R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F4R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F4R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F4R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F4R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F4R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F4R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F4R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F4R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F4R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F4R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F4R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F4R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F4R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F4R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F4R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F4R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F4R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F4R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F4R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F4R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F4R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R1 register  *******************/
+#define CAN_F5R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F5R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F5R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F5R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F5R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F5R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F5R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F5R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F5R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F5R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F5R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F5R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F5R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F5R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F5R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F5R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F5R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F5R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F5R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F5R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F5R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F5R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F5R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F5R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F5R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F5R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F5R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F5R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F5R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F5R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F5R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F5R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R1 register  *******************/
+#define CAN_F6R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F6R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F6R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F6R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F6R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F6R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F6R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F6R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F6R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F6R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F6R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F6R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F6R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F6R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F6R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F6R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F6R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F6R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F6R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F6R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F6R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F6R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F6R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F6R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F6R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F6R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F6R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F6R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F6R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F6R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F6R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F6R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R1 register  *******************/
+#define CAN_F7R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F7R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F7R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F7R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F7R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F7R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F7R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F7R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F7R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F7R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F7R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F7R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F7R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F7R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F7R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F7R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F7R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F7R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F7R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F7R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F7R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F7R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F7R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F7R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F7R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F7R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F7R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F7R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F7R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F7R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F7R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F7R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R1 register  *******************/
+#define CAN_F8R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F8R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F8R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F8R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F8R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F8R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F8R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F8R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F8R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F8R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F8R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F8R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F8R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F8R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F8R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F8R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F8R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F8R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F8R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F8R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F8R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F8R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F8R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F8R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F8R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F8R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F8R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F8R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F8R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F8R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F8R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F8R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R1 register  *******************/
+#define CAN_F9R1_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F9R1_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F9R1_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F9R1_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F9R1_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F9R1_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F9R1_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F9R1_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F9R1_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F9R1_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F9R1_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F9R1_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F9R1_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F9R1_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F9R1_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F9R1_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F9R1_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F9R1_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F9R1_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F9R1_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F9R1_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F9R1_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F9R1_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F9R1_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F9R1_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F9R1_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F9R1_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F9R1_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F9R1_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F9R1_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F9R1_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F9R1_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R1 register  ******************/
+#define CAN_F10R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F10R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F10R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F10R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F10R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F10R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F10R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F10R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F10R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F10R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F10R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F10R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F10R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F10R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F10R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F10R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F10R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F10R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F10R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F10R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F10R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F10R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F10R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F10R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F10R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F10R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F10R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F10R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F10R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F10R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F10R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F10R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R1 register  ******************/
+#define CAN_F11R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F11R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F11R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F11R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F11R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F11R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F11R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F11R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F11R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F11R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F11R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F11R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F11R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F11R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F11R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F11R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F11R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F11R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F11R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F11R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F11R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F11R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F11R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F11R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F11R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F11R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F11R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F11R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F11R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F11R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F11R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F11R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R1 register  ******************/
+#define CAN_F12R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F12R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F12R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F12R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F12R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F12R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F12R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F12R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F12R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F12R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F12R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F12R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F12R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F12R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F12R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F12R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F12R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F12R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F12R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F12R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F12R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F12R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F12R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F12R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F12R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F12R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F12R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F12R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F12R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F12R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F12R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F12R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R1 register  ******************/
+#define CAN_F13R1_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F13R1_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F13R1_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F13R1_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F13R1_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F13R1_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F13R1_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F13R1_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F13R1_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F13R1_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F13R1_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F13R1_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F13R1_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F13R1_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F13R1_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F13R1_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F13R1_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F13R1_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F13R1_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F13R1_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F13R1_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F13R1_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F13R1_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F13R1_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F13R1_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F13R1_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F13R1_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F13R1_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F13R1_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F13R1_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F13R1_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F13R1_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F0R2 register  *******************/
+#define CAN_F0R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F0R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F0R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F0R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F0R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F0R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F0R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F0R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F0R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F0R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F0R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F0R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F0R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F0R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F0R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F0R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F0R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F0R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F0R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F0R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F0R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F0R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F0R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F0R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F0R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F0R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F0R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F0R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F0R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F0R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F0R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F0R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F1R2 register  *******************/
+#define CAN_F1R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F1R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F1R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F1R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F1R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F1R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F1R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F1R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F1R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F1R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F1R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F1R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F1R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F1R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F1R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F1R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F1R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F1R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F1R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F1R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F1R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F1R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F1R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F1R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F1R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F1R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F1R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F1R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F1R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F1R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F1R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F1R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F2R2 register  *******************/
+#define CAN_F2R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F2R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F2R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F2R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F2R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F2R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F2R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F2R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F2R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F2R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F2R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F2R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F2R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F2R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F2R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F2R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F2R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F2R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F2R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F2R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F2R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F2R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F2R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F2R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F2R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F2R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F2R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F2R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F2R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F2R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F2R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F2R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F3R2 register  *******************/
+#define CAN_F3R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F3R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F3R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F3R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F3R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F3R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F3R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F3R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F3R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F3R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F3R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F3R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F3R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F3R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F3R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F3R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F3R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F3R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F3R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F3R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F3R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F3R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F3R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F3R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F3R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F3R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F3R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F3R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F3R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F3R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F3R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F3R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F4R2 register  *******************/
+#define CAN_F4R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F4R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F4R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F4R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F4R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F4R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F4R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F4R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F4R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F4R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F4R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F4R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F4R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F4R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F4R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F4R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F4R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F4R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F4R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F4R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F4R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F4R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F4R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F4R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F4R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F4R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F4R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F4R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F4R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F4R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F4R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F4R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F5R2 register  *******************/
+#define CAN_F5R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F5R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F5R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F5R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F5R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F5R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F5R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F5R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F5R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F5R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F5R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F5R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F5R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F5R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F5R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F5R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F5R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F5R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F5R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F5R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F5R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F5R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F5R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F5R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F5R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F5R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F5R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F5R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F5R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F5R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F5R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F5R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F6R2 register  *******************/
+#define CAN_F6R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F6R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F6R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F6R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F6R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F6R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F6R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F6R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F6R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F6R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F6R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F6R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F6R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F6R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F6R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F6R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F6R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F6R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F6R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F6R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F6R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F6R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F6R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F6R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F6R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F6R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F6R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F6R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F6R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F6R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F6R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F6R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F7R2 register  *******************/
+#define CAN_F7R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F7R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F7R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F7R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F7R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F7R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F7R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F7R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F7R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F7R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F7R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F7R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F7R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F7R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F7R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F7R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F7R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F7R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F7R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F7R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F7R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F7R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F7R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F7R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F7R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F7R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F7R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F7R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F7R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F7R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F7R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F7R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F8R2 register  *******************/
+#define CAN_F8R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F8R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F8R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F8R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F8R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F8R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F8R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F8R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F8R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F8R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F8R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F8R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F8R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F8R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F8R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F8R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F8R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F8R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F8R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F8R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F8R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F8R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F8R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F8R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F8R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F8R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F8R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F8R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F8R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F8R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F8R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F8R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F9R2 register  *******************/
+#define CAN_F9R2_FB0                            ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F9R2_FB1                            ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F9R2_FB2                            ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F9R2_FB3                            ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F9R2_FB4                            ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F9R2_FB5                            ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F9R2_FB6                            ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F9R2_FB7                            ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F9R2_FB8                            ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F9R2_FB9                            ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F9R2_FB10                           ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F9R2_FB11                           ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F9R2_FB12                           ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F9R2_FB13                           ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F9R2_FB14                           ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F9R2_FB15                           ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F9R2_FB16                           ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F9R2_FB17                           ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F9R2_FB18                           ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F9R2_FB19                           ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F9R2_FB20                           ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F9R2_FB21                           ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F9R2_FB22                           ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F9R2_FB23                           ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F9R2_FB24                           ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F9R2_FB25                           ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F9R2_FB26                           ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F9R2_FB27                           ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F9R2_FB28                           ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F9R2_FB29                           ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F9R2_FB30                           ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F9R2_FB31                           ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F10R2 register  ******************/
+#define CAN_F10R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F10R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F10R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F10R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F10R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F10R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F10R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F10R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F10R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F10R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F10R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F10R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F10R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F10R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F10R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F10R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F10R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F10R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F10R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F10R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F10R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F10R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F10R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F10R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F10R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F10R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F10R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F10R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F10R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F10R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F10R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F10R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F11R2 register  ******************/
+#define CAN_F11R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F11R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F11R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F11R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F11R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F11R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F11R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F11R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F11R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F11R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F11R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F11R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F11R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F11R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F11R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F11R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F11R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F11R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F11R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F11R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F11R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F11R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F11R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F11R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F11R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F11R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F11R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F11R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F11R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F11R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F11R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F11R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F12R2 register  ******************/
+#define CAN_F12R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F12R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F12R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F12R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F12R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F12R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F12R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F12R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F12R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F12R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F12R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F12R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F12R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F12R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F12R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F12R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F12R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F12R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F12R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F12R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F12R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F12R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F12R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F12R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F12R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F12R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F12R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F12R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F12R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F12R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F12R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F12R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/*******************  Bit definition for CAN_F13R2 register  ******************/
+#define CAN_F13R2_FB0                           ((uint32_t)0x00000001) /* Filter bit 0 */
+#define CAN_F13R2_FB1                           ((uint32_t)0x00000002) /* Filter bit 1 */
+#define CAN_F13R2_FB2                           ((uint32_t)0x00000004) /* Filter bit 2 */
+#define CAN_F13R2_FB3                           ((uint32_t)0x00000008) /* Filter bit 3 */
+#define CAN_F13R2_FB4                           ((uint32_t)0x00000010) /* Filter bit 4 */
+#define CAN_F13R2_FB5                           ((uint32_t)0x00000020) /* Filter bit 5 */
+#define CAN_F13R2_FB6                           ((uint32_t)0x00000040) /* Filter bit 6 */
+#define CAN_F13R2_FB7                           ((uint32_t)0x00000080) /* Filter bit 7 */
+#define CAN_F13R2_FB8                           ((uint32_t)0x00000100) /* Filter bit 8 */
+#define CAN_F13R2_FB9                           ((uint32_t)0x00000200) /* Filter bit 9 */
+#define CAN_F13R2_FB10                          ((uint32_t)0x00000400) /* Filter bit 10 */
+#define CAN_F13R2_FB11                          ((uint32_t)0x00000800) /* Filter bit 11 */
+#define CAN_F13R2_FB12                          ((uint32_t)0x00001000) /* Filter bit 12 */
+#define CAN_F13R2_FB13                          ((uint32_t)0x00002000) /* Filter bit 13 */
+#define CAN_F13R2_FB14                          ((uint32_t)0x00004000) /* Filter bit 14 */
+#define CAN_F13R2_FB15                          ((uint32_t)0x00008000) /* Filter bit 15 */
+#define CAN_F13R2_FB16                          ((uint32_t)0x00010000) /* Filter bit 16 */
+#define CAN_F13R2_FB17                          ((uint32_t)0x00020000) /* Filter bit 17 */
+#define CAN_F13R2_FB18                          ((uint32_t)0x00040000) /* Filter bit 18 */
+#define CAN_F13R2_FB19                          ((uint32_t)0x00080000) /* Filter bit 19 */
+#define CAN_F13R2_FB20                          ((uint32_t)0x00100000) /* Filter bit 20 */
+#define CAN_F13R2_FB21                          ((uint32_t)0x00200000) /* Filter bit 21 */
+#define CAN_F13R2_FB22                          ((uint32_t)0x00400000) /* Filter bit 22 */
+#define CAN_F13R2_FB23                          ((uint32_t)0x00800000) /* Filter bit 23 */
+#define CAN_F13R2_FB24                          ((uint32_t)0x01000000) /* Filter bit 24 */
+#define CAN_F13R2_FB25                          ((uint32_t)0x02000000) /* Filter bit 25 */
+#define CAN_F13R2_FB26                          ((uint32_t)0x04000000) /* Filter bit 26 */
+#define CAN_F13R2_FB27                          ((uint32_t)0x08000000) /* Filter bit 27 */
+#define CAN_F13R2_FB28                          ((uint32_t)0x10000000) /* Filter bit 28 */
+#define CAN_F13R2_FB29                          ((uint32_t)0x20000000) /* Filter bit 29 */
+#define CAN_F13R2_FB30                          ((uint32_t)0x40000000) /* Filter bit 30 */
+#define CAN_F13R2_FB31                          ((uint32_t)0x80000000) /* Filter bit 31 */
+
+/******************************************************************************/
+/*                          CRC Calculation Unit                              */
+/******************************************************************************/
+
+/*******************  Bit definition for CRC_DATAR register  *********************/
+#define CRC_DATAR_DR                            ((uint32_t)0xFFFFFFFF) /* Data register bits */
+
+/*******************  Bit definition for CRC_IDATAR register  ********************/
+#define CRC_IDR_IDATAR                          ((uint8_t)0xFF) /* General-purpose 8-bit data register bits */
+
+/********************  Bit definition for CRC_CTLR register  ********************/
+#define CRC_CTLR_RESET                          ((uint8_t)0x01) /* RESET bit */
+#endif
+
+#if defined(CH32V30x)
+/******************************************************************************/
+/*                      Digital to Analog Converter                           */
+/******************************************************************************/
+
+/********************  Bit definition for DAC_CTLR register  ********************/
+#define  DAC_EN1                          ((uint32_t)0x00000001)        /* DAC channel1 enable */
+#define  DAC_BOFF1                        ((uint32_t)0x00000002)        /* DAC channel1 output buffer disable */
+#define  DAC_TEN1                         ((uint32_t)0x00000004)        /* DAC channel1 Trigger enable */
+
+#define  DAC_TSEL1                        ((uint32_t)0x00000038)        /* TSEL1[2:0] (DAC channel1 Trigger selection) */
+#define  DAC_TSEL1_0                      ((uint32_t)0x00000008)        /* Bit 0 */
+#define  DAC_TSEL1_1                      ((uint32_t)0x00000010)        /* Bit 1 */
+#define  DAC_TSEL1_2                      ((uint32_t)0x00000020)        /* Bit 2 */
+
+#define  DAC_WAVE1                        ((uint32_t)0x000000C0)        /* WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define  DAC_WAVE1_0                      ((uint32_t)0x00000040)        /* Bit 0 */
+#define  DAC_WAVE1_1                      ((uint32_t)0x00000080)        /* Bit 1 */
+
+#define  DAC_MAMP1                        ((uint32_t)0x00000F00)        /* MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define  DAC_MAMP1_0                      ((uint32_t)0x00000100)        /* Bit 0 */
+#define  DAC_MAMP1_1                      ((uint32_t)0x00000200)        /* Bit 1 */
+#define  DAC_MAMP1_2                      ((uint32_t)0x00000400)        /* Bit 2 */
+#define  DAC_MAMP1_3                      ((uint32_t)0x00000800)        /* Bit 3 */
+
+#define  DAC_DMAEN1                       ((uint32_t)0x00001000)        /* DAC channel1 DMA enable */
+#define  DAC_EN2                          ((uint32_t)0x00010000)        /* DAC channel2 enable */
+#define  DAC_BOFF2                        ((uint32_t)0x00020000)        /* DAC channel2 output buffer disable */
+#define  DAC_TEN2                         ((uint32_t)0x00040000)        /* DAC channel2 Trigger enable */
+
+#define  DAC_TSEL2                        ((uint32_t)0x00380000)        /* TSEL2[2:0] (DAC channel2 Trigger selection) */
+#define  DAC_TSEL2_0                      ((uint32_t)0x00080000)        /* Bit 0 */
+#define  DAC_TSEL2_1                      ((uint32_t)0x00100000)        /* Bit 1 */
+#define  DAC_TSEL2_2                      ((uint32_t)0x00200000)        /* Bit 2 */
+
+#define  DAC_WAVE2                        ((uint32_t)0x00C00000)        /* WAVE2[1:0] (DAC channel2 noise/triangle wave generation enable) */
+#define  DAC_WAVE2_0                      ((uint32_t)0x00400000)        /* Bit 0 */
+#define  DAC_WAVE2_1                      ((uint32_t)0x00800000)        /* Bit 1 */
+
+#define  DAC_MAMP2                        ((uint32_t)0x0F000000)        /* MAMP2[3:0] (DAC channel2 Mask/Amplitude selector) */
+#define  DAC_MAMP2_0                      ((uint32_t)0x01000000)        /* Bit 0 */
+#define  DAC_MAMP2_1                      ((uint32_t)0x02000000)        /* Bit 1 */
+#define  DAC_MAMP2_2                      ((uint32_t)0x04000000)        /* Bit 2 */
+#define  DAC_MAMP2_3                      ((uint32_t)0x08000000)        /* Bit 3 */
+
+#define  DAC_DMAEN2                       ((uint32_t)0x10000000)        /* DAC channel2 DMA enabled */
+
+/*****************  Bit definition for DAC_SWTR register  ******************/
+#define  DAC_SWTRIG1                      ((uint8_t)0x01)               /* DAC channel1 software trigger */
+#define  DAC_SWTRIG2                      ((uint8_t)0x02)               /* DAC channel2 software trigger */
+
+/*****************  Bit definition for DAC_R12BDHR1 register  ******************/
+#define  DAC_DHR12R1                      ((uint16_t)0x0FFF)            /* DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_L12BDHR1 register  ******************/
+#define  DAC_DHR12L1                      ((uint16_t)0xFFF0)            /* DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_R8BDHR1 register  ******************/
+#define  DAC_DHR8R1                       ((uint8_t)0xFF)               /* DAC channel1 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_R12BDHR2 register  ******************/
+#define  DAC_DHR12R2                      ((uint16_t)0x0FFF)            /* DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_L12BDHR2 register  ******************/
+#define  DAC_DHR12L2                      ((uint16_t)0xFFF0)            /* DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_R8BDHR2 register  ******************/
+#define  DAC_DHR8R2                       ((uint8_t)0xFF)               /* DAC channel2 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_RD12BDHR register  ******************/
+#define  DAC_RD12BDHR_DACC1DHR            ((uint32_t)0x00000FFF)        /* DAC channel1 12-bit Right aligned data */
+#define  DAC_RD12BDHR_DACC2DHR            ((uint32_t)0x0FFF0000)        /* DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_LD12BDHR register  ******************/
+#define  DAC_LD12BDHR_DACC1DHR            ((uint32_t)0x0000FFF0)        /* DAC channel1 12-bit Left aligned data */
+#define  DAC_LD12BDHR_DACC2DHR            ((uint32_t)0xFFF00000)        /* DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_RD8BDHR register  ******************/
+#define  DAC_RD8BDHR_DACC1DHR             ((uint16_t)0x00FF)            /* DAC channel1 8-bit Right aligned data */
+#define  DAC_RD8BDHR_DACC2DHR             ((uint16_t)0xFF00)            /* DAC channel2 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define  DAC_DACC1DOR                     ((uint16_t)0x0FFF)            /* DAC channel1 data output */
+
+/*******************  Bit definition for DAC_DOR2 register  *******************/
+#define  DAC_DACC2DOR                     ((uint16_t)0x0FFF)            /* DAC channel2 data output */
+#endif
+
 /******************************************************************************/
 /*                             DMA Controller                                 */
 /******************************************************************************/
@@ -811,6 +4659,25 @@ typedef struct
 #define DMA_TCIF7                               ((uint32_t)0x02000000) /* Channel 7 Transfer Complete flag */
 #define DMA_HTIF7                               ((uint32_t)0x04000000) /* Channel 7 Half Transfer flag */
 #define DMA_TEIF7                               ((uint32_t)0x08000000) /* Channel 7 Transfer Error flag */
+
+#if defined(CH32V20x) || defined(CH32V30x)
+#define DMA_GIF8                                ((uint32_t)0x00000001) /* Channel 8 Global interrupt flag */
+#define DMA_TCIF8                               ((uint32_t)0x00000002) /* Channel 8 Transfer Complete flag */
+#define DMA_HTIF8                               ((uint32_t)0x00000004) /* Channel 8 Half Transfer flag */
+#define DMA_TEIF8                               ((uint32_t)0x00000008) /* Channel 8 Transfer Error flag */
+#define DMA_GIF9                                ((uint32_t)0x00000010) /* Channel 9 Global interrupt flag */
+#define DMA_TCIF9                               ((uint32_t)0x00000020) /* Channel 9 Transfer Complete flag */
+#define DMA_HTIF9                               ((uint32_t)0x00000040) /* Channel 9 Half Transfer flag */
+#define DMA_TEIF9                               ((uint32_t)0x00000080) /* Channel 9 Transfer Error flag */
+#define DMA_GIF10                               ((uint32_t)0x00000100) /* Channel 10 Global interrupt flag */
+#define DMA_TCIF10                              ((uint32_t)0x00000200) /* Channel 10 Transfer Complete flag */
+#define DMA_HTIF10                              ((uint32_t)0x00000400) /* Channel 10 Half Transfer flag */
+#define DMA_TEIF10                              ((uint32_t)0x00000800) /* Channel 10 Transfer Error flag */
+#define DMA_GIF11                               ((uint32_t)0x00001000) /* Channel 11 Global interrupt flag */
+#define DMA_TCIF11                              ((uint32_t)0x00002000) /* Channel 11 Transfer Complete flag */
+#define DMA_HTIF11                              ((uint32_t)0x00004000) /* Channel 11 Half Transfer flag */
+#define DMA_TEIF11                              ((uint32_t)0x00008000) /* Channel 11 Transfer Error flag */
+#endif
 
 /*******************  Bit definition for DMA_INTFCR register  *******************/
 #define DMA_CGIF1                               ((uint32_t)0x00000001) /* Channel 1 Global interrupt clear */
@@ -1088,6 +4955,18 @@ typedef struct
 #define EXTI_INTENR_MR7                         ((uint32_t)0x00000080) /* Interrupt Mask on line 7 */
 #define EXTI_INTENR_MR8                         ((uint32_t)0x00000100) /* Interrupt Mask on line 8 */
 #define EXTI_INTENR_MR9                         ((uint32_t)0x00000200) /* Interrupt Mask on line 9 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_INTENR_MR10                        ((uint32_t)0x00000400) /* Interrupt Mask on line 10 */
+#define EXTI_INTENR_MR11                        ((uint32_t)0x00000800) /* Interrupt Mask on line 11 */
+#define EXTI_INTENR_MR12                        ((uint32_t)0x00001000) /* Interrupt Mask on line 12 */
+#define EXTI_INTENR_MR13                        ((uint32_t)0x00002000) /* Interrupt Mask on line 13 */
+#define EXTI_INTENR_MR14                        ((uint32_t)0x00004000) /* Interrupt Mask on line 14 */
+#define EXTI_INTENR_MR15                        ((uint32_t)0x00008000) /* Interrupt Mask on line 15 */
+#define EXTI_INTENR_MR16                        ((uint32_t)0x00010000) /* Interrupt Mask on line 16 */
+#define EXTI_INTENR_MR17                        ((uint32_t)0x00020000) /* Interrupt Mask on line 17 */
+#define EXTI_INTENR_MR18                        ((uint32_t)0x00040000) /* Interrupt Mask on line 18 */
+#define EXTI_INTENR_MR19                        ((uint32_t)0x00080000) /* Interrupt Mask on line 19 */
+#endif
 
 /*******************  Bit definition for EXTI_EVENR register  *******************/
 #define EXTI_EVENR_MR0                          ((uint32_t)0x00000001) /* Event Mask on line 0 */
@@ -1100,6 +4979,18 @@ typedef struct
 #define EXTI_EVENR_MR7                          ((uint32_t)0x00000080) /* Event Mask on line 7 */
 #define EXTI_EVENR_MR8                          ((uint32_t)0x00000100) /* Event Mask on line 8 */
 #define EXTI_EVENR_MR9                          ((uint32_t)0x00000200) /* Event Mask on line 9 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_EVENR_MR10                         ((uint32_t)0x00000400) /* Event Mask on line 10 */
+#define EXTI_EVENR_MR11                         ((uint32_t)0x00000800) /* Event Mask on line 11 */
+#define EXTI_EVENR_MR12                         ((uint32_t)0x00001000) /* Event Mask on line 12 */
+#define EXTI_EVENR_MR13                         ((uint32_t)0x00002000) /* Event Mask on line 13 */
+#define EXTI_EVENR_MR14                         ((uint32_t)0x00004000) /* Event Mask on line 14 */
+#define EXTI_EVENR_MR15                         ((uint32_t)0x00008000) /* Event Mask on line 15 */
+#define EXTI_EVENR_MR16                         ((uint32_t)0x00010000) /* Event Mask on line 16 */
+#define EXTI_EVENR_MR17                         ((uint32_t)0x00020000) /* Event Mask on line 17 */
+#define EXTI_EVENR_MR18                         ((uint32_t)0x00040000) /* Event Mask on line 18 */
+#define EXTI_EVENR_MR19                         ((uint32_t)0x00080000) /* Event Mask on line 19 */
+#endif
 
 /******************  Bit definition for EXTI_RTENR register  *******************/
 #define EXTI_RTENR_TR0                          ((uint32_t)0x00000001) /* Rising trigger event configuration bit of line 0 */
@@ -1112,6 +5003,18 @@ typedef struct
 #define EXTI_RTENR_TR7                          ((uint32_t)0x00000080) /* Rising trigger event configuration bit of line 7 */
 #define EXTI_RTENR_TR8                          ((uint32_t)0x00000100) /* Rising trigger event configuration bit of line 8 */
 #define EXTI_RTENR_TR9                          ((uint32_t)0x00000200) /* Rising trigger event configuration bit of line 9 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_RTENR_TR10                         ((uint32_t)0x00000400) /* Rising trigger event configuration bit of line 10 */
+#define EXTI_RTENR_TR11                         ((uint32_t)0x00000800) /* Rising trigger event configuration bit of line 11 */
+#define EXTI_RTENR_TR12                         ((uint32_t)0x00001000) /* Rising trigger event configuration bit of line 12 */
+#define EXTI_RTENR_TR13                         ((uint32_t)0x00002000) /* Rising trigger event configuration bit of line 13 */
+#define EXTI_RTENR_TR14                         ((uint32_t)0x00004000) /* Rising trigger event configuration bit of line 14 */
+#define EXTI_RTENR_TR15                         ((uint32_t)0x00008000) /* Rising trigger event configuration bit of line 15 */
+#define EXTI_RTENR_TR16                         ((uint32_t)0x00010000) /* Rising trigger event configuration bit of line 16 */
+#define EXTI_RTENR_TR17                         ((uint32_t)0x00020000) /* Rising trigger event configuration bit of line 17 */
+#define EXTI_RTENR_TR18                         ((uint32_t)0x00040000) /* Rising trigger event configuration bit of line 18 */
+#define EXTI_RTENR_TR19                         ((uint32_t)0x00080000) /* Rising trigger event configuration bit of line 19 */
+#endif
 
 /******************  Bit definition for EXTI_FTENR register  *******************/
 #define EXTI_FTENR_TR0                          ((uint32_t)0x00000001) /* Falling trigger event configuration bit of line 0 */
@@ -1124,6 +5027,18 @@ typedef struct
 #define EXTI_FTENR_TR7                          ((uint32_t)0x00000080) /* Falling trigger event configuration bit of line 7 */
 #define EXTI_FTENR_TR8                          ((uint32_t)0x00000100) /* Falling trigger event configuration bit of line 8 */
 #define EXTI_FTENR_TR9                          ((uint32_t)0x00000200) /* Falling trigger event configuration bit of line 9 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_FTENR_TR10                         ((uint32_t)0x00000400) /* Falling trigger event configuration bit of line 10 */
+#define EXTI_FTENR_TR11                         ((uint32_t)0x00000800) /* Falling trigger event configuration bit of line 11 */
+#define EXTI_FTENR_TR12                         ((uint32_t)0x00001000) /* Falling trigger event configuration bit of line 12 */
+#define EXTI_FTENR_TR13                         ((uint32_t)0x00002000) /* Falling trigger event configuration bit of line 13 */
+#define EXTI_FTENR_TR14                         ((uint32_t)0x00004000) /* Falling trigger event configuration bit of line 14 */
+#define EXTI_FTENR_TR15                         ((uint32_t)0x00008000) /* Falling trigger event configuration bit of line 15 */
+#define EXTI_FTENR_TR16                         ((uint32_t)0x00010000) /* Falling trigger event configuration bit of line 16 */
+#define EXTI_FTENR_TR17                         ((uint32_t)0x00020000) /* Falling trigger event configuration bit of line 17 */
+#define EXTI_FTENR_TR18                         ((uint32_t)0x00040000) /* Falling trigger event configuration bit of line 18 */
+#define EXTI_FTENR_TR19                         ((uint32_t)0x00080000) /* Falling trigger event configuration bit of line 19 */
+#endif
 
 /******************  Bit definition for EXTI_SWIEVR register  ******************/
 #define EXTI_SWIEVR_SWIEVR0                     ((uint32_t)0x00000001) /* Software Interrupt on line 0 */
@@ -1136,6 +5051,18 @@ typedef struct
 #define EXTI_SWIEVR_SWIEVR7                     ((uint32_t)0x00000080) /* Software Interrupt on line 7 */
 #define EXTI_SWIEVR_SWIEVR8                     ((uint32_t)0x00000100) /* Software Interrupt on line 8 */
 #define EXTI_SWIEVR_SWIEVR9                     ((uint32_t)0x00000200) /* Software Interrupt on line 9 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_SWIEVR_SWIEVR10                    ((uint32_t)0x00000400) /* Software Interrupt on line 10 */
+#define EXTI_SWIEVR_SWIEVR11                    ((uint32_t)0x00000800) /* Software Interrupt on line 11 */
+#define EXTI_SWIEVR_SWIEVR12                    ((uint32_t)0x00001000) /* Software Interrupt on line 12 */
+#define EXTI_SWIEVR_SWIEVR13                    ((uint32_t)0x00002000) /* Software Interrupt on line 13 */
+#define EXTI_SWIEVR_SWIEVR14                    ((uint32_t)0x00004000) /* Software Interrupt on line 14 */
+#define EXTI_SWIEVR_SWIEVR15                    ((uint32_t)0x00008000) /* Software Interrupt on line 15 */
+#define EXTI_SWIEVR_SWIEVR16                    ((uint32_t)0x00010000) /* Software Interrupt on line 16 */
+#define EXTI_SWIEVR_SWIEVR17                    ((uint32_t)0x00020000) /* Software Interrupt on line 17 */
+#define EXTI_SWIEVR_SWIEVR18                    ((uint32_t)0x00040000) /* Software Interrupt on line 18 */
+#define EXTI_SWIEVR_SWIEVR19                    ((uint32_t)0x00080000) /* Software Interrupt on line 19 */
+#endif
 
 /*******************  Bit definition for EXTI_INTFR register  ********************/
 #define EXTI_INTF_INTF0                         ((uint32_t)0x00000001) /* Pending bit for line 0 */
@@ -1148,16 +5075,36 @@ typedef struct
 #define EXTI_INTF_INTF7                         ((uint32_t)0x00000080) /* Pending bit for line 7 */
 #define EXTI_INTF_INTF8                         ((uint32_t)0x00000100) /* Pending bit for line 8 */
 #define EXTI_INTF_INTF9                         ((uint32_t)0x00000200) /* Pending bit for line 9 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_INTF_INTF10                        ((uint32_t)0x00000400) /* Pending bit for line 10 */
+#define EXTI_INTF_INTF11                        ((uint32_t)0x00000800) /* Pending bit for line 11 */
+#define EXTI_INTF_INTF12                        ((uint32_t)0x00001000) /* Pending bit for line 12 */
+#define EXTI_INTF_INTF13                        ((uint32_t)0x00002000) /* Pending bit for line 13 */
+#define EXTI_INTF_INTF14                        ((uint32_t)0x00004000) /* Pending bit for line 14 */
+#define EXTI_INTF_INTF15                        ((uint32_t)0x00008000) /* Pending bit for line 15 */
+#define EXTI_INTF_INTF16                        ((uint32_t)0x00010000) /* Pending bit for line 16 */
+#define EXTI_INTF_INTF17                        ((uint32_t)0x00020000) /* Pending bit for line 17 */
+#define EXTI_INTF_INTF18                        ((uint32_t)0x00040000) /* Pending bit for line 18 */
+#define EXTI_INTF_INTF19                        ((uint32_t)0x00080000) /* Pending bit for line 19 */
+#endif
 
 /******************************************************************************/
 /*                      FLASH and Option Bytes Registers                      */
 /******************************************************************************/
 
+#if defined(CH32V003) || defined(CH32V10x) || defined(CH32X03x)
 /*******************  Bit definition for FLASH_ACTLR register  ******************/
 #define FLASH_ACTLR_LATENCY                     ((uint8_t)0x03) /* LATENCY[2:0] bits (Latency) */
 #define FLASH_ACTLR_LATENCY_0                   ((uint8_t)0x00) /* Bit 0 */
 #define FLASH_ACTLR_LATENCY_1                   ((uint8_t)0x01) /* Bit 0 */
 #define FLASH_ACTLR_LATENCY_2                   ((uint8_t)0x02) /* Bit 1 */
+#endif
+
+#if defined(CH32V10x)
+#define FLASH_ACTLR_HLFCYA                      ((uint8_t)0x08) /* Flash Half Cycle Access Enable */
+#define FLASH_ACTLR_PRFTBE                      ((uint8_t)0x10) /* Prefetch Buffer Enable */
+#define FLASH_ACTLR_PRFTBS                      ((uint8_t)0x20) /* Prefetch Buffer Status */
+#endif
 
 /******************  Bit definition for FLASH_KEYR register  ******************/
 #define FLASH_KEYR_FKEYR                        ((uint32_t)0xFFFFFFFF) /* FPEC Key */
@@ -1167,24 +5114,36 @@ typedef struct
 
 /******************  Bit definition for FLASH_STATR register  *******************/
 #define FLASH_STATR_BSY                         ((uint8_t)0x01) /* Busy */
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define FLASH_STATR_PGERR                       ((uint8_t)0x04) /* Programming Error */
+#endif
 #define FLASH_STATR_WRPRTERR                    ((uint8_t)0x10) /* Write Protection Error */
 #define FLASH_STATR_EOP                         ((uint8_t)0x20) /* End of operation */
 
 /*******************  Bit definition for FLASH_CTLR register  *******************/
-#define FLASH_CTLR_PG                           ((uint16_t)0x0001)     /* Programming */
-#define FLASH_CTLR_PER                          ((uint16_t)0x0002)     /* Page Erase 1KByte*/
-#define FLASH_CTLR_MER                          ((uint16_t)0x0004)     /* Mass Erase */
-#define FLASH_CTLR_OPTPG                        ((uint16_t)0x0010)     /* Option Byte Programming */
-#define FLASH_CTLR_OPTER                        ((uint16_t)0x0020)     /* Option Byte Erase */
-#define FLASH_CTLR_STRT                         ((uint16_t)0x0040)     /* Start */
-#define FLASH_CTLR_LOCK                         ((uint16_t)0x0080)     /* Lock */
-#define FLASH_CTLR_OPTWRE                       ((uint16_t)0x0200)     /* Option Bytes Write Enable */
-#define FLASH_CTLR_ERRIE                        ((uint16_t)0x0400)     /* Error Interrupt Enable */
-#define FLASH_CTLR_EOPIE                        ((uint16_t)0x1000)     /* End of operation interrupt enable */
-#define FLASH_CTLR_PAGE_PG                      ((uint16_t)0x00010000) /* Page Programming 64Byte */
-#define FLASH_CTLR_PAGE_ER                      ((uint16_t)0x00020000) /* Page Erase 64Byte */
-#define FLASH_CTLR_BUF_LOAD                     ((uint16_t)0x00040000) /* Buffer Load */
-#define FLASH_CTLR_BUF_RST                      ((uint16_t)0x00080000) /* Buffer Reset */
+#define FLASH_CTLR_PG                           (0x0001)     /* Programming */
+#define FLASH_CTLR_PER                          (0x0002)     /* Page Erase 1KByte*/
+#define FLASH_CTLR_MER                          (0x0004)     /* Mass Erase */
+#define FLASH_CTLR_OPTPG                        (0x0010)     /* Option Byte Programming */
+#define FLASH_CTLR_OPTER                        (0x0020)     /* Option Byte Erase */
+#define FLASH_CTLR_STRT                         (0x0040)     /* Start */
+#define FLASH_CTLR_LOCK                         (0x0080)     /* Lock */
+#define FLASH_CTLR_OPTWRE                       (0x0200)     /* Option Bytes Write Enable */
+#define FLASH_CTLR_ERRIE                        (0x0400)     /* Error Interrupt Enable */
+#define FLASH_CTLR_EOPIE                        (0x1000)     /* End of operation interrupt enable */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define FLASH_CTLR_FAST_LOCK                    (0x00008000) /* Fast Lock */
+#endif
+#define FLASH_CTLR_PAGE_PG                      (0x00010000) /* Page Programming 64Byte */
+#define FLASH_CTLR_PAGE_ER                      (0x00020000) /* Page Erase 64Byte */
+#ifdef CH32V003
+#define FLASH_CTLR_BUF_LOAD                     (0x00040000) /* Buffer Load */
+#define FLASH_CTLR_BUF_RST                      (0x00080000) /* Buffer Reset */
+#elif defined(CH32V20x) || defined(CH32V30x)
+#define FLASH_CTLR_PAGE_BER32                   (0x00040000) /* Block Erase 32K */
+#define FLASH_CTLR_PAGE_BER64                   (0x00080000) /* Block Erase 64K */
+#define FLASH_CTLR_PG_STRT                      (0x00200000) /* Page Programming Start */
+#endif
 
 /*******************  Bit definition for FLASH_ADDR register  *******************/
 #define FLASH_ADDR_FAR                          ((uint32_t)0xFFFFFFFF) /* Flash Address */
@@ -1226,6 +5185,15 @@ typedef struct
 #define FLASH_WRPR1_WRPR1                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
 #define FLASH_WRPR1_nWRPR1                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
 
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/******************  Bit definition for FLASH_WRPR2 register  ******************/
+#define FLASH_WRPR2_WRPR2                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR2_nWRPR2                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR3 register  ******************/
+#define FLASH_WRPR3_WRPR3                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR3_nWRPR3                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+#endif
 
 /******************************************************************************/
 /*                General Purpose and Alternate Function I/O                  */
@@ -1477,6 +5445,45 @@ typedef struct
 #define GPIO_LCK15                              ((uint32_t)0x00008000) /* Port x Lock bit 15 */
 #define GPIO_LCKK                               ((uint32_t)0x00010000) /* Lock key */
 
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/******************  Bit definition for AFIO_ECR register  *******************/
+#define AFIO_ECR_PIN                            ((uint8_t)0x0F) /* PIN[3:0] bits (Pin selection) */
+#define AFIO_ECR_PIN_0                          ((uint8_t)0x01) /* Bit 0 */
+#define AFIO_ECR_PIN_1                          ((uint8_t)0x02) /* Bit 1 */
+#define AFIO_ECR_PIN_2                          ((uint8_t)0x04) /* Bit 2 */
+#define AFIO_ECR_PIN_3                          ((uint8_t)0x08) /* Bit 3 */
+
+#define AFIO_ECR_PIN_PX0                        ((uint8_t)0x00) /* Pin 0 selected */
+#define AFIO_ECR_PIN_PX1                        ((uint8_t)0x01) /* Pin 1 selected */
+#define AFIO_ECR_PIN_PX2                        ((uint8_t)0x02) /* Pin 2 selected */
+#define AFIO_ECR_PIN_PX3                        ((uint8_t)0x03) /* Pin 3 selected */
+#define AFIO_ECR_PIN_PX4                        ((uint8_t)0x04) /* Pin 4 selected */
+#define AFIO_ECR_PIN_PX5                        ((uint8_t)0x05) /* Pin 5 selected */
+#define AFIO_ECR_PIN_PX6                        ((uint8_t)0x06) /* Pin 6 selected */
+#define AFIO_ECR_PIN_PX7                        ((uint8_t)0x07) /* Pin 7 selected */
+#define AFIO_ECR_PIN_PX8                        ((uint8_t)0x08) /* Pin 8 selected */
+#define AFIO_ECR_PIN_PX9                        ((uint8_t)0x09) /* Pin 9 selected */
+#define AFIO_ECR_PIN_PX10                       ((uint8_t)0x0A) /* Pin 10 selected */
+#define AFIO_ECR_PIN_PX11                       ((uint8_t)0x0B) /* Pin 11 selected */
+#define AFIO_ECR_PIN_PX12                       ((uint8_t)0x0C) /* Pin 12 selected */
+#define AFIO_ECR_PIN_PX13                       ((uint8_t)0x0D) /* Pin 13 selected */
+#define AFIO_ECR_PIN_PX14                       ((uint8_t)0x0E) /* Pin 14 selected */
+#define AFIO_ECR_PIN_PX15                       ((uint8_t)0x0F) /* Pin 15 selected */
+
+#define AFIO_ECR_PORT                           ((uint8_t)0x70) /* PORT[2:0] bits (Port selection) */
+#define AFIO_ECR_PORT_0                         ((uint8_t)0x10) /* Bit 0 */
+#define AFIO_ECR_PORT_1                         ((uint8_t)0x20) /* Bit 1 */
+#define AFIO_ECR_PORT_2                         ((uint8_t)0x40) /* Bit 2 */
+
+#define AFIO_ECR_PORT_PA                        ((uint8_t)0x00) /* Port A selected */
+#define AFIO_ECR_PORT_PB                        ((uint8_t)0x10) /* Port B selected */
+#define AFIO_ECR_PORT_PC                        ((uint8_t)0x20) /* Port C selected */
+#define AFIO_ECR_PORT_PD                        ((uint8_t)0x30) /* Port D selected */
+#define AFIO_ECR_PORT_PE                        ((uint8_t)0x40) /* Port E selected */
+
+#define AFIO_ECR_EVOE                           ((uint8_t)0x80) /* Event Output Enable */
+#endif
+
 /******************  Bit definition for AFIO_PCFR1register  *******************/
 #define AFIO_PCFR1_SPI1_REMAP                   ((uint32_t)0x00000001) /* SPI1 remapping */
 #define AFIO_PCFR1_I2C1_REMAP                   ((uint32_t)0x00000002) /* I2C1 remapping */
@@ -1526,7 +5533,11 @@ typedef struct
 #define AFIO_PCFR1_CAN_REMAP_REMAP2             ((uint32_t)0x00004000) /* CANRX mapped to PB8, CANTX mapped to PB9 */
 #define AFIO_PCFR1_CAN_REMAP_REMAP3             ((uint32_t)0x00006000) /* CANRX mapped to PD0, CANTX mapped to PD1 */
 
+#ifdef CH32V003
 #define AFIO_PCFR1_PA12_REMAP                   ((uint32_t)0x00008000) /* Port D0/Port D1 mapping on OSC_IN/OSC_OUT */
+#elif defined(CH32V20x) || defined(CH32V30x)
+#define AFIO_PCFR1_PD01_REMAP                   ((uint32_t)0x00008000) /* Port D0/Port D1 mapping on OSC_IN/OSC_OUT */
+#endif
 #define AFIO_PCFR1_TIM5CH4_IREMAP               ((uint32_t)0x00010000) /* TIM5 Channel4 Internal Remap */
 #define AFIO_PCFR1_ADC1_ETRGINJ_REMAP           ((uint32_t)0x00020000) /* ADC 1 External Trigger Injected Conversion remapping */
 #define AFIO_PCFR1_ADC1_ETRGREG_REMAP           ((uint32_t)0x00040000) /* ADC 1 External Trigger Regular Conversion remapping */
@@ -1543,6 +5554,39 @@ typedef struct
 #define AFIO_PCFR1_SWJ_CFG_JTAGDISABLE          ((uint32_t)0x02000000) /* JTAG-DP Disabled and SW-DP Enabled */
 #define AFIO_PCFR1_SWJ_CFG_DISABLE              ((uint32_t)0x04000000) /* JTAG-DP Disabled and SW-DP Disabled */
 
+
+#if defined(CH32V003)
+/*****************  Bit definition for AFIO_EXTICR register  *****************/
+#define AFIO_EXTICR_EXTI0                       ((uint16_t)0x0003) /* EXTI 0 configuration */
+#define AFIO_EXTICR_EXTI1                       ((uint16_t)0x000C) /* EXTI 1 configuration */
+#define AFIO_EXTICR_EXTI2                       ((uint16_t)0x0030) /* EXTI 2 configuration */
+#define AFIO_EXTICR_EXTI3                       ((uint16_t)0x00C0) /* EXTI 3 configuration */
+#define AFIO_EXTICR_EXTI4                       ((uint16_t)0x0300) /* EXTI 4 configuration */
+#define AFIO_EXTICR_EXTI5                       ((uint16_t)0x0C00) /* EXTI 5 configuration */
+#define AFIO_EXTICR_EXTI6                       ((uint16_t)0x3000) /* EXTI 6 configuration */
+#define AFIO_EXTICR_EXTI7                       ((uint16_t)0xC000) /* EXTI 7 configuration */
+
+#define AFIO_EXTICR_EXTI0_PC                    ((uint16_t)0x0002) /* PC[0] pin */
+#define AFIO_EXTICR_EXTI0_PD                    ((uint16_t)0x0003) /* PD[0] pin */
+#define AFIO_EXTICR_EXTI1_PA                    ((uint16_t)0x0000) /* PA[1] pin */
+#define AFIO_EXTICR_EXTI1_PC                    ((uint16_t)0x0008) /* PC[1] pin */
+#define AFIO_EXTICR_EXTI1_PD                    ((uint16_t)0x000C) /* PD[1] pin */
+#define AFIO_EXTICR_EXTI2_PA                    ((uint16_t)0x0000) /* PA[2] pin */
+#define AFIO_EXTICR_EXTI2_PC                    ((uint16_t)0x0020) /* PC[2] pin */
+#define AFIO_EXTICR_EXTI2_PD                    ((uint16_t)0x0030) /* PD[2] pin */
+#define AFIO_EXTICR_EXTI3_PC                    ((uint16_t)0x0080) /* PC[3] pin */
+#define AFIO_EXTICR_EXTI3_PD                    ((uint16_t)0x00C0) /* PD[3] pin */
+#define AFIO_EXTICR_EXTI4_PC                    ((uint16_t)0x0200) /* PC[4] pin */
+#define AFIO_EXTICR_EXTI4_PD                    ((uint16_t)0x0300) /* PD[4] pin */
+#define AFIO_EXTICR_EXTI5_PC                    ((uint16_t)0x0800) /* PC[5] pin */
+#define AFIO_EXTICR_EXTI5_PD                    ((uint16_t)0x0C00) /* PD[5] pin */
+#define AFIO_EXTICR_EXTI6_PC                    ((uint16_t)0x2000) /* PC[6] pin */
+#define AFIO_EXTICR_EXTI6_PD                    ((uint16_t)0x3000) /* PD[6] pin */
+#define AFIO_EXTICR_EXTI7_PC                    ((uint16_t)0x8000) /* PC[7] pin */
+#define AFIO_EXTICR_EXTI7_PD                    ((uint16_t)0xC000) /* PD[7] pin */
+#endif
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 /*****************  Bit definition for AFIO_EXTICR1 register  *****************/
 #define AFIO_EXTICR1_EXTI0                      ((uint16_t)0x000F) /* EXTI 0 configuration */
 #define AFIO_EXTICR1_EXTI1                      ((uint16_t)0x00F0) /* EXTI 1 configuration */
@@ -1580,6 +5624,121 @@ typedef struct
 #define AFIO_EXTICR1_EXTI3_PE                   ((uint16_t)0x4000) /* PE[3] pin */
 #define AFIO_EXTICR1_EXTI3_PF                   ((uint16_t)0x5000) /* PF[3] pin */
 #define AFIO_EXTICR1_EXTI3_PG                   ((uint16_t)0x6000) /* PG[3] pin */
+
+/*****************  Bit definition for AFIO_EXTICR2 register  *****************/
+#define AFIO_EXTICR2_EXTI4                      ((uint16_t)0x000F) /* EXTI 4 configuration */
+#define AFIO_EXTICR2_EXTI5                      ((uint16_t)0x00F0) /* EXTI 5 configuration */
+#define AFIO_EXTICR2_EXTI6                      ((uint16_t)0x0F00) /* EXTI 6 configuration */
+#define AFIO_EXTICR2_EXTI7                      ((uint16_t)0xF000) /* EXTI 7 configuration */
+
+#define AFIO_EXTICR2_EXTI4_PA                   ((uint16_t)0x0000) /* PA[4] pin */
+#define AFIO_EXTICR2_EXTI4_PB                   ((uint16_t)0x0001) /* PB[4] pin */
+#define AFIO_EXTICR2_EXTI4_PC                   ((uint16_t)0x0002) /* PC[4] pin */
+#define AFIO_EXTICR2_EXTI4_PD                   ((uint16_t)0x0003) /* PD[4] pin */
+#define AFIO_EXTICR2_EXTI4_PE                   ((uint16_t)0x0004) /* PE[4] pin */
+#define AFIO_EXTICR2_EXTI4_PF                   ((uint16_t)0x0005) /* PF[4] pin */
+#define AFIO_EXTICR2_EXTI4_PG                   ((uint16_t)0x0006) /* PG[4] pin */
+
+#define AFIO_EXTICR2_EXTI5_PA                   ((uint16_t)0x0000) /* PA[5] pin */
+#define AFIO_EXTICR2_EXTI5_PB                   ((uint16_t)0x0010) /* PB[5] pin */
+#define AFIO_EXTICR2_EXTI5_PC                   ((uint16_t)0x0020) /* PC[5] pin */
+#define AFIO_EXTICR2_EXTI5_PD                   ((uint16_t)0x0030) /* PD[5] pin */
+#define AFIO_EXTICR2_EXTI5_PE                   ((uint16_t)0x0040) /* PE[5] pin */
+#define AFIO_EXTICR2_EXTI5_PF                   ((uint16_t)0x0050) /* PF[5] pin */
+#define AFIO_EXTICR2_EXTI5_PG                   ((uint16_t)0x0060) /* PG[5] pin */
+
+#define AFIO_EXTICR2_EXTI6_PA                   ((uint16_t)0x0000) /* PA[6] pin */
+#define AFIO_EXTICR2_EXTI6_PB                   ((uint16_t)0x0100) /* PB[6] pin */
+#define AFIO_EXTICR2_EXTI6_PC                   ((uint16_t)0x0200) /* PC[6] pin */
+#define AFIO_EXTICR2_EXTI6_PD                   ((uint16_t)0x0300) /* PD[6] pin */
+#define AFIO_EXTICR2_EXTI6_PE                   ((uint16_t)0x0400) /* PE[6] pin */
+#define AFIO_EXTICR2_EXTI6_PF                   ((uint16_t)0x0500) /* PF[6] pin */
+#define AFIO_EXTICR2_EXTI6_PG                   ((uint16_t)0x0600) /* PG[6] pin */
+
+#define AFIO_EXTICR2_EXTI7_PA                   ((uint16_t)0x0000) /* PA[7] pin */
+#define AFIO_EXTICR2_EXTI7_PB                   ((uint16_t)0x1000) /* PB[7] pin */
+#define AFIO_EXTICR2_EXTI7_PC                   ((uint16_t)0x2000) /* PC[7] pin */
+#define AFIO_EXTICR2_EXTI7_PD                   ((uint16_t)0x3000) /* PD[7] pin */
+#define AFIO_EXTICR2_EXTI7_PE                   ((uint16_t)0x4000) /* PE[7] pin */
+#define AFIO_EXTICR2_EXTI7_PF                   ((uint16_t)0x5000) /* PF[7] pin */
+#define AFIO_EXTICR2_EXTI7_PG                   ((uint16_t)0x6000) /* PG[7] pin */
+
+/*****************  Bit definition for AFIO_EXTICR3 register  *****************/
+#define AFIO_EXTICR3_EXTI8                      ((uint16_t)0x000F) /* EXTI 8 configuration */
+#define AFIO_EXTICR3_EXTI9                      ((uint16_t)0x00F0) /* EXTI 9 configuration */
+#define AFIO_EXTICR3_EXTI10                     ((uint16_t)0x0F00) /* EXTI 10 configuration */
+#define AFIO_EXTICR3_EXTI11                     ((uint16_t)0xF000) /* EXTI 11 configuration */
+
+#define AFIO_EXTICR3_EXTI8_PA                   ((uint16_t)0x0000) /* PA[8] pin */
+#define AFIO_EXTICR3_EXTI8_PB                   ((uint16_t)0x0001) /* PB[8] pin */
+#define AFIO_EXTICR3_EXTI8_PC                   ((uint16_t)0x0002) /* PC[8] pin */
+#define AFIO_EXTICR3_EXTI8_PD                   ((uint16_t)0x0003) /* PD[8] pin */
+#define AFIO_EXTICR3_EXTI8_PE                   ((uint16_t)0x0004) /* PE[8] pin */
+#define AFIO_EXTICR3_EXTI8_PF                   ((uint16_t)0x0005) /* PF[8] pin */
+#define AFIO_EXTICR3_EXTI8_PG                   ((uint16_t)0x0006) /* PG[8] pin */
+
+#define AFIO_EXTICR3_EXTI9_PA                   ((uint16_t)0x0000) /* PA[9] pin */
+#define AFIO_EXTICR3_EXTI9_PB                   ((uint16_t)0x0010) /* PB[9] pin */
+#define AFIO_EXTICR3_EXTI9_PC                   ((uint16_t)0x0020) /* PC[9] pin */
+#define AFIO_EXTICR3_EXTI9_PD                   ((uint16_t)0x0030) /* PD[9] pin */
+#define AFIO_EXTICR3_EXTI9_PE                   ((uint16_t)0x0040) /* PE[9] pin */
+#define AFIO_EXTICR3_EXTI9_PF                   ((uint16_t)0x0050) /* PF[9] pin */
+#define AFIO_EXTICR3_EXTI9_PG                   ((uint16_t)0x0060) /* PG[9] pin */
+
+#define AFIO_EXTICR3_EXTI10_PA                  ((uint16_t)0x0000) /* PA[10] pin */
+#define AFIO_EXTICR3_EXTI10_PB                  ((uint16_t)0x0100) /* PB[10] pin */
+#define AFIO_EXTICR3_EXTI10_PC                  ((uint16_t)0x0200) /* PC[10] pin */
+#define AFIO_EXTICR3_EXTI10_PD                  ((uint16_t)0x0300) /* PD[10] pin */
+#define AFIO_EXTICR3_EXTI10_PE                  ((uint16_t)0x0400) /* PE[10] pin */
+#define AFIO_EXTICR3_EXTI10_PF                  ((uint16_t)0x0500) /* PF[10] pin */
+#define AFIO_EXTICR3_EXTI10_PG                  ((uint16_t)0x0600) /* PG[10] pin */
+
+#define AFIO_EXTICR3_EXTI11_PA                  ((uint16_t)0x0000) /* PA[11] pin */
+#define AFIO_EXTICR3_EXTI11_PB                  ((uint16_t)0x1000) /* PB[11] pin */
+#define AFIO_EXTICR3_EXTI11_PC                  ((uint16_t)0x2000) /* PC[11] pin */
+#define AFIO_EXTICR3_EXTI11_PD                  ((uint16_t)0x3000) /* PD[11] pin */
+#define AFIO_EXTICR3_EXTI11_PE                  ((uint16_t)0x4000) /* PE[11] pin */
+#define AFIO_EXTICR3_EXTI11_PF                  ((uint16_t)0x5000) /* PF[11] pin */
+#define AFIO_EXTICR3_EXTI11_PG                  ((uint16_t)0x6000) /* PG[11] pin */
+
+/*****************  Bit definition for AFIO_EXTICR4 register  *****************/
+#define AFIO_EXTICR4_EXTI12                     ((uint16_t)0x000F) /* EXTI 12 configuration */
+#define AFIO_EXTICR4_EXTI13                     ((uint16_t)0x00F0) /* EXTI 13 configuration */
+#define AFIO_EXTICR4_EXTI14                     ((uint16_t)0x0F00) /* EXTI 14 configuration */
+#define AFIO_EXTICR4_EXTI15                     ((uint16_t)0xF000) /* EXTI 15 configuration */
+
+#define AFIO_EXTICR4_EXTI12_PA                  ((uint16_t)0x0000) /* PA[12] pin */
+#define AFIO_EXTICR4_EXTI12_PB                  ((uint16_t)0x0001) /* PB[12] pin */
+#define AFIO_EXTICR4_EXTI12_PC                  ((uint16_t)0x0002) /* PC[12] pin */
+#define AFIO_EXTICR4_EXTI12_PD                  ((uint16_t)0x0003) /* PD[12] pin */
+#define AFIO_EXTICR4_EXTI12_PE                  ((uint16_t)0x0004) /* PE[12] pin */
+#define AFIO_EXTICR4_EXTI12_PF                  ((uint16_t)0x0005) /* PF[12] pin */
+#define AFIO_EXTICR4_EXTI12_PG                  ((uint16_t)0x0006) /* PG[12] pin */
+
+#define AFIO_EXTICR4_EXTI13_PA                  ((uint16_t)0x0000) /* PA[13] pin */
+#define AFIO_EXTICR4_EXTI13_PB                  ((uint16_t)0x0010) /* PB[13] pin */
+#define AFIO_EXTICR4_EXTI13_PC                  ((uint16_t)0x0020) /* PC[13] pin */
+#define AFIO_EXTICR4_EXTI13_PD                  ((uint16_t)0x0030) /* PD[13] pin */
+#define AFIO_EXTICR4_EXTI13_PE                  ((uint16_t)0x0040) /* PE[13] pin */
+#define AFIO_EXTICR4_EXTI13_PF                  ((uint16_t)0x0050) /* PF[13] pin */
+#define AFIO_EXTICR4_EXTI13_PG                  ((uint16_t)0x0060) /* PG[13] pin */
+
+#define AFIO_EXTICR4_EXTI14_PA                  ((uint16_t)0x0000) /* PA[14] pin */
+#define AFIO_EXTICR4_EXTI14_PB                  ((uint16_t)0x0100) /* PB[14] pin */
+#define AFIO_EXTICR4_EXTI14_PC                  ((uint16_t)0x0200) /* PC[14] pin */
+#define AFIO_EXTICR4_EXTI14_PD                  ((uint16_t)0x0300) /* PD[14] pin */
+#define AFIO_EXTICR4_EXTI14_PE                  ((uint16_t)0x0400) /* PE[14] pin */
+#define AFIO_EXTICR4_EXTI14_PF                  ((uint16_t)0x0500) /* PF[14] pin */
+#define AFIO_EXTICR4_EXTI14_PG                  ((uint16_t)0x0600) /* PG[14] pin */
+
+#define AFIO_EXTICR4_EXTI15_PA                  ((uint16_t)0x0000) /* PA[15] pin */
+#define AFIO_EXTICR4_EXTI15_PB                  ((uint16_t)0x1000) /* PB[15] pin */
+#define AFIO_EXTICR4_EXTI15_PC                  ((uint16_t)0x2000) /* PC[15] pin */
+#define AFIO_EXTICR4_EXTI15_PD                  ((uint16_t)0x3000) /* PD[15] pin */
+#define AFIO_EXTICR4_EXTI15_PE                  ((uint16_t)0x4000) /* PE[15] pin */
+#define AFIO_EXTICR4_EXTI15_PF                  ((uint16_t)0x5000) /* PF[15] pin */
+#define AFIO_EXTICR4_EXTI15_PG                  ((uint16_t)0x6000) /* PG[15] pin */
+#endif
 
 /******************************************************************************/
 /*                           Independent WATCHDOG                             */
@@ -1691,6 +5850,11 @@ typedef struct
 #define I2C_CKCFGR_DUTY                         ((uint16_t)0x4000) /* Fast Mode Duty Cycle */
 #define I2C_CKCFGR_FS                           ((uint16_t)0x8000) /* I2C Master Mode Selection */
 
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/******************  Bit definition for I2C_RTR register  *******************/
+#define I2C_RTR_TRISE                           ((uint8_t)0x3F) /* Maximum Rise Time in Fast/Standard mode (Master mode) */
+#endif
+
 /******************************************************************************/
 /*                             Power Control                                  */
 /******************************************************************************/
@@ -1740,6 +5904,14 @@ typedef struct
 #define RCC_PLLON                               ((uint32_t)0x01000000) /* PLL enable */
 #define RCC_PLLRDY                              ((uint32_t)0x02000000) /* PLL clock ready flag */
 
+#if defined(CH32V30x)
+/* for CH32V307 */
+#define RCC_PLL3RDY								((uint32_t)(1<<29))
+#define RCC_PLL3ON								((uint32_t)(1<<28))
+#define RCC_PLL2RDY								((uint32_t)(1<<27))
+#define RCC_PLL2ON								((uint32_t)(1<<26))
+#endif
+
 /*******************  Bit definition for RCC_CFGR0 register  *******************/
 #define RCC_SW                                  ((uint32_t)0x00000003) /* SW[1:0] bits (System clock Switch) */
 #define RCC_SW_0                                ((uint32_t)0x00000001) /* Bit 0 */
@@ -1763,6 +5935,7 @@ typedef struct
 #define RCC_HPRE_2                              ((uint32_t)0x00000040) /* Bit 2 */
 #define RCC_HPRE_3                              ((uint32_t)0x00000080) /* Bit 3 */
 
+#if defined(CH32V003) || defined(CH32X03x)
 #define RCC_HPRE_DIV1                           ((uint32_t)0x00000000) /* SYSCLK not divided */
 #define RCC_HPRE_DIV2                           ((uint32_t)0x00000010) /* SYSCLK divided by 2 */
 #define RCC_HPRE_DIV3                           ((uint32_t)0x00000020) /* SYSCLK divided by 3 */
@@ -1776,6 +5949,17 @@ typedef struct
 #define RCC_HPRE_DIV64                          ((uint32_t)0x000000D0) /* SYSCLK divided by 64 */
 #define RCC_HPRE_DIV128                         ((uint32_t)0x000000E0) /* SYSCLK divided by 128 */
 #define RCC_HPRE_DIV256                         ((uint32_t)0x000000F0) /* SYSCLK divided by 256 */
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define RCC_HPRE_DIV1                   		((uint32_t)0x00000000) /* SYSCLK not divided */
+#define RCC_HPRE_DIV2                   		((uint32_t)0x00000080) /* SYSCLK divided by 2 */
+#define RCC_HPRE_DIV4                   		((uint32_t)0x00000090) /* SYSCLK divided by 4 */
+#define RCC_HPRE_DIV8                   		((uint32_t)0x000000A0) /* SYSCLK divided by 8 */
+#define RCC_HPRE_DIV16                  		((uint32_t)0x000000B0) /* SYSCLK divided by 16 */
+#define RCC_HPRE_DIV64                  		((uint32_t)0x000000C0) /* SYSCLK divided by 64 */
+#define RCC_HPRE_DIV128                 		((uint32_t)0x000000D0) /* SYSCLK divided by 128 */
+#define RCC_HPRE_DIV256                 		((uint32_t)0x000000E0) /* SYSCLK divided by 256 */
+#define RCC_HPRE_DIV512                 		((uint32_t)0x000000F0) /* SYSCLK divided by 512 */
+#endif
 
 #define RCC_PPRE1                               ((uint32_t)0x00000700) /* PRE1[2:0] bits (APB1 prescaler) */
 #define RCC_PPRE1_0                             ((uint32_t)0x00000100) /* Bit 0 */
@@ -1818,8 +6002,13 @@ typedef struct
 #define RCC_PLLMULL_2                           ((uint32_t)0x00100000) /* Bit 2 */
 #define RCC_PLLMULL_3                           ((uint32_t)0x00200000) /* Bit 3 */
 
+#ifdef CH32V003
 #define RCC_PLLSRC_HSI_Mul2                     ((uint32_t)0x00000000) /* HSI clock*2 selected as PLL entry clock source */
 #define RCC_PLLSRC_HSE_Mul2                     ((uint32_t)0x00010000) /* HSE clock*2 selected as PLL entry clock source */
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define RCC_PLLSRC_HSI_Div2                     ((uint32_t)0x00000000) /* HSI clock divided by 2 selected as PLL entry clock source */
+#define RCC_PLLSRC_HSE                          ((uint32_t)0x00010000) /* HSE clock selected as PLL entry clock source */
+#endif
 
 #define RCC_PLLXTPRE_HSE                        ((uint32_t)0x00000000) /* HSE clock not divided for PLL entry */
 #define RCC_PLLXTPRE_HSE_Div2                   ((uint32_t)0x00020000) /* HSE clock divided by 2 for PLL entry */
@@ -1839,6 +6028,31 @@ typedef struct
 #define RCC_PLLMULL14                           ((uint32_t)0x00300000) /* PLL input clock*14 */
 #define RCC_PLLMULL15                           ((uint32_t)0x00340000) /* PLL input clock*15 */
 #define RCC_PLLMULL16                           ((uint32_t)0x00380000) /* PLL input clock*16 */
+#if defined(CH32V20x)
+#define RCC_PLLMULL18                           ((uint32_t)0x003C0000) /* PLL input clock*18 */
+#endif
+
+#if defined(CH32V30x)
+
+/* for CH32V307 */
+#define  RCC_PLLMULL18_EXTEN             		((uint32_t)0x00000000) /* PLL input clock*18 */
+#define  RCC_PLLMULL3_EXTEN              		((uint32_t)0x00040000) /* PLL input clock*3 */
+#define  RCC_PLLMULL4_EXTEN              		((uint32_t)0x00080000) /* PLL input clock*4 */
+#define  RCC_PLLMULL5_EXTEN              		((uint32_t)0x000C0000) /* PLL input clock*5 */
+#define  RCC_PLLMULL6_EXTEN              		((uint32_t)0x00100000) /* PLL input clock*6 */
+#define  RCC_PLLMULL7_EXTEN              		((uint32_t)0x00140000) /* PLL input clock*7 */
+#define  RCC_PLLMULL8_EXTEN              		((uint32_t)0x00180000) /* PLL input clock*8 */
+#define  RCC_PLLMULL9_EXTEN              		((uint32_t)0x001C0000) /* PLL input clock*9 */
+#define  RCC_PLLMULL10_EXTEN             		((uint32_t)0x00200000) /* PLL input clock10 */
+#define  RCC_PLLMULL11_EXTEN             		((uint32_t)0x00240000) /* PLL input clock*11 */
+#define  RCC_PLLMULL12_EXTEN             		((uint32_t)0x00280000) /* PLL input clock*12 */
+#define  RCC_PLLMULL13_EXTEN             		((uint32_t)0x002C0000) /* PLL input clock*13 */
+#define  RCC_PLLMULL14_EXTEN             		((uint32_t)0x00300000) /* PLL input clock*14 */
+#define  RCC_PLLMULL6_5_EXTEN            		((uint32_t)0x00340000) /* PLL input clock*6.5 */
+#define  RCC_PLLMULL15_EXTEN             		((uint32_t)0x00380000) /* PLL input clock*15 */
+#define  RCC_PLLMULL16_EXTEN             		((uint32_t)0x003C0000) /* PLL input clock*16 */
+#endif
+
 #define RCC_USBPRE                              ((uint32_t)0x00400000) /* USB Device prescaler */
 
 #define RCC_CFGR0_MCO                           ((uint32_t)0x07000000) /* MCO[2:0] bits (Microcontroller Clock Output) */
@@ -1851,6 +6065,32 @@ typedef struct
 #define RCC_CFGR0_MCO_HSI                       ((uint32_t)0x05000000) /* HSI clock selected as MCO source */
 #define RCC_CFGR0_MCO_HSE                       ((uint32_t)0x06000000) /* HSE clock selected as MCO source  */
 #define RCC_CFGR0_MCO_PLL                       ((uint32_t)0x07000000) /* PLL clock divided by 2 selected as MCO source */
+
+/*******************  Bit definition for RCC_CFGR2 register  *******************/
+#ifdef CH32V30x
+#define RCC_PREDIV1_OFFSET						(0)
+#define RCC_PREDIV1_MASK						((uint32_t)(0xf<<RCC_PREDIV1_OFFSET))
+#define RCC_PREDIV2_OFFSET						(4)
+#define RCC_PREDIV2_MASK						((uint32_t)(0xf<<RCC_PREDIV2_OFFSET))
+#define RCC_PLL2MUL_OFFSET						(8)
+#define RCC_PLL2MUL_MASK						((uint32_t)(0xf<<RCC_PLL2MUL_OFFSET))
+#define RCC_PLL3MUL_OFFSET						(12)
+#define RCC_PLL3MUL 							((uint32_t)(0xf<<RCC_PLL3MUL_OFFSET))
+#define RCC_PREDIV1SRC 							((uint32_t)(1<<16))
+#define RCC_I2S2SRC 							((uint32_t)(1<<17))
+#define RCC_I2S3SRC 							((uint32_t)(1<<18))
+#define RCC_RNG_SRC 							((uint32_t)(1<<19))
+#define RCC_ETH1GSRC_OFFSET						(20)
+#define RCC_ETH1GSRC_MASK						((uint32_t)(3<<RCC_ETH1GSRC_OFFSET))
+#define RCC_ETH1G_125M_EN						((uint32_t)(1<<22))
+#define RCC_USBHSDIV_OFFSET						(24)
+#define RCC_USBHSDIV_MASK						((uint32_t)(7<<RCC_USBHSDIV_OFFSET))
+#define RCC_USBHSPLLSRC							((uint32_t)(1<<27))
+#define RCC_USBHSCLK_OFFSET						(3)
+#define RCC_USBHSCLK_MASK						((uint32_t)(3<<RCC_USBHSCLK))
+#define RCC_USBHSPLL							((uint32_t)(1<<30))
+#define RCC_USBHSSRC							((uint32_t)(1<<31))
+#endif
 
 /*******************  Bit definition for RCC_INTR register  ********************/
 #define RCC_LSIRDYF                             ((uint32_t)0x00000001) /* LSI Ready Interrupt flag */
@@ -1907,11 +6147,27 @@ typedef struct
 #define RCC_USBRST                              ((uint32_t)0x00800000) /* USB Device reset */
 
 /******************  Bit definition for RCC_AHBPCENR register  ******************/
-#define RCC_DMA1EN                              ((uint16_t)0x0001) /* DMA1 clock enable */
-#define RCC_SRAMEN                              ((uint16_t)0x0004) /* SRAM interface clock enable */
-#define RCC_FLITFEN                             ((uint16_t)0x0010) /* FLITF clock enable */
-#define RCC_CRCEN                               ((uint16_t)0x0040) /* CRC clock enable */
-#define RCC_USBHD                               ((uint16_t)0x1000)
+#define RCC_DMA1EN                              ((uint32_t)0x0001) /* DMA1 clock enable */
+#define RCC_SRAMEN                              ((uint32_t)0x0004) /* SRAM interface clock enable */
+#define RCC_FLITFEN                             ((uint32_t)0x0010) /* FLITF clock enable */
+#define RCC_CRCEN                               ((uint32_t)0x0040) /* CRC clock enable */
+#define RCC_USBHD                               ((uint32_t)0x1000)
+#define RCC_USBFS                               ((uint32_t)0x1000)
+#define RCC_USBPD                               ((uint32_t)0x20000)
+#ifdef CH32V30x
+#define RCC_DMA2EN								((uint32_t)0x00000002)
+#define RCC_FSMCEN								((uint32_t)0x00000100)
+#define RCC_RNGEN								((uint32_t)0x00000200)
+#define RCC_SDIOEN								((uint32_t)0x00000400)
+#define RCC_USBHSEN								((uint32_t)0x00000800)
+#define RCC_OTG_FSEN							((uint32_t)0x00001000)
+#define RCC_DVPEN								((uint32_t)0x00002000)
+#define RCC_ETHMACEN							((uint32_t)0x00004000)
+#define RCC_ETHMACTXEN							((uint32_t)0x00008000)
+#define RCC_ETHMACRXEN							((uint32_t)0x00010000)
+#define RCC_BLEC								((uint32_t)0x00020000)
+#define RCC_DBLES								((uint32_t)0x00040000)
+#endif
 
 /******************  Bit definition for RCC_APB2PCENR register  *****************/
 #define RCC_AFIOEN                              ((uint32_t)0x00000001) /* Alternate Function I/O clock enable */
@@ -1939,6 +6195,25 @@ typedef struct
 
 #define RCC_USBEN                               ((uint32_t)0x00800000) /* USB Device clock enable */
 
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/*******************  Bit definition for RCC_BDCTLR register  *******************/
+#define RCC_LSEON                               ((uint32_t)0x00000001) /* External Low Speed oscillator enable */
+#define RCC_LSERDY                              ((uint32_t)0x00000002) /* External Low Speed oscillator Ready */
+#define RCC_LSEBYP                              ((uint32_t)0x00000004) /* External Low Speed oscillator Bypass */
+
+#define RCC_RTCSEL                              ((uint32_t)0x00000300) /* RTCSEL[1:0] bits (RTC clock source selection) */
+#define RCC_RTCSEL_0                            ((uint32_t)0x00000100) /* Bit 0 */
+#define RCC_RTCSEL_1                            ((uint32_t)0x00000200) /* Bit 1 */
+
+#define RCC_RTCSEL_NOCLOCK                      ((uint32_t)0x00000000) /* No clock */
+#define RCC_RTCSEL_LSE                          ((uint32_t)0x00000100) /* LSE oscillator clock used as RTC clock */
+#define RCC_RTCSEL_LSI                          ((uint32_t)0x00000200) /* LSI oscillator clock used as RTC clock */
+#define RCC_RTCSEL_HSE                          ((uint32_t)0x00000300) /* HSE oscillator clock divided by 128 used as RTC clock */
+
+#define RCC_RTCEN                               ((uint32_t)0x00008000) /* RTC clock enable */
+#define RCC_BDRST                               ((uint32_t)0x00010000) /* Backup domain software reset  */
+#endif
+
 /*******************  Bit definition for RCC_RSTSCKR register  ********************/
 #define RCC_LSION                               ((uint32_t)0x00000001) /* Internal Low Speed oscillator enable */
 #define RCC_LSIRDY                              ((uint32_t)0x00000002) /* Internal Low Speed oscillator Ready */
@@ -1949,6 +6224,73 @@ typedef struct
 #define RCC_IWDGRSTF                            ((uint32_t)0x20000000) /* Independent Watchdog reset flag */
 #define RCC_WWDGRSTF                            ((uint32_t)0x40000000) /* Window watchdog reset flag */
 #define RCC_LPWRRSTF                            ((uint32_t)0x80000000) /* Low-Power reset flag */
+
+/******************  Bit definition for RCC_AHBRSTR register  *****************/
+#if defined(CH32V30x)
+#define RCC_ETHMACRST							((uint32_t)(1<<14))
+#define RCC_DVPRST								((uint32_t)(1<<13))
+#define RCC_OTGFSRST							((uint32_t)(1<<12))
+#endif
+
+
+#if defined(CH32V30x)
+/******************************************************************************/
+/*                                    RNG                                     */
+/******************************************************************************/
+/********************  Bit definition for RNG_CR register  *******************/
+#define  RNG_CR_RNGEN                         ((uint32_t)0x00000004)
+#define  RNG_CR_IE                            ((uint32_t)0x00000008)
+
+/********************  Bit definition for RNG_SR register  *******************/
+#define  RNG_SR_DRDY                          ((uint32_t)0x00000001)
+#define  RNG_SR_CECS                          ((uint32_t)0x00000002)
+#define  RNG_SR_SECS                          ((uint32_t)0x00000004)
+#define  RNG_SR_CEIS                          ((uint32_t)0x00000020)
+#define  RNG_SR_SEIS                          ((uint32_t)0x00000040)
+#endif
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/******************************************************************************/
+/*                             Real-Time Clock                                */
+/******************************************************************************/
+
+/*******************  Bit definition for RTC_CTLRH register  ********************/
+#define RTC_CTLRH_SECIE                         ((uint8_t)0x01) /* Second Interrupt Enable */
+#define RTC_CTLRH_ALRIE                         ((uint8_t)0x02) /* Alarm Interrupt Enable */
+#define RTC_CTLRH_OWIE                          ((uint8_t)0x04) /* OverfloW Interrupt Enable */
+
+/*******************  Bit definition for RTC_CTLRL register  ********************/
+#define RTC_CTLRL_SECF                          ((uint8_t)0x01) /* Second Flag */
+#define RTC_CTLRL_ALRF                          ((uint8_t)0x02) /* Alarm Flag */
+#define RTC_CTLRL_OWF                           ((uint8_t)0x04) /* OverfloW Flag */
+#define RTC_CTLRL_RSF                           ((uint8_t)0x08) /* Registers Synchronized Flag */
+#define RTC_CTLRL_CNF                           ((uint8_t)0x10) /* Configuration Flag */
+#define RTC_CTLRL_RTOFF                         ((uint8_t)0x20) /* RTC operation OFF */
+
+/*******************  Bit definition for RTC_PSCH register  *******************/
+#define RTC_PSCH_PRL                            ((uint16_t)0x000F) /* RTC Prescaler Reload Value High */
+
+/*******************  Bit definition for RTC_PRLL register  *******************/
+#define RTC_PSCL_PRL                            ((uint16_t)0xFFFF) /* RTC Prescaler Reload Value Low */
+
+/*******************  Bit definition for RTC_DIVH register  *******************/
+#define RTC_DIVH_RTC_DIV                        ((uint16_t)0x000F) /* RTC Clock Divider High */
+
+/*******************  Bit definition for RTC_DIVL register  *******************/
+#define RTC_DIVL_RTC_DIV                        ((uint16_t)0xFFFF) /* RTC Clock Divider Low */
+
+/*******************  Bit definition for RTC_CNTH register  *******************/
+#define RTC_CNTH_RTC_CNT                        ((uint16_t)0xFFFF) /* RTC Counter High */
+
+/*******************  Bit definition for RTC_CNTL register  *******************/
+#define RTC_CNTL_RTC_CNT                        ((uint16_t)0xFFFF) /* RTC Counter Low */
+
+/*******************  Bit definition for RTC_ALRMH register  *******************/
+#define RTC_ALRMH_RTC_ALRM                      ((uint16_t)0xFFFF) /* RTC Alarm High */
+
+/*******************  Bit definition for RTC_ALRML register  *******************/
+#define RTC_ALRML_RTC_ALRM                      ((uint16_t)0xFFFF) /* RTC Alarm Low */
+#endif
 
 /******************************************************************************/
 /*                        Serial Peripheral Interface                         */
@@ -2003,6 +6345,35 @@ typedef struct
 
 /******************  Bit definition for SPI_TCRCR register  ******************/
 #define SPI_TCRCR_TXCRC                         ((uint16_t)0xFFFF) /* Tx CRC Register */
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN                       ((uint16_t)0x0001) /* Channel length (number of bits per audio channel) */
+
+#define SPI_I2SCFGR_DATLEN                      ((uint16_t)0x0006) /* DATLEN[1:0] bits (Data length to be transferred) */
+#define SPI_I2SCFGR_DATLEN_0                    ((uint16_t)0x0002) /* Bit 0 */
+#define SPI_I2SCFGR_DATLEN_1                    ((uint16_t)0x0004) /* Bit 1 */
+
+#define SPI_I2SCFGR_CKPOL                       ((uint16_t)0x0008) /* steady state clock polarity */
+
+#define SPI_I2SCFGR_I2SSTD                      ((uint16_t)0x0030) /* I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0                    ((uint16_t)0x0010) /* Bit 0 */
+#define SPI_I2SCFGR_I2SSTD_1                    ((uint16_t)0x0020) /* Bit 1 */
+
+#define SPI_I2SCFGR_PCMSYNC                     ((uint16_t)0x0080) /* PCM frame synchronization */
+
+#define SPI_I2SCFGR_I2SCFG                      ((uint16_t)0x0300) /* I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0                    ((uint16_t)0x0100) /* Bit 0 */
+#define SPI_I2SCFGR_I2SCFG_1                    ((uint16_t)0x0200) /* Bit 1 */
+
+#define SPI_I2SCFGR_I2SE                        ((uint16_t)0x0400) /* I2S Enable */
+#define SPI_I2SCFGR_I2SMOD                      ((uint16_t)0x0800) /* I2S mode selection */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV                        ((uint16_t)0x00FF) /* I2S Linear prescaler */
+#define SPI_I2SPR_ODD                           ((uint16_t)0x0100) /* Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE                         ((uint16_t)0x0200) /* Master Clock Output Enable */
+#endif
 
 /******************************************************************************/
 /*                                    TIM                                     */
@@ -2412,14 +6783,261 @@ typedef struct
 /******************************************************************************/
 
 /****************************  Enhanced register  *****************************/
-#define EXTEN_LOCKUP_EN                         ((uint32_t)0x00000040) /* Bit 6 */
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define EXTEN_USBD_LS                           ((uint32_t)0x00000001) /* Bit 0 */
+#define EXTEN_USBD_PU_EN                        ((uint32_t)0x00000002) /* Bit 1 */
+#define EXTEN_ETH_10M_EN                        ((uint32_t)0x00000004) /* Bit 2 */
+#define EXTEN_PLL_HSI_PRE                       ((uint32_t)0x00000010) /* Bit 4 */
+#endif
+#define EXTEN_LOCKUP_EN                         ((uint32_t)0x00000040) /* Bit 5 */
 #define EXTEN_LOCKUP_RSTF                       ((uint32_t)0x00000080) /* Bit 7 */
 
-#define EXTEN_LDO_TRIM                          ((uint32_t)0x00000400) /* Bit 10 */
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define EXTEN_ULLDO_TRIM                        ((uint32_t)0x00000300) /* ULLDO_TRIM[1:0] bits */
+#define EXTEN_ULLDO_TRIM0                       ((uint32_t)0x00000100) /* Bit 0 */
+#define EXTEN_ULLDO_TRIM1                       ((uint32_t)0x00000200) /* Bit 1 */
+#endif
 
+#if !defined(CH32V10x)
+
+#define EXTEN_LDO_TRIM                          ((uint32_t)0x00000400) /* Bit 10 */
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTEN_LDO_TRIM0                         ((uint32_t)0x00000400) /* Bit 0 */
+#define EXTEN_LDO_TRIM1                         ((uint32_t)0x00000800) /* Bit 1 */
+#endif
+
+#else
+
+#define EXTEN_IDO_TRIM                          ((uint32_t)0x00000400) /* Bit 10 */
+#define EXTEN_WRITE_EN                          ((uint32_t)0x00004000) /* Bit 14 */
+#define EXTEN_SHORT_WAKE                        ((uint32_t)0x00008000) /* Bit 15 */
+
+#define EXTEN_FLASH_CLK_TRIM                    ((uint32_t)0x00070000) /* FLASH_CLK_TRIM[2:0] bits */
+#define EXTEN_FLASH_CLK_TRIM0                   ((uint32_t)0x00010000) /* Bit 0 */
+#define EXTEN_FLASH_CLK_TRIM1                   ((uint32_t)0x00020000) /* Bit 1 */
+#define EXTEN_FLASH_CLK_TRIM2                   ((uint32_t)0x00040000) /* Bit 2 */
+
+#endif
+
+#if defined(CH32V003)
 #define EXTEN_OPA_EN                            ((uint32_t)0x00010000)
 #define EXTEN_OPA_NSEL                          ((uint32_t)0x00020000)
 #define EXTEN_OPA_PSEL                          ((uint32_t)0x00040000)
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+/******************************************************************************/
+/*                                  DVP                                       */
+/******************************************************************************/
+
+/*******************  Bit definition for DVP_CR0 register  ********************/
+#define RB_DVP_ENABLE                           0x01  // RW, DVP enable
+#define RB_DVP_V_POLAR                          0x02  // RW, DVP VSYNC polarity control: 1 = invert, 0 = not invert
+#define RB_DVP_H_POLAR                          0x04  // RW, DVP HSYNC polarity control: 1 = invert, 0 = not invert
+#define RB_DVP_P_POLAR                          0x08  // RW, DVP PCLK polarity control: 1 = invert, 0 = not invert
+#define RB_DVP_MSK_DAT_MOD                      0x30
+#define RB_DVP_D8_MOD                           0x00  // RW, DVP 8bits data mode
+#define RB_DVP_D10_MOD                          0x10  // RW, DVP 10bits data mode
+#define RB_DVP_D12_MOD                          0x20  // RW, DVP 12bits data mode
+#define RB_DVP_JPEG                             0x40  // RW, DVP JPEG mode
+
+/*******************  Bit definition for DVP_CR1 register  ********************/
+#define RB_DVP_DMA_EN                           0x01  // RW, DVP dma enable
+#define RB_DVP_ALL_CLR                          0x02  // RW, DVP all clear, high action
+#define RB_DVP_RCV_CLR                          0x04  // RW, DVP receive logic clear, high action
+#define RB_DVP_BUF_TOG                          0x08  // RW, DVP bug toggle by software, write 1 to toggle, ignored writing 0
+#define RB_DVP_CM                               0x10  // RW, DVP capture mode
+#define RB_DVP_CROP                             0x20  // RW, DVP Crop feature enable
+#define RB_DVP_FCRC                             0xC0  // RW, DVP frame capture rate control:
+#define DVP_RATE_100P                           0x00  //00 = every frame captured (100%)
+#define DVP_RATE_50P                            0x40  //01 = every alternate frame captured (50%)
+#define DVP_RATE_25P                            0x80  //10 = one frame in four frame captured (25%)
+
+/*******************  Bit definition for DVP_IER register  ********************/
+#define RB_DVP_IE_STR_FRM                       0x01  // RW, DVP frame start interrupt enable
+#define RB_DVP_IE_ROW_DONE                      0x02  // RW, DVP row received done interrupt enable
+#define RB_DVP_IE_FRM_DONE                      0x04  // RW, DVP frame received done interrupt enable
+#define RB_DVP_IE_FIFO_OV                       0x08  // RW, DVP receive fifo overflow interrupt enable
+#define RB_DVP_IE_STP_FRM                       0x10  // RW, DVP frame stop interrupt enable
+
+/*******************  Bit definition for DVP_IFR register  ********************/
+#define RB_DVP_IF_STR_FRM                       0x01  // RW1, interrupt flag for DVP frame start
+#define RB_DVP_IF_ROW_DONE                      0x02  // RW1, interrupt flag for DVP row receive done
+#define RB_DVP_IF_FRM_DONE                      0x04  // RW1, interrupt flag for DVP frame receive done
+#define RB_DVP_IF_FIFO_OV                       0x08  // RW1, interrupt flag for DVP receive fifo overflow
+#define RB_DVP_IF_STP_FRM                       0x10  // RW1, interrupt flag for DVP frame stop
+
+/*******************  Bit definition for DVP_STATUS register  ********************/
+#define RB_DVP_FIFO_RDY                         0x01  // RO, DVP receive fifo ready
+#define RB_DVP_FIFO_FULL                        0x02  // RO, DVP receive fifo full
+#define RB_DVP_FIFO_OV                          0x04  // RO, DVP receive fifo overflow
+#define RB_DVP_MSK_FIFO_CNT                     0x70  // RO, DVP receive fifo count
+
+#if defined(CH32V20x)
+/******************************************************************************/
+/*                                  ETH10M                                    */
+/******************************************************************************/
+/* ETH register */
+#define R8_ETH_EIE              (*((volatile uint8_t *)(0x40028000+3))) /* Interrupt Enable Register */
+#define  RB_ETH_EIE_INTIE       0x80                  /* RW interrupt enable*/
+#define  RB_ETH_EIE_RXIE        0x40                  /* RW Receive complete interrupt enable */
+#define  RB_ETH_EIE_LINKIE      0x10                  /* RW Link Change Interrupt Enable */
+#define  RB_ETH_EIE_TXIE        0x08                  /* RW send complete interrupt enable */
+#define  RB_ETH_EIE_R_EN50      0x04                  /* RW TX 50�� resistor adjustment. 1: On-chip 50�� connected 0: On-chip 50�� disconnected */
+#define  RB_ETH_EIE_TXERIE      0x02                  /* RW Transmit Error Interrupt Enable */
+#define  RB_ETH_EIE_RXERIE      0x01                  /* RW1 receive error flag */
+#define R8_ETH_EIR              (*((volatile uint8_t *)(0x40028000+4))) /* Interrupt Flag Register */
+#define  RB_ETH_EIR_RXIF        0x40                  /* RW1 Receive complete flag */
+#define  RB_ETH_EIR_LINKIF      0x10                  /* RW1 Link Change Flag */
+#define  RB_ETH_EIR_TXIF        0x08                  /* RW1 Link Change Flag */
+#define  RB_ETH_EIR_TXERIF      0x02                  /* RW1 send error flag */
+#define  RB_ETH_EIR_RXERIF      0x01                  /* RW1 receive error flag */
+#define R8_ETH_ESTAT            (*((volatile uint8_t *)(0x40028000+5))) /* status register */
+#define  RB_ETH_ESTAT_INT       0x80                  /* RW1 interrupt */
+#define  RB_ETH_ESTAT_BUFER     0x40                  /* RW1 Buffer error */
+#define  RB_ETH_ESTAT_RXCRCER   0x20                  /* RO receive crc error */
+#define  RB_ETH_ESTAT_RXNIBBLE  0x10                  /* RO receives nibble error */
+#define  RB_ETH_ESTAT_RXMORE    0x08                  /* RO receives more than maximum packets */
+#define  RB_ETH_ESTAT_RXBUSY    0x04                  /* RO receive busy */
+#define  RB_ETH_ESTAT_TXABRT    0x02                  /* RO send interrupted by mcu */
+#define R8_ETH_ECON2            (*((volatile uint8_t *)(0x40028000+6))) /* ETH PHY Analog Block Control Register */
+#define  RB_ETH_ECON2_RX        0x0E                  /* 011b must be written */
+#define  RB_ETH_ECON2_TX        0x01
+#define  RB_ETH_ECON2_MUST      0x06                  /* 011b must be written */
+#define R8_ETH_ECON1            (*((volatile uint8_t *)(0x40028000+7))) /* Transceiver Control Register */
+#define  RB_ETH_ECON1_TXRST     0x80                  /* RW Send module reset */
+#define  RB_ETH_ECON1_RXRST     0x40                  /* RW Receiver module reset */
+#define  RB_ETH_ECON1_TXRTS     0x08                  /* RW The transmission starts, and it is automatically cleared after the transmission is completed. */
+#define  RB_ETH_ECON1_RXEN      0x04                  /* RW Receive is enabled, when cleared, the error flag RXERIF will change to 1 if it is receiving */
+
+#define R32_ETH_TX              (*((volatile uint32_t *)(0x40028000+8))) /* send control */
+#define R16_ETH_ETXST           (*((volatile uint16_t *)(0x40028000+8))) /* RW Send DMA buffer start address */
+#define R16_ETH_ETXLN           (*((volatile uint16_t *)(0x40028000+0xA))) /* RW send length */
+#define R32_ETH_RX              (*((volatile uint32_t *)(0x40028000+0xC))) /* receive control */
+#define R16_ETH_ERXST           (*((volatile uint16_t *)(0x40028000+0xC))) /* RW Receive DMA buffer start address */
+#define R16_ETH_ERXLN           (*((volatile uint16_t *)(0x40028000+0xE))) /* RO receive length */
+
+#define R32_ETH_HTL             (*((volatile uint32_t *)(0x40028000+0x10)))
+#define R8_ETH_EHT0             (*((volatile uint8_t *)(0x40028000+0x10))) /* RW Hash Table Byte0 */
+#define R8_ETH_EHT1             (*((volatile uint8_t *)(0x40028000+0x11))) /* RW Hash Table Byte1 */
+#define R8_ETH_EHT2             (*((volatile uint8_t *)(0x40028000+0x12))) /* RW Hash Table Byte2 */
+#define R8_ETH_EHT3             (*((volatile uint8_t *)(0x40028000+0x13))) /* RW Hash Table Byte3 */
+#define R32_ETH_HTH             (*((volatile uint32_t *)(0x40028000+0x14)))
+#define R8_ETH_EHT4             (*((volatile uint8_t *)(0x40028000+0x14))) /* RW Hash Table Byte4 */
+#define R8_ETH_EHT5             (*((volatile uint8_t *)(0x40028000+0x15))) /* RW Hash Table Byte5 */
+#define R8_ETH_EHT6             (*((volatile uint8_t *)(0x40028000+0x16))) /* RW Hash Table Byte6 */
+#define R8_ETH_EHT7             (*((volatile uint8_t *)(0x40028000+0x17))) /* RW Hash Table Byte7 */
+
+#define R32_ETH_MACON           (*((volatile uint32_t *)(0x40028000+0x18)))
+#define R8_ETH_ERXFCON          (*((volatile uint8_t *)(0x40028000+0x18))) /* Received Packet Filtering Control Register */
+/* RW 0=Do not enable this filter condition, 1=When ANDOR=1,
+target address mismatch will be filtered, when ANDOR=0, target address match will be accepted */
+#define  RB_ETH_ERXFCON_UCEN    0x80
+#define  RB_ETH_ERXFCON_CRCEN   0x20
+#define  RB_ETH_ERXFCON_EN      0x10
+#define  RB_ETH_ERXFCON_MPEN    0x08
+#define  RB_ETH_ERXFCON_HTEN    0x04
+#define  RB_ETH_ERXFCON_MCEN    0x02
+#define  RB_ETH_ERXFCON_BCEN    0x01
+#define R8_ETH_MACON1           (*((volatile uint8_t *)(0x40028000+0x19))) /* Mac flow control registers */
+/* RW When FULDPX=0 is invalid, when FULDPX=1, 11=send 0 timer pause frame,
+then stop sending, 10=send pause frame periodically, 01=send pause frame once, then stop sending, 00=stop sending pause frame */
+#define  RB_ETH_MACON1_FCEN     0x30
+#define  RB_ETH_MACON1_TXPAUS   0x08                  /* RW Send pause frame enable*/
+#define  RB_ETH_MACON1_RXPAUS   0x04                  /* RW Receive pause frame enable */
+#define  RB_ETH_MACON1_PASSALL  0x02                  /* RW 1=Unfiltered control frames will be written to the buffer, 0=Control frames will be filtered */
+#define  RB_ETH_MACON1_MARXEN   0x01                  /* RW MAC layer receive enable */
+#define R8_ETH_MACON2           (*((volatile uint8_t *)(0x40028000+0x1A))) /* Mac Layer Packet Control Register */
+#define  RB_ETH_MACON2_PADCFG   0xE0                  /* RW Short Packet Padding Settings */
+#define  RB_ETH_MACON2_TXCRCEN  0x10                  /* RW Send to add crc, if you need to add crc in PADCFG, this position is 1 */
+#define  RB_ETH_MACON2_PHDREN   0x08                  /* RW Special 4 bytes do not participate in crc check */
+#define  RB_ETH_MACON2_HFRMEN   0x04                  /* RW Allow jumbo frames */
+#define  RB_ETH_MACON2_FULDPX   0x01                  /* RW full duplex */
+#define R8_ETH_MABBIPG          (*((volatile uint8_t *)(0x40028000+0x1B))) /* Minimum Interpacket Interval Register */
+#define  RB_ETH_MABBIPG_MABBIPG 0x7F                  /* RW Minimum number of bytes between packets */
+
+#define R32_ETH_TIM             (*((volatile uint32_t *)(0x40028000+0x1C)))
+#define R16_ETH_EPAUS           (*((volatile uint16_t *)(0x40028000+0x1C))) /* RW Flow Control Pause Frame Time Register */
+#define R16_ETH_MAMXFL          (*((volatile uint16_t *)(0x40028000+0x1E))) /* RW Maximum Received Packet Length Register */
+#define R16_ETH_MIRD            (*((volatile uint16_t *)(0x40028000+0x20))) /* RW MII read data register */
+
+#define R32_ETH_MIWR            (*((volatile uint32_t *)(0x40028000+0x24)))
+#define R8_ETH_MIREGADR         (*((volatile uint8_t *)(0x40028000+0x24))) /* MII address register*/
+#define  RB_ETH_MIREGADR_MASK   0x1F                  /* RW PHY register address mask */
+#define R8_ETH_MISTAT           (*((volatile uint8_t *)(0x40028000+0x25))) /* RW PHY register address mask */
+//#define  RB_ETH_MIREGADR_MIIWR  0x20                  /* WO MII write command */
+#define R16_ETH_MIWR            (*((volatile uint16_t *)(0x40028000+0x26))) /* WO MII Write Data Register */
+#define R32_ETH_MAADRL          (*((volatile uint32_t *)(0x40028000+0x28))) /* RW MAC 1-4 */
+#define R8_ETH_MAADRL1          (*((volatile uint8_t *)(0x40028000+0x28))) /* RW MAC 1 */
+#define R8_ETH_MAADRL2          (*((volatile uint8_t *)(0x40028000+0x29))) /* RW MAC 2 */
+#define R8_ETH_MAADRL3          (*((volatile uint8_t *)(0x40028000+0x2A))) /* RW MAC 3 */
+#define R8_ETH_MAADRL4          (*((volatile uint8_t *)(0x40028000+0x2B))) /* RW MAC 4 */
+#define R16_ETH_MAADRH          (*((volatile uint16_t *)(0x40028000+0x2C))) /* RW MAC 5-6 */
+#define R8_ETH_MAADRL5          (*((volatile uint8_t *)(0x40028000+0x2C))) /* RW MAC 4 */
+#define R8_ETH_MAADRL6          (*((volatile uint8_t *)(0x40028000+0x2D))) /* RW MAC 4 */
+
+//PHY address
+#define PHY_BMCR                0x00                                            /* Control Register */
+#define PHY_BMSR                0x01                                            /* Status Register */
+#define PHY_ANAR                0x04                                            /* Auto-Negotiation Advertisement Register */
+#define PHY_ANLPAR              0x05                                            /* Auto-Negotiation Link Partner Base  Page Ability Register*/
+#define PHY_ANER                0x06                                            /* Auto-Negotiation Expansion Register */
+#define PHY_MDIX                0x1e                                            /* Custom MDIX Mode Register */
+//Custom MDIX Mode Register  @PHY_MDIX
+#define PN_NORMAL               0x04                                            /* Analog p, n polarity selection */
+#define MDIX_MODE_MASK          0x03                                            /* mdix settings */
+#define MDIX_MODE_AUTO          0x00                                            /*  */
+#define MDIX_MODE_MDIX          0x01
+#define MDIX_MODE_MDI           0x02
+//ECON2 test mode, to be determined
+#define RX_VCM_MODE_0
+#define RX_VCM_MODE_1
+#define RX_VCM_MODE_2
+#define RX_VCM_MODE_3
+//RX reference voltage value setting  @RX_REF
+#define RX_REF_25mV             (0<<2)                                          /* 25mV */
+#define RX_REF_49mV             (1<<2)                                          /* 49mV */
+#define RX_REF_74mV             (2<<2)                                          /* 74mV */
+#define RX_REF_98mV             (3<<2)                                          /* 98mV */
+#define RX_REF_123mV            (4<<2)                                          /* 123mV */
+#define RX_REF_148mV            (5<<2)                                          /* 148mV */
+#define RX_REF_173mV            (6<<2)                                          /* 173mV */
+#define RX_REF_198mV            (7<<2)                                          /* 198mV */
+//TX DRIVER Bias Current  @TX_AMP
+#define TX_AMP_0                (0<<0)                                          /* 43mA   / 14.5mA   (1.4V/0.7V) */
+#define TX_AMP_1                (1<<0)                                          /* 53.1mA / 18mA     (1.8V/0.9V) */
+#define TX_AMP_2                (2<<0)                                          /* 75.6mA / 25.6mA   (2.6V/1.3V) */
+#define TX_AMP_3                (3<<0)                                          /* 122mA  / 41.45mA  (4.1V/2.3V) */
+//FCEN pause frame control      @FCEN
+#define FCEN_0_TIMER            (3<<4)                                          /* Send a 0 timer pause frame, then stop sending */
+#define FCEN_CYCLE              (2<<4)                                          /* Periodically send pause frames */
+#define FCEN_ONCE               (1<<4)                                          /* Send pause frame once, then stop sending */
+#define FCEN_STOP               (0<<4)                                          /* Stop sending pause frames */
+//PADCFG short packet control  @PADCFG
+#define PADCFG_AUTO_0           (7<<5)                                          /* All short packets are filled with 00h to 64 bytes, then 4 bytes crc */
+#define PADCFG_NO_ACT_0         (6<<5)                                          /* No padding for short packets */
+/* The detected VLAN network packet whose field is 8100h is automatically filled
+with 00h to 64 bytes, otherwise the short packet is filled with 60 bytes of 0, and then 4 bytes of crc after filling */
+#define PADCFG_DETE_AUTO        (5<<5)
+#define PADCFG_NO_ACT_1         (4<<5)                                          /* No padding for short packets */
+#define PADCFG_AUTO_1           (3<<5)                                          /* All short packets are filled with 00h to 64 bytes, then 4 bytes crc */
+#define PADCFG_NO_ACT_2         (2<<5)                                          /* No padding for short packets */
+#define PADCFG_AUTO_3           (1<<5)                                          /* All short packets are filled with 00h to 60 bytes, and then 4 bytes crc */
+#define PADCFG_NO_ACT_3         (0<<5)                                          /* No padding for short packets */
+
+/* Bit or field definition for PHY basic status register */
+#define PHY_Linked_Status       ((uint16_t)0x0004)      /* Valid link established */
+
+#define PHY_Reset                               ((uint16_t)0x8000)      /* PHY Reset */
+
+#define PHY_AutoNego_Complete                   ((uint16_t)0x0020)      /* Auto-Negotioation process completed */
+
+//MII control
+#define  RB_ETH_MIREGADR_MIIWR  0x20                                            /* WO MII write command */
+#define  RB_ETH_MIREGADR_MIRDL  0x1f                                            /* RW PHY register address */
+
+#endif // defined(CH32V20x)
+#endif // defined(CH32V20x) || defined(CH32V30x)
 
 #ifdef __cplusplus
 }
@@ -2427,32 +7045,6 @@ typedef struct
 
 #endif /* __CH32V00x_H */
 
-
-
-
-
-
-
-/*
- * This file contains the contents of various parts of the evt.
- * 
- * The collection of this file was generated by cnlohr, 2023-02-18
- *
- * Contents subject to below copyright where applicable by law. 
- *
- * (IANAL, BUT Because it is an interface, it is unlikely protected by copyright)
- *
- *********************************** (C) COPYRIGHT *******************************
- * File Name          : ------------------
- * Author             : WCH
- * Version            : V1.0.0
- * Date               : 2020/08/08
- * Description        : Library configuration file.
-*********************************************************************************
-* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
-*******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H
 
@@ -2465,6 +7057,9 @@ extern "C" {
 
 /* ch32v00x_gpio.c -----------------------------------------------------------*/
 /* MASK */
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ECR_PORTPINCONFIG_MASK    ((uint16_t)0xFF80)
+#endif
 #define LSB_MASK                  ((uint16_t)0xFFFF)
 #define DBGAFR_POSITION_MASK      ((uint32_t)0x000F0000)
 #define DBGAFR_SDI_MASK           ((uint32_t)0xF8FFFFFF)
@@ -2473,6 +7068,7 @@ extern "C" {
 
 
 /* ch32v00x_adc.c ------------------------------------------------------------*/
+
 /* ADC DISCNUM mask */
 #define CTLR1_DISCNUM_Reset              ((uint32_t)0xFFFF1FFF)
 
@@ -2566,6 +7162,73 @@ extern "C" {
 /* ADC IDATARx registers offset */
 #define IDATAR_Offset                    ((uint8_t)0x28)
 
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* ADC1 RDATAR register base address */
+#define RDATAR_ADDRESS                   ((uint32_t)0x4001244C)
+
+/* ch32v20x_bkp.c ------------------------------------------------------------*/
+#define OCTLR_CAL_MASK    ((uint16_t)0xFF80)
+#define OCTLR_MASK        ((uint16_t)0xFC7F)
+
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+/* ch32v20x_can.c ------------------------------------------------------------*/
+/* CAN CTLR Register bits */
+#define CTLR_DBF                     ((uint32_t)0x00010000)
+
+/* CAN Mailbox Transmit Request */
+#define TMIDxR_TXRQ                  ((uint32_t)0x00000001)
+
+/* CAN FCTLR Register bits */
+#define FCTLR_FINIT                  ((uint32_t)0x00000001)
+
+/* Time out for INAK bit */
+#define INAK_TIMEOUT                 ((uint32_t)0x0000FFFF)
+/* Time out for SLAK bit */
+#define SLAK_TIMEOUT                 ((uint32_t)0x0000FFFF)
+
+
+/* Flags in TSTATR register */
+#define CAN_FLAGS_TSTATR             ((uint32_t)0x08000000)
+/* Flags in RFIFO1 register */
+#define CAN_FLAGS_RFIFO1             ((uint32_t)0x04000000)
+/* Flags in RFIFO0 register */
+#define CAN_FLAGS_RFIFO0             ((uint32_t)0x02000000)
+/* Flags in STATR register */
+#define CAN_FLAGS_STATR              ((uint32_t)0x01000000)
+/* Flags in ERRSR register */
+#define CAN_FLAGS_ERRSR              ((uint32_t)0x00F00000)
+
+/* Mailboxes definition */
+#define CAN_TXMAILBOX_0              ((uint8_t)0x00)
+#define CAN_TXMAILBOX_1              ((uint8_t)0x01)
+#define CAN_TXMAILBOX_2              ((uint8_t)0x02)
+
+
+#define CAN_MODE_MASK                ((uint32_t) 0x00000003)
+
+#endif
+
+#if defined(CH32V30x)
+/* ch32v30x_dac.c ------------------------------------------------------------*/
+/* CTLR register Mask */
+// Editor's note: Overloaded Definition.
+#define DAC_CTLR_CLEAR_MASK    ((uint32_t)0x00000FFE)
+
+/* DAC Dual Channels SWTR masks */
+#define DUAL_SWTR_SET      		((uint32_t)0x00000003)
+#define DUAL_SWTR_RESET    		((uint32_t)0xFFFFFFFC)
+
+/* DHR registers offsets */
+#define DHR12R1_OFFSET     		((uint32_t)0x00000008)
+#define DHR12R2_OFFSET     		((uint32_t)0x00000014)
+#define DHR12RD_OFFSET     		((uint32_t)0x00000020)
+
+/* DOR register offset */
+#define DOR_OFFSET         		((uint32_t)0x0000002C)
+#endif
 
 /* ch32v00x_dbgmcu.c ---------------------------------------------------------*/
 #define IDCODE_DEVID_MASK    ((uint32_t)0x0000FFFF)
@@ -2581,10 +7244,33 @@ extern "C" {
 #define DMA1_Channel5_IT_Mask    ((uint32_t)(DMA_GIF5 | DMA_TCIF5 | DMA_HTIF5 | DMA_TEIF5))
 #define DMA1_Channel6_IT_Mask    ((uint32_t)(DMA_GIF6 | DMA_TCIF6 | DMA_HTIF6 | DMA_TEIF6))
 #define DMA1_Channel7_IT_Mask    ((uint32_t)(DMA_GIF7 | DMA_TCIF7 | DMA_HTIF7 | DMA_TEIF7))
+#if defined(CH32V20x)
+#define DMA1_Channel8_IT_Mask    ((uint32_t)(DMA_GIF8 | DMA_TCIF8 | DMA_HTIF8 | DMA_TEIF8))
+#endif
+
+#if defined(CH32V30x)
+/* DMA2 Channelx interrupt pending bit masks */
+#define DMA2_Channel1_IT_Mask     ((uint32_t)(DMA_GIF1 | DMA_TCIF1 | DMA_HTIF1 | DMA_TEIF1))
+#define DMA2_Channel2_IT_Mask     ((uint32_t)(DMA_GIF2 | DMA_TCIF2 | DMA_HTIF2 | DMA_TEIF2))
+#define DMA2_Channel3_IT_Mask     ((uint32_t)(DMA_GIF3 | DMA_TCIF3 | DMA_HTIF3 | DMA_TEIF3))
+#define DMA2_Channel4_IT_Mask     ((uint32_t)(DMA_GIF4 | DMA_TCIF4 | DMA_HTIF4 | DMA_TEIF4))
+#define DMA2_Channel5_IT_Mask     ((uint32_t)(DMA_GIF5 | DMA_TCIF5 | DMA_HTIF5 | DMA_TEIF5))
+#endif
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DMA2_Channel6_IT_Mask     ((uint32_t)(DMA_GIF6 | DMA_TCIF6 | DMA_HTIF6 | DMA_TEIF6))
+#define DMA2_Channel7_IT_Mask     ((uint32_t)(DMA_GIF7 | DMA_TCIF7 | DMA_HTIF7 | DMA_TEIF7))
+#define DMA2_Channel8_IT_Mask     ((uint32_t)(DMA_GIF8 | DMA_TCIF8 | DMA_HTIF8 | DMA_TEIF8))
+#define DMA2_Channel9_IT_Mask     ((uint32_t)(DMA_GIF9 | DMA_TCIF9 | DMA_HTIF9 | DMA_TEIF9))
+#define DMA2_Channel10_IT_Mask    ((uint32_t)(DMA_GIF10 | DMA_TCIF10 | DMA_HTIF10 | DMA_TEIF10))
+#define DMA2_Channel11_IT_Mask    ((uint32_t)(DMA_GIF11 | DMA_TCIF11 | DMA_HTIF11 | DMA_TEIF11))
+#endif
 
 /* DMA2 FLAG mask */
 // Editor's note: Overloaded Definition.
-#define DMA2_FLAG_Mask                ((uint32_t)0x10000000)
+#define DMA2_FLAG_Mask            ((uint32_t)0x10000000)
+#if defined(CH32V30x)
+#define DMA2_EXTEN_FLAG_Mask      ((uint32_t)0x20000000)
+#endif
 
 /* DMA registers Masks */
 #define CFGR_CLEAR_Mask          ((uint32_t)0xFFFF800F)
@@ -2597,8 +7283,16 @@ extern "C" {
 
 /* ch32v00x_flash.c ----------------------------------------------------------*/
 
+#if defined(CH32V003) || defined(CH32V10x)
 /* Flash Access Control Register bits */
 #define ACR_LATENCY_Mask           ((uint32_t)0x00000038)
+#endif
+
+#if defined(CH32V10x)
+#define ACR_HLFCYA_Mask            ((uint32_t)0xFFFFFFF7)
+#define ACR_PRFTBE_Mask            ((uint32_t)0xFFFFFFEF)
+#define ACR_PRFTBS_Mask            ((uint32_t)0x00000020)
+#endif
 
 /* Flash Control Register bits */
 #define CR_PG_Set                  ((uint32_t)0x00000001)
@@ -2613,13 +7307,28 @@ extern "C" {
 #define CR_OPTER_Reset             ((uint32_t)0xFFFFFFDF)
 #define CR_STRT_Set                ((uint32_t)0x00000040)
 #define CR_LOCK_Set                ((uint32_t)0x00000080)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define CR_FAST_LOCK_Set           ((uint32_t)0x00008000)
+#endif
 #define CR_PAGE_PG                 ((uint32_t)0x00010000)
 #define CR_PAGE_ER                 ((uint32_t)0x00020000)
+#if defined(CH32V003) || defined(CH32V10x)
 #define CR_BUF_LOAD                ((uint32_t)0x00040000)
 #define CR_BUF_RST                 ((uint32_t)0x00080000)
+#elif defined(CH32V20x) || defined(CH32V30x)
+#define CR_BER32                   ((uint32_t)0x00040000)
+#define CR_BER64                   ((uint32_t)0x00080000)
+#define CR_PG_STRT                 ((uint32_t)0x00200000)
+#endif
 
 /* FLASH Status Register bits */
 #define SR_BSY                     ((uint32_t)0x00000001)
+#if defined(CH32V20x) || defined(CH32V30x)
+#define SR_WR_BSY                  ((uint32_t)0x00000002)
+#endif
+#if defined(CH32V10x)
+#define SR_PGERR                   ((uint32_t)0x00000004)
+#endif
 #define SR_WRPRTERR                ((uint32_t)0x00000010)
 #define SR_EOP                     ((uint32_t)0x00000020)
 
@@ -2629,6 +7338,9 @@ extern "C" {
 #define WRP1_Mask                  ((uint32_t)0x0000FF00)
 #define WRP2_Mask                  ((uint32_t)0x00FF0000)
 #define WRP3_Mask                  ((uint32_t)0xFF000000)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define OB_USER_BFB2               ((uint16_t)0x0008)
+#endif
 
 /* FLASH Keys */
 #define RDP_Key                    ((uint16_t)0x00A5)
@@ -2638,13 +7350,44 @@ extern "C" {
 /* FLASH BANK address */
 #define FLASH_BANK1_END_ADDRESS    ((uint32_t)0x807FFFF)
 
+#if defined(CH32V20x)
+/* EEPROM address */
+#define EEPROM_ADDRESS             ((uint32_t)0x8070000)
+#endif
+
 /* Delay definition */
 #define EraseTimeout               ((uint32_t)0x000B0000)
+#if defined(CH32V003) || defined(CH32V20x) || defined(CH32V10x)
 #define ProgramTimeout             ((uint32_t)0x00002000)
+#elif defined(CH32V30x)
+#define ProgramTimeout             ((uint32_t)0x00005000)
+#endif
 
-/* Flash Program Vaild Address */
+/* Flash Program Valid Address */
 #define ValidAddrStart             (FLASH_BASE)
+#if !defined(CH32V10x)
 #define ValidAddrEnd               (FLASH_BASE + 0x4000)
+#else
+#define ValidAddrEnd               (FLASH_BASE + 0x10000)
+#endif
+
+#if defined(CH32V30x)
+
+/* ch32v30x_fsmc.c -----------------------------------------------------------*/
+
+/* FSMC BCRx Mask */
+#define BCR_MBKEN_Set          ((uint32_t)0x00000001)
+#define BCR_MBKEN_Reset        ((uint32_t)0x000FFFFE)
+#define BCR_FACCEN_Set         ((uint32_t)0x00000040)
+
+/* FSMC PCRx Mask */
+#define PCR_PBKEN_Set          ((uint32_t)0x00000004)
+#define PCR_PBKEN_Reset        ((uint32_t)0x000FFFFB)
+#define PCR_ECCEN_Set          ((uint32_t)0x00000040)
+#define PCR_ECCEN_Reset        ((uint32_t)0x000FFFBF)
+#define PCR_MemoryType_NAND    ((uint32_t)0x00000008)
+
+#endif
 
 /* ch32v00x_i2c.c ------------------------------------------------------------*/
 
@@ -2723,7 +7466,7 @@ extern "C" {
 
 /* I2C FLAG mask */
 //Editor's Note: Overloaded Definition
-#define I2c_FLAG_Mask                ((uint32_t)0x00FFFFFF)
+#define I2c_FLAG_Mask            ((uint32_t)0x00FFFFFF)
 
 /* I2C Interrupt Enable mask */
 #define ITEN_Mask                ((uint32_t)0x07000000)
@@ -2734,15 +7477,29 @@ extern "C" {
 #define CTLR_KEY_Reload    ((uint16_t)0xAAAA)
 #define CTLR_KEY_Enable    ((uint16_t)0xCCCC)
 
+#if defined(CH32V20x) || defined(CH32V30x)
+
+/* ch32v20x_opa.c ------------------------------------------------------------*/
+#define OPA_MASK         ((uint32_t)0x000F)
+#define OPA_Total_NUM    4
+
+#endif
+
 /* ch32v00x_pwr.c ------------------------------------------------------------*/
 
 
 /* PWR registers bit mask */
 /* CTLR register bit mask */
+#if !defined(CH32V10x)
 #define CTLR_DS_MASK     ((uint32_t)0xFFFFFFFD)
+#else
+#define CTLR_DS_MASK     ((uint32_t)0xFFFFFFFC)
+#endif
 #define CTLR_PLS_MASK    ((uint32_t)0xFFFFFF1F)
+#if defined(CH32V003)
 #define AWUPSC_MASK      ((uint32_t)0xFFFFFFF0)
 #define AWUWR_MASK       ((uint32_t)0xFFFFFFC0)
+#endif
 
 /* ch32v00x_rcc.c ------------------------------------------------------------*/
 
@@ -2779,6 +7536,15 @@ extern "C" {
 /* RSTSCKR register bit mask */
 #define RSTSCKR_RMVF_Set           ((uint32_t)0x01000000)
 
+#if defined(CH32V30x)
+/* CFGR2 register bit mask */
+#define CFGR2_PREDIV1SRC           ((uint32_t)0x00010000)
+#define CFGR2_PREDIV1              ((uint32_t)0x0000000F)
+#define CFGR2_PREDIV2              ((uint32_t)0x000000F0)
+#define CFGR2_PLL2MUL              ((uint32_t)0x00000F00)
+#define CFGR2_PLL3MUL              ((uint32_t)0x0000F000)
+#endif
+
 /* RCC Flag Mask */
 //Editor's Note: Overloaded Definition
 #define RCC_FLAG_Mask                  ((uint8_t)0x1F)
@@ -2795,16 +7561,60 @@ extern "C" {
 /* BDCTLR register base address */
 #define BDCTLR_ADDRESS             (PERIPH_BASE + BDCTLR_OFFSET)
 
+#ifndef __ASSEMBLER__
+#ifdef CH32V003
 static __I uint8_t APBAHBPrescTable[16] = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
 static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32, 16, 32, 48, 64, 32, 64, 96, 128};
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+static __I uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+static __I uint8_t ADCPrescTable[4] = {2, 4, 6, 8};
+#endif
+#endif
 
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* ch32v20x_rtc.c ------------------------------------------------------------*/
+
+/* RTC_Private_Defines */
+#define RTC_LSB_MASK     ((uint32_t)0x0000FFFF) /* RTC LSB Mask */
+#define PRLH_MSB_MASK    ((uint32_t)0x000F0000) /* RTC Prescaler MSB Mask */
+
+#endif
+
+#if defined(CH32V30x)
+
+/* ch32v00x_sdio.c -----------------------------------------------------------*/
+
+#define SDIO_OFFSET         (SDIO_BASE - PERIPH_BASE)
+
+/* CLKCR register clear mask */
+#define CLKCR_CLEAR_MASK    ((uint32_t)0xFFFF8100)
+
+/* SDIO PWRCTRL Mask */
+#define PWR_PWRCTRL_MASK    ((uint32_t)0xFFFFFFFC)
+
+/* SDIO DCTRL Clear Mask */
+#define DCTRL_CLEAR_MASK    ((uint32_t)0xFFFFFF08)
+
+/* CMD Register clear mask */
+#define CMD_CLEAR_MASK      ((uint32_t)0xFFFFF800)
+
+/* SDIO RESP Registers Address */
+#define SDIO_RESP_ADDR      ((uint32_t)(SDIO_BASE + 0x14))
+
+#endif // defined(CH32V30x)
 
 /* ch32v00x_spi.c ------------------------------------------------------------*/
-
 
 /* SPI SPE mask */
 #define CTLR1_SPE_Set         ((uint16_t)0x0040)
 #define CTLR1_SPE_Reset       ((uint16_t)0xFFBF)
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/* I2S I2SE mask */
+#define I2SCFGR_I2SE_Set      ((uint16_t)0x0400)
+#define I2SCFGR_I2SE_Reset    ((uint16_t)0xFBFF)
+#endif
 
 /* SPI CRCNext mask */
 #define CTLR1_CRCNext_Set     ((uint16_t)0x1000)
@@ -2819,8 +7629,20 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 
 /* SPI registers Masks */
 //Editor's Note: Overloaded Definition
-#define SPI_CTLR1_CLEAR_Mask      ((uint16_t)0x3040)
+#define SPI_CTLR1_CLEAR_Mask  ((uint16_t)0x3040)
 #define I2SCFGR_CLEAR_Mask    ((uint16_t)0xF040)
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+/* SPI or I2S mode selection masks */
+#define SPI_Mode_Select       ((uint16_t)0xF7FF)
+#define I2S_Mode_Select       ((uint16_t)0x0800)
+
+/* I2S clock source selection masks */
+#define I2S2_CLOCK_SRC        ((uint32_t)(0x00020000))
+#define I2S3_CLOCK_SRC        ((uint32_t)(0x00040000))
+#define I2S_MUL_MASK          ((uint32_t)(0x0000F000))
+#define I2S_DIV_MASK          ((uint32_t)(0x000000F0))
+#endif
 
 
 /* ch32v00x_tim.c ------------------------------------------------------------*/
@@ -2881,7 +7703,6 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 
 /* ch32v00x_wwdg.c ------------------------------------------------------------*/
 
-
 /* CTLR register bit mask */
 #define CTLR_WDGA_Set      ((uint32_t)0x00000080)
 
@@ -2893,12 +7714,23 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 
 /* ch32v00x_adc.h ------------------------------------------------------------*/
 
-
-
 /* ADC_mode */
 #define ADC_Mode_Independent                           ((uint32_t)0x00000000)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC_Mode_RegInjecSimult                        ((uint32_t)0x00010000)
+#define ADC_Mode_RegSimult_AlterTrig                   ((uint32_t)0x00020000)
+#define ADC_Mode_InjecSimult_FastInterl                ((uint32_t)0x00030000)
+#define ADC_Mode_InjecSimult_SlowInterl                ((uint32_t)0x00040000)
+#define ADC_Mode_InjecSimult                           ((uint32_t)0x00050000)
+#define ADC_Mode_RegSimult                             ((uint32_t)0x00060000)
+#define ADC_Mode_FastInterl                            ((uint32_t)0x00070000)
+#define ADC_Mode_SlowInterl                            ((uint32_t)0x00080000)
+#define ADC_Mode_AlterTrig                             ((uint32_t)0x00090000)
+#endif
 
 /* ADC_external_trigger_sources_for_regular_channels_conversion */
+#ifdef CH32V003
+
 #define ADC_ExternalTrigConv_T1_TRGO                   ((uint32_t)0x00000000)
 #define ADC_ExternalTrigConv_T1_CC1                    ((uint32_t)0x00020000)
 #define ADC_ExternalTrigConv_T1_CC2                    ((uint32_t)0x00040000)
@@ -2907,6 +7739,31 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 #define ADC_ExternalTrigConv_T2_CC2                    ((uint32_t)0x000A0000)
 #define ADC_ExternalTrigConv_Ext_PD3_PC2               ((uint32_t)0x000C0000)
 #define ADC_ExternalTrigConv_None                      ((uint32_t)0x000E0000)
+
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+#define ADC_ExternalTrigConv_T1_CC1                    ((uint32_t)0x00000000)
+#define ADC_ExternalTrigConv_T1_CC2                    ((uint32_t)0x00020000)
+#define ADC_ExternalTrigConv_T2_CC2                    ((uint32_t)0x00060000)
+#define ADC_ExternalTrigConv_T3_TRGO                   ((uint32_t)0x00080000)
+#define ADC_ExternalTrigConv_T4_CC4                    ((uint32_t)0x000A0000)
+#define ADC_ExternalTrigConv_Ext_IT11_TIM8_TRGO        ((uint32_t)0x000C0000)
+
+#define ADC_ExternalTrigConv_T1_CC3                    ((uint32_t)0x00040000)
+#define ADC_ExternalTrigConv_None                      ((uint32_t)0x000E0000)
+
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+
+#define ADC_ExternalTrigConv_T3_CC1                    ((uint32_t)0x00000000)
+#define ADC_ExternalTrigConv_T2_CC3                    ((uint32_t)0x00020000)
+#define ADC_ExternalTrigConv_T8_CC1                    ((uint32_t)0x00060000)
+#define ADC_ExternalTrigConv_T8_TRGO                   ((uint32_t)0x00080000)
+#define ADC_ExternalTrigConv_T5_CC1                    ((uint32_t)0x000A0000)
+#define ADC_ExternalTrigConv_T5_CC3                    ((uint32_t)0x000C0000)
+
+#endif
 
 /* ADC_data_align */
 #define ADC_DataAlign_Right                            ((uint32_t)0x00000000)
@@ -2923,11 +7780,39 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 #define ADC_Channel_7                                  ((uint8_t)0x07)
 #define ADC_Channel_8                                  ((uint8_t)0x08)
 #define ADC_Channel_9                                  ((uint8_t)0x09)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC_Channel_10                                 ((uint8_t)0x0A)
+#define ADC_Channel_11                                 ((uint8_t)0x0B)
+#define ADC_Channel_12                                 ((uint8_t)0x0C)
+#define ADC_Channel_13                                 ((uint8_t)0x0D)
+#define ADC_Channel_14                                 ((uint8_t)0x0E)
+#define ADC_Channel_15                                 ((uint8_t)0x0F)
+#define ADC_Channel_16                                 ((uint8_t)0x10)
+#define ADC_Channel_17                                 ((uint8_t)0x11)
+#endif
 
+#ifdef CH32V003
 #define ADC_Channel_Vrefint                            ((uint8_t)ADC_Channel_8)
 #define ADC_Channel_Vcalint                            ((uint8_t)ADC_Channel_9)
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC_Channel_TempSensor                         ((uint8_t)ADC_Channel_16)
+#define ADC_Channel_Vrefint                            ((uint8_t)ADC_Channel_17)
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+/*ADC_output_buffer*/
+#define ADC_OutputBuffer_Enable                        ((uint32_t)0x04000000)
+#define ADC_OutputBuffer_Disable                       ((uint32_t)0x00000000)
+
+/*ADC_pga*/
+#define ADC_Pga_1                                      ((uint32_t)0x00000000)
+#define ADC_Pga_4                                      ((uint32_t)0x08000000)
+#define ADC_Pga_16                                     ((uint32_t)0x10000000)
+#define ADC_Pga_64                                     ((uint32_t)0x18000000)
+#endif
 
 /* ADC_sampling_time */
+#ifdef CH32V003
 #define ADC_SampleTime_3Cycles                         ((uint8_t)0x00)
 #define ADC_SampleTime_9Cycles                         ((uint8_t)0x01)
 #define ADC_SampleTime_15Cycles                        ((uint8_t)0x02)
@@ -2936,14 +7821,44 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 #define ADC_SampleTime_57Cycles                        ((uint8_t)0x05)
 #define ADC_SampleTime_73Cycles                        ((uint8_t)0x06)
 #define ADC_SampleTime_241Cycles                       ((uint8_t)0x07)
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC_SampleTime_1Cycles5                        ((uint8_t)0x00)
+#define ADC_SampleTime_7Cycles5                        ((uint8_t)0x01)
+#define ADC_SampleTime_13Cycles5                       ((uint8_t)0x02)
+#define ADC_SampleTime_28Cycles5                       ((uint8_t)0x03)
+#define ADC_SampleTime_41Cycles5                       ((uint8_t)0x04)
+#define ADC_SampleTime_55Cycles5                       ((uint8_t)0x05)
+#define ADC_SampleTime_71Cycles5                       ((uint8_t)0x06)
+#define ADC_SampleTime_239Cycles5                      ((uint8_t)0x07)
+#endif
 
 /* ADC_external_trigger_sources_for_injected_channels_conversion */
+#ifdef CH32V003
 #define ADC_ExternalTrigInjecConv_T1_CC3               ((uint32_t)0x00000000)
 #define ADC_ExternalTrigInjecConv_T1_CC4               ((uint32_t)0x00001000)
 #define ADC_ExternalTrigInjecConv_T2_CC3               ((uint32_t)0x00002000)
 #define ADC_ExternalTrigInjecConv_T2_CC4               ((uint32_t)0x00003000)
 #define ADC_ExternalTrigInjecConv_Ext_PD1_PA2          ((uint32_t)0x00006000)
 #define ADC_ExternalTrigInjecConv_None                 ((uint32_t)0x00007000)
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define ADC_ExternalTrigInjecConv_T2_TRGO              ((uint32_t)0x00002000)
+#define ADC_ExternalTrigInjecConv_T2_CC1               ((uint32_t)0x00003000)
+#define ADC_ExternalTrigInjecConv_T3_CC4               ((uint32_t)0x00004000)
+#define ADC_ExternalTrigInjecConv_T4_TRGO              ((uint32_t)0x00005000)
+#define ADC_ExternalTrigInjecConv_Ext_IT15_TIM8_CC4    ((uint32_t)0x00006000)
+
+#define ADC_ExternalTrigInjecConv_T1_TRGO              ((uint32_t)0x00000000)
+#define ADC_ExternalTrigInjecConv_T1_CC4               ((uint32_t)0x00001000)
+#define ADC_ExternalTrigInjecConv_None                 ((uint32_t)0x00007000)
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+#define ADC_ExternalTrigInjecConv_T4_CC3               ((uint32_t)0x00002000)
+#define ADC_ExternalTrigInjecConv_T8_CC2               ((uint32_t)0x00003000)
+#define ADC_ExternalTrigInjecConv_T8_CC4               ((uint32_t)0x00004000)
+#define ADC_ExternalTrigInjecConv_T5_TRGO              ((uint32_t)0x00005000)
+#define ADC_ExternalTrigInjecConv_T5_CC4               ((uint32_t)0x00006000)
+#endif
 
 /* ADC_injected_channel_selection */
 #define ADC_InjectedChannel_1                          ((uint8_t)0x14)
@@ -2972,6 +7887,7 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 #define ADC_FLAG_JSTRT                                 ((uint8_t)0x08)
 #define ADC_FLAG_STRT                                  ((uint8_t)0x10)
 
+#if defined(CH32V003)
 /* ADC_calibration_voltage_definition */
 #define ADC_CALVOL_50PERCENT                           ((uint32_t)0x02000000)
 #define ADC_CALVOL_75PERCENT                           ((uint32_t)0x04000000)
@@ -2979,16 +7895,360 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 /* ADC_external_trigger_sources_delay_channels_definition */
 #define ADC_ExternalTrigRegul_DLY                      ((uint32_t)0x00000000)
 #define ADC_ExternalTrigInjec_DLY                      ((uint32_t)0x00020000)
+#endif
+
+#if defined(CH32V10x) || defined(CH32V20x)
+
+/* ch32v20x_bkp.h ------------------------------------------------------------*/
+
+/* Tamper_Pin_active_level */
+#define BKP_TamperPinLevel_High           ((uint16_t)0x0000)
+#define BKP_TamperPinLevel_Low            ((uint16_t)0x0001)
+
+/* RTC_output_source_to_output_on_the_Tamper_pin */
+#define BKP_RTCOutputSource_None          ((uint16_t)0x0000)
+#define BKP_RTCOutputSource_CalibClock    ((uint16_t)0x0080)
+#define BKP_RTCOutputSource_Alarm         ((uint16_t)0x0100)
+#define BKP_RTCOutputSource_Second        ((uint16_t)0x0300)
+
+/* Data_Backup_Register */
+#define BKP_DR1                           ((uint16_t)0x0004)
+#define BKP_DR2                           ((uint16_t)0x0008)
+#define BKP_DR3                           ((uint16_t)0x000C)
+#define BKP_DR4                           ((uint16_t)0x0010)
+#define BKP_DR5                           ((uint16_t)0x0014)
+#define BKP_DR6                           ((uint16_t)0x0018)
+#define BKP_DR7                           ((uint16_t)0x001C)
+#define BKP_DR8                           ((uint16_t)0x0020)
+#define BKP_DR9                           ((uint16_t)0x0024)
+#define BKP_DR10                          ((uint16_t)0x0028)
+#define BKP_DR11                          ((uint16_t)0x0040)
+#define BKP_DR12                          ((uint16_t)0x0044)
+#define BKP_DR13                          ((uint16_t)0x0048)
+#define BKP_DR14                          ((uint16_t)0x004C)
+#define BKP_DR15                          ((uint16_t)0x0050)
+#define BKP_DR16                          ((uint16_t)0x0054)
+#define BKP_DR17                          ((uint16_t)0x0058)
+#define BKP_DR18                          ((uint16_t)0x005C)
+#define BKP_DR19                          ((uint16_t)0x0060)
+#define BKP_DR20                          ((uint16_t)0x0064)
+#define BKP_DR21                          ((uint16_t)0x0068)
+#define BKP_DR22                          ((uint16_t)0x006C)
+#define BKP_DR23                          ((uint16_t)0x0070)
+#define BKP_DR24                          ((uint16_t)0x0074)
+#define BKP_DR25                          ((uint16_t)0x0078)
+#define BKP_DR26                          ((uint16_t)0x007C)
+#define BKP_DR27                          ((uint16_t)0x0080)
+#define BKP_DR28                          ((uint16_t)0x0084)
+#define BKP_DR29                          ((uint16_t)0x0088)
+#define BKP_DR30                          ((uint16_t)0x008C)
+#define BKP_DR31                          ((uint16_t)0x0090)
+#define BKP_DR32                          ((uint16_t)0x0094)
+#define BKP_DR33                          ((uint16_t)0x0098)
+#define BKP_DR34                          ((uint16_t)0x009C)
+#define BKP_DR35                          ((uint16_t)0x00A0)
+#define BKP_DR36                          ((uint16_t)0x00A4)
+#define BKP_DR37                          ((uint16_t)0x00A8)
+#define BKP_DR38                          ((uint16_t)0x00AC)
+#define BKP_DR39                          ((uint16_t)0x00B0)
+#define BKP_DR40                          ((uint16_t)0x00B4)
+#define BKP_DR41                          ((uint16_t)0x00B8)
+#define BKP_DR42                          ((uint16_t)0x00BC)
+
+#endif
+
+#if defined(CH32V20x)
+
+/* ch32v20x_can.h ------------------------------------------------------------*/
+
+/* CAN_sleep_constants */
+#define CAN_InitStatus_Failed               ((uint8_t)0x00) /* CAN initialization failed */
+#define CAN_InitStatus_Success              ((uint8_t)0x01) /* CAN initialization OK */
+
+/* CAN_Mode */
+#define CAN_Mode_Normal                     ((uint8_t)0x00) /* normal mode */
+#define CAN_Mode_LoopBack                   ((uint8_t)0x01) /* loopback mode */
+#define CAN_Mode_Silent                     ((uint8_t)0x02) /* silent mode */
+#define CAN_Mode_Silent_LoopBack            ((uint8_t)0x03) /* loopback combined with silent mode */
+
+/* CAN_Operating_Mode */
+#define CAN_OperatingMode_Initialization    ((uint8_t)0x00) /* Initialization mode */
+#define CAN_OperatingMode_Normal            ((uint8_t)0x01) /* Normal mode */
+#define CAN_OperatingMode_Sleep             ((uint8_t)0x02) /* sleep mode */
+
+/* CAN_Mode_Status */
+#define CAN_ModeStatus_Failed               ((uint8_t)0x00)                   /* CAN entering the specific mode failed */
+#define CAN_ModeStatus_Success              ((uint8_t)!CAN_ModeStatus_Failed) /* CAN entering the specific mode Succeed */
+
+/* CAN_synchronisation_jump_width */
+#define CAN_SJW_1tq                         ((uint8_t)0x00) /* 1 time quantum */
+#define CAN_SJW_2tq                         ((uint8_t)0x01) /* 2 time quantum */
+#define CAN_SJW_3tq                         ((uint8_t)0x02) /* 3 time quantum */
+#define CAN_SJW_4tq                         ((uint8_t)0x03) /* 4 time quantum */
+
+/* CAN_time_quantum_in_bit_segment_1 */
+#define CAN_BS1_1tq                         ((uint8_t)0x00) /* 1 time quantum */
+#define CAN_BS1_2tq                         ((uint8_t)0x01) /* 2 time quantum */
+#define CAN_BS1_3tq                         ((uint8_t)0x02) /* 3 time quantum */
+#define CAN_BS1_4tq                         ((uint8_t)0x03) /* 4 time quantum */
+#define CAN_BS1_5tq                         ((uint8_t)0x04) /* 5 time quantum */
+#define CAN_BS1_6tq                         ((uint8_t)0x05) /* 6 time quantum */
+#define CAN_BS1_7tq                         ((uint8_t)0x06) /* 7 time quantum */
+#define CAN_BS1_8tq                         ((uint8_t)0x07) /* 8 time quantum */
+#define CAN_BS1_9tq                         ((uint8_t)0x08) /* 9 time quantum */
+#define CAN_BS1_10tq                        ((uint8_t)0x09) /* 10 time quantum */
+#define CAN_BS1_11tq                        ((uint8_t)0x0A) /* 11 time quantum */
+#define CAN_BS1_12tq                        ((uint8_t)0x0B) /* 12 time quantum */
+#define CAN_BS1_13tq                        ((uint8_t)0x0C) /* 13 time quantum */
+#define CAN_BS1_14tq                        ((uint8_t)0x0D) /* 14 time quantum */
+#define CAN_BS1_15tq                        ((uint8_t)0x0E) /* 15 time quantum */
+#define CAN_BS1_16tq                        ((uint8_t)0x0F) /* 16 time quantum */
+
+/* CAN_time_quantum_in_bit_segment_2 */
+#define CAN_BS2_1tq                         ((uint8_t)0x00) /* 1 time quantum */
+#define CAN_BS2_2tq                         ((uint8_t)0x01) /* 2 time quantum */
+#define CAN_BS2_3tq                         ((uint8_t)0x02) /* 3 time quantum */
+#define CAN_BS2_4tq                         ((uint8_t)0x03) /* 4 time quantum */
+#define CAN_BS2_5tq                         ((uint8_t)0x04) /* 5 time quantum */
+#define CAN_BS2_6tq                         ((uint8_t)0x05) /* 6 time quantum */
+#define CAN_BS2_7tq                         ((uint8_t)0x06) /* 7 time quantum */
+#define CAN_BS2_8tq                         ((uint8_t)0x07) /* 8 time quantum */
+
+/* CAN_filter_mode */
+#define CAN_FilterMode_IdMask               ((uint8_t)0x00) /* identifier/mask mode */
+#define CAN_FilterMode_IdList               ((uint8_t)0x01) /* identifier list mode */
+
+/* CAN_filter_scale */
+#define CAN_FilterScale_16bit               ((uint8_t)0x00) /* Two 16-bit filters */
+#define CAN_FilterScale_32bit               ((uint8_t)0x01) /* One 32-bit filter */
+
+/* CAN_filter_FIFO */
+#define CAN_Filter_FIFO0                    ((uint8_t)0x00) /* Filter FIFO 0 assignment for filter x */
+#define CAN_Filter_FIFO1                    ((uint8_t)0x01) /* Filter FIFO 1 assignment for filter x */
+
+/* CAN_identifier_type */
+#define CAN_Id_Standard                     ((uint32_t)0x00000000) /* Standard Id */
+#define CAN_Id_Extended                     ((uint32_t)0x00000004) /* Extended Id */
+
+/* CAN_remote_transmission_request */
+#define CAN_RTR_Data                        ((uint32_t)0x00000000) /* Data frame */
+#define CAN_RTR_Remote                      ((uint32_t)0x00000002) /* Remote frame */
+
+/* CAN_transmit_constants */
+#define CAN_TxStatus_Failed                 ((uint8_t)0x00) /* CAN transmission failed */
+#define CAN_TxStatus_Ok                     ((uint8_t)0x01) /* CAN transmission succeeded */
+#define CAN_TxStatus_Pending                ((uint8_t)0x02) /* CAN transmission pending */
+#define CAN_TxStatus_NoMailBox              ((uint8_t)0x04) /* CAN cell did not provide an empty mailbox */
+
+/* CAN_receive_FIFO_number_constants */
+#define CAN_FIFO0                           ((uint8_t)0x00) /* CAN FIFO 0 used to receive */
+#define CAN_FIFO1                           ((uint8_t)0x01) /* CAN FIFO 1 used to receive */
+
+/* CAN_sleep_constants */
+#define CAN_Sleep_Failed                    ((uint8_t)0x00) /* CAN did not enter the sleep mode */
+#define CAN_Sleep_Ok                        ((uint8_t)0x01) /* CAN entered the sleep mode */
+
+/* CAN_wake_up_constants */
+#define CAN_WakeUp_Failed                   ((uint8_t)0x00) /* CAN did not leave the sleep mode */
+#define CAN_WakeUp_Ok                       ((uint8_t)0x01) /* CAN leaved the sleep mode */
+
+/* CAN_Error_Code_constants */
+#define CAN_ErrorCode_NoErr                 ((uint8_t)0x00) /* No Error */
+#define CAN_ErrorCode_StuffErr              ((uint8_t)0x10) /* Stuff Error */
+#define CAN_ErrorCode_FormErr               ((uint8_t)0x20) /* Form Error */
+#define CAN_ErrorCode_ACKErr                ((uint8_t)0x30) /* Acknowledgment Error */
+#define CAN_ErrorCode_BitRecessiveErr       ((uint8_t)0x40) /* Bit Recessive Error */
+#define CAN_ErrorCode_BitDominantErr        ((uint8_t)0x50) /* Bit Dominant Error */
+#define CAN_ErrorCode_CRCErr                ((uint8_t)0x60) /* CRC Error  */
+#define CAN_ErrorCode_SoftwareSetErr        ((uint8_t)0x70) /* Software Set Error */
+
+/* CAN_flags */
+/* Transmit Flags */
+/* If the flag is 0x3XXXXXXX, it means that it can be used with CAN_GetFlagStatus()
+ * and CAN_ClearFlag() functions.
+ * If the flag is 0x1XXXXXXX, it means that it can only be used with CAN_GetFlagStatus() function.
+*/
+#define CAN_FLAG_RQCP0                      ((uint32_t)0x38000001) /* Request MailBox0 Flag */
+#define CAN_FLAG_RQCP1                      ((uint32_t)0x38000100) /* Request MailBox1 Flag */
+#define CAN_FLAG_RQCP2                      ((uint32_t)0x38010000) /* Request MailBox2 Flag */
+
+/* Receive Flags */
+#define CAN_FLAG_FMP0                       ((uint32_t)0x12000003) /* FIFO 0 Message Pending Flag */
+#define CAN_FLAG_FF0                        ((uint32_t)0x32000008) /* FIFO 0 Full Flag            */
+#define CAN_FLAG_FOV0                       ((uint32_t)0x32000010) /* FIFO 0 Overrun Flag         */
+#define CAN_FLAG_FMP1                       ((uint32_t)0x14000003) /* FIFO 1 Message Pending Flag */
+#define CAN_FLAG_FF1                        ((uint32_t)0x34000008) /* FIFO 1 Full Flag            */
+#define CAN_FLAG_FOV1                       ((uint32_t)0x34000010) /* FIFO 1 Overrun Flag         */
+
+/* Operating Mode Flags */
+#define CAN_FLAG_WKU                        ((uint32_t)0x31000008) /* Wake up Flag */
+#define CAN_FLAG_SLAK                       ((uint32_t)0x31000012) /* Sleep acknowledge Flag */
+/* Note:
+ *When SLAK intterupt is disabled (SLKIE=0), no polling on SLAKI is possible.
+ *In this case the SLAK bit can be polled.
+*/
 
 
+/* Error Flags */
+#define CAN_FLAG_EWG                        ((uint32_t)0x10F00001) /* Error Warning Flag   */
+#define CAN_FLAG_EPV                        ((uint32_t)0x10F00002) /* Error Passive Flag   */
+#define CAN_FLAG_BOF                        ((uint32_t)0x10F00004) /* Bus-Off Flag         */
+#define CAN_FLAG_LEC                        ((uint32_t)0x30F00070) /* Last error code Flag */
+
+/* CAN_interrupts */
+#define CAN_IT_TME                          ((uint32_t)0x00000001) /* Transmit mailbox empty Interrupt*/
+
+/* Receive Interrupts */
+#define CAN_IT_FMP0                         ((uint32_t)0x00000002) /* FIFO 0 message pending Interrupt*/
+#define CAN_IT_FF0                          ((uint32_t)0x00000004) /* FIFO 0 full Interrupt*/
+#define CAN_IT_FOV0                         ((uint32_t)0x00000008) /* FIFO 0 overrun Interrupt*/
+#define CAN_IT_FMP1                         ((uint32_t)0x00000010) /* FIFO 1 message pending Interrupt*/
+#define CAN_IT_FF1                          ((uint32_t)0x00000020) /* FIFO 1 full Interrupt*/
+#define CAN_IT_FOV1                         ((uint32_t)0x00000040) /* FIFO 1 overrun Interrupt*/
+
+/* Operating Mode Interrupts */
+#define CAN_IT_WKU                          ((uint32_t)0x00010000) /* Wake-up Interrupt*/
+#define CAN_IT_SLK                          ((uint32_t)0x00020000) /* Sleep acknowledge Interrupt*/
+
+/* Error Interrupts */
+#define CAN_IT_EWG                          ((uint32_t)0x00000100) /* Error warning Interrupt*/
+#define CAN_IT_EPV                          ((uint32_t)0x00000200) /* Error passive Interrupt*/
+#define CAN_IT_BOF                          ((uint32_t)0x00000400) /* Bus-off Interrupt*/
+#define CAN_IT_LEC                          ((uint32_t)0x00000800) /* Last error code Interrupt*/
+#define CAN_IT_ERR                          ((uint32_t)0x00008000) /* Error Interrupt*/
+
+/* Flags named as Interrupts : kept only for FW compatibility */
+#define CAN_IT_RQCP0                        CAN_IT_TME
+#define CAN_IT_RQCP1                        CAN_IT_TME
+#define CAN_IT_RQCP2                        CAN_IT_TME
+
+/* CAN_Legacy */
+#define CANINITFAILED                       CAN_InitStatus_Failed
+#define CANINITOK                           CAN_InitStatus_Success
+#define CAN_FilterFIFO0                     CAN_Filter_FIFO0
+#define CAN_FilterFIFO1                     CAN_Filter_FIFO1
+#define CAN_ID_STD                          CAN_Id_Standard
+#define CAN_ID_EXT                          CAN_Id_Extended
+#define CAN_RTR_DATA                        CAN_RTR_Data
+#define CAN_RTR_REMOTE                      CAN_RTR_Remote
+#define CANTXFAILE                          CAN_TxStatus_Failed
+#define CANTXOK                             CAN_TxStatus_Ok
+#define CANTXPENDING                        CAN_TxStatus_Pending
+#define CAN_NO_MB                           CAN_TxStatus_NoMailBox
+#define CANSLEEPFAILED                      CAN_Sleep_Failed
+#define CANSLEEPOK                          CAN_Sleep_Ok
+#define CANWAKEUPFAILED                     CAN_WakeUp_Failed
+#define CANWAKEUPOK                         CAN_WakeUp_Ok
+
+#endif
+
+#if defined(CH32V20x)
+/* ch32v00x_dac.h ------------------------------------------------------------*/
+
+/* DAC_trigger_selection */
+#define DAC_Trigger_None                   ((uint32_t)0x00000000) /* Conversion is automatic once the DAC1_DHRxxxx register
+                                                                     has been loaded, and not by external trigger */
+#define DAC_Trigger_T6_TRGO                ((uint32_t)0x00000004) /* TIM6 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_Trigger_T8_TRGO                ((uint32_t)0x0000000C) /* TIM8 TRGO selected as external conversion trigger for DAC channel
+                                                                     only in High-density devices*/
+#define DAC_Trigger_T7_TRGO                ((uint32_t)0x00000014) /* TIM7 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_Trigger_T5_TRGO                ((uint32_t)0x0000001C) /* TIM5 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_Trigger_T2_TRGO                ((uint32_t)0x00000024) /* TIM2 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_Trigger_T4_TRGO                ((uint32_t)0x0000002C) /* TIM4 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_Trigger_Ext_IT9                ((uint32_t)0x00000034) /* EXTI Line9 event selected as external conversion trigger for DAC channel */
+#define DAC_Trigger_Software               ((uint32_t)0x0000003C) /* Conversion started by software trigger for DAC channel */
+
+/* DAC_wave_generation */
+#define DAC_WaveGeneration_None            ((uint32_t)0x00000000)
+#define DAC_WaveGeneration_Noise           ((uint32_t)0x00000040)
+#define DAC_WaveGeneration_Triangle        ((uint32_t)0x00000080)
+
+
+/* DAC_lfsrunmask_triangleamplitude */
+#define DAC_LFSRUnmask_Bit0                ((uint32_t)0x00000000) /* Unmask DAC channel LFSR bit0 for noise wave generation */
+#define DAC_LFSRUnmask_Bits1_0             ((uint32_t)0x00000100) /* Unmask DAC channel LFSR bit[1:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits2_0             ((uint32_t)0x00000200) /* Unmask DAC channel LFSR bit[2:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits3_0             ((uint32_t)0x00000300) /* Unmask DAC channel LFSR bit[3:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits4_0             ((uint32_t)0x00000400) /* Unmask DAC channel LFSR bit[4:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits5_0             ((uint32_t)0x00000500) /* Unmask DAC channel LFSR bit[5:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits6_0             ((uint32_t)0x00000600) /* Unmask DAC channel LFSR bit[6:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits7_0             ((uint32_t)0x00000700) /* Unmask DAC channel LFSR bit[7:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits8_0             ((uint32_t)0x00000800) /* Unmask DAC channel LFSR bit[8:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits9_0             ((uint32_t)0x00000900) /* Unmask DAC channel LFSR bit[9:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits10_0            ((uint32_t)0x00000A00) /* Unmask DAC channel LFSR bit[10:0] for noise wave generation */
+#define DAC_LFSRUnmask_Bits11_0            ((uint32_t)0x00000B00) /* Unmask DAC channel LFSR bit[11:0] for noise wave generation */
+#define DAC_TriangleAmplitude_1            ((uint32_t)0x00000000) /* Select max triangle amplitude of 1 */
+#define DAC_TriangleAmplitude_3            ((uint32_t)0x00000100) /* Select max triangle amplitude of 3 */
+#define DAC_TriangleAmplitude_7            ((uint32_t)0x00000200) /* Select max triangle amplitude of 7 */
+#define DAC_TriangleAmplitude_15           ((uint32_t)0x00000300) /* Select max triangle amplitude of 15 */
+#define DAC_TriangleAmplitude_31           ((uint32_t)0x00000400) /* Select max triangle amplitude of 31 */
+#define DAC_TriangleAmplitude_63           ((uint32_t)0x00000500) /* Select max triangle amplitude of 63 */
+#define DAC_TriangleAmplitude_127          ((uint32_t)0x00000600) /* Select max triangle amplitude of 127 */
+#define DAC_TriangleAmplitude_255          ((uint32_t)0x00000700) /* Select max triangle amplitude of 255 */
+#define DAC_TriangleAmplitude_511          ((uint32_t)0x00000800) /* Select max triangle amplitude of 511 */
+#define DAC_TriangleAmplitude_1023         ((uint32_t)0x00000900) /* Select max triangle amplitude of 1023 */
+#define DAC_TriangleAmplitude_2047         ((uint32_t)0x00000A00) /* Select max triangle amplitude of 2047 */
+#define DAC_TriangleAmplitude_4095         ((uint32_t)0x00000B00) /* Select max triangle amplitude of 4095 */
+
+/* DAC_output_buffer */
+#define DAC_OutputBuffer_Enable            ((uint32_t)0x00000000)
+#define DAC_OutputBuffer_Disable           ((uint32_t)0x00000002)
+
+/* DAC_Channel_selection */
+#define DAC_Channel_1                      ((uint32_t)0x00000000)
+#define DAC_Channel_2                      ((uint32_t)0x00000010)
+
+/* DAC_data_alignment */
+#define DAC_Align_12b_R                    ((uint32_t)0x00000000)
+#define DAC_Align_12b_L                    ((uint32_t)0x00000004)
+#define DAC_Align_8b_R                     ((uint32_t)0x00000008)
+
+/* DAC_wave_generation */
+#define DAC_Wave_Noise                     ((uint32_t)0x00000040)
+#define DAC_Wave_Triangle                  ((uint32_t)0x00000080)
+#endif
 
 /* ch32v00x_dbgmcu.h ---------------------------------------------------------*/
 
 /* CFGR0 Register */
+#ifdef CH32V003
 #define DBGMCU_IWDG_STOP             ((uint32_t)0x00000001)
 #define DBGMCU_WWDG_STOP             ((uint32_t)0x00000002)
 #define DBGMCU_TIM1_STOP             ((uint32_t)0x00000010)
 #define DBGMCU_TIM2_STOP             ((uint32_t)0x00000020)
+#elif defined(CH32V20x) || defined(CH32V30x)
+#define DBGMCU_SLEEP                 ((uint32_t)0x00000001)
+#define DBGMCU_STOP                  ((uint32_t)0x00000002)
+#define DBGMCU_STANDBY               ((uint32_t)0x00000004)
+#define DBGMCU_IWDG_STOP             ((uint32_t)0x00000100)
+#define DBGMCU_WWDG_STOP             ((uint32_t)0x00000200)
+#define DBGMCU_I2C1_SMBUS_TIMEOUT    ((uint32_t)0x00000400)
+#define DBGMCU_I2C2_SMBUS_TIMEOUT    ((uint32_t)0x00000800)
+#define DBGMCU_TIM1_STOP             ((uint32_t)0x00001000)
+#define DBGMCU_TIM2_STOP             ((uint32_t)0x00002000)
+#define DBGMCU_TIM3_STOP             ((uint32_t)0x00004000)
+#define DBGMCU_TIM4_STOP             ((uint32_t)0x00008000)
+#define DBGMCU_TIM5_STOP             ((uint32_t)0x00010000)
+#define DBGMCU_TIM6_STOP             ((uint32_t)0x00020000)
+#define DBGMCU_TIM7_STOP             ((uint32_t)0x00040000)
+#define DBGMCU_TIM8_STOP             ((uint32_t)0x00080000)
+#define DBGMCU_CAN1_STOP             ((uint32_t)0x00100000)
+#define DBGMCU_CAN2_STOP             ((uint32_t)0x00200000)
+#define DBGMCU_TIM9_STOP             ((uint32_t)0x00400000)
+#define DBGMCU_TIM10_STOP            ((uint32_t)0x00800000)
+#elif defined(CH32V10x)
+#define DBGMCU_IWDG_STOP             ((uint32_t)0x00000001)
+#define DBGMCU_WWDG_STOP             ((uint32_t)0x00000002)
+#define DBGMCU_I2C1_SMBUS_TIMEOUT    ((uint32_t)0x00000004)
+#define DBGMCU_I2C2_SMBUS_TIMEOUT    ((uint32_t)0x00000008)
+#define DBGMCU_TIM1_STOP             ((uint32_t)0x00000010)
+#define DBGMCU_TIM2_STOP             ((uint32_t)0x00000020)
+#define DBGMCU_TIM3_STOP             ((uint32_t)0x00000040)
+#define DBGMCU_TIM4_STOP             ((uint32_t)0x00000080)
+#define DBGMCU_SLEEP                 ((uint32_t)0x00000001)
+#define DBGMCU_STOP                  ((uint32_t)0x00000002)
+#define DBGMCU_STANDBY               ((uint32_t)0x00000004)
+#endif
 
 /* ch32v00x_dma.h ------------------------------------------------------------*/
 
@@ -3061,6 +8321,62 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 #define DMA1_IT_TC7                        ((uint32_t)0x02000000)
 #define DMA1_IT_HT7                        ((uint32_t)0x04000000)
 #define DMA1_IT_TE7                        ((uint32_t)0x08000000)
+#if defined(CH32V20x)
+#define DMA1_IT_GL8                        ((uint32_t)0x10000000)
+#define DMA1_IT_TC8                        ((uint32_t)0x20000000)
+#define DMA1_IT_HT8                        ((uint32_t)0x40000000)
+#define DMA1_IT_TE8                        ((uint32_t)0x80000000)
+#endif
+
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DMA2_IT_GL1                        ((uint32_t)0x10000001)
+#define DMA2_IT_TC1                        ((uint32_t)0x10000002)
+#define DMA2_IT_HT1                        ((uint32_t)0x10000004)
+#define DMA2_IT_TE1                        ((uint32_t)0x10000008)
+#define DMA2_IT_GL2                        ((uint32_t)0x10000010)
+#define DMA2_IT_TC2                        ((uint32_t)0x10000020)
+#define DMA2_IT_HT2                        ((uint32_t)0x10000040)
+#define DMA2_IT_TE2                        ((uint32_t)0x10000080)
+#define DMA2_IT_GL3                        ((uint32_t)0x10000100)
+#define DMA2_IT_TC3                        ((uint32_t)0x10000200)
+#define DMA2_IT_HT3                        ((uint32_t)0x10000400)
+#define DMA2_IT_TE3                        ((uint32_t)0x10000800)
+#define DMA2_IT_GL4                        ((uint32_t)0x10001000)
+#define DMA2_IT_TC4                        ((uint32_t)0x10002000)
+#define DMA2_IT_HT4                        ((uint32_t)0x10004000)
+#define DMA2_IT_TE4                        ((uint32_t)0x10008000)
+#define DMA2_IT_GL5                        ((uint32_t)0x10010000)
+#define DMA2_IT_TC5                        ((uint32_t)0x10020000)
+#define DMA2_IT_HT5                        ((uint32_t)0x10040000)
+#define DMA2_IT_TE5                        ((uint32_t)0x10080000)
+#endif
+#if defined(CH32V30x)
+#define DMA2_IT_GL6                        ((uint32_t)0x10100000)
+#define DMA2_IT_TC6                        ((uint32_t)0x10200000)
+#define DMA2_IT_HT6                        ((uint32_t)0x10400000)
+#define DMA2_IT_TE6                        ((uint32_t)0x10800000)
+#define DMA2_IT_GL7                        ((uint32_t)0x11000000)
+#define DMA2_IT_TC7                        ((uint32_t)0x12000000)
+#define DMA2_IT_HT7                        ((uint32_t)0x14000000)
+#define DMA2_IT_TE7                        ((uint32_t)0x18000000)
+
+#define DMA2_IT_GL8                        ((uint32_t)0x20000001)
+#define DMA2_IT_TC8                        ((uint32_t)0x20000002)
+#define DMA2_IT_HT8                        ((uint32_t)0x20000004)
+#define DMA2_IT_TE8                        ((uint32_t)0x20000008)
+#define DMA2_IT_GL9                        ((uint32_t)0x20000010)
+#define DMA2_IT_TC9                        ((uint32_t)0x20000020)
+#define DMA2_IT_HT9                        ((uint32_t)0x20000040)
+#define DMA2_IT_TE9                        ((uint32_t)0x20000080)
+#define DMA2_IT_GL10                       ((uint32_t)0x20000100)
+#define DMA2_IT_TC10                       ((uint32_t)0x20000200)
+#define DMA2_IT_HT10                       ((uint32_t)0x20000400)
+#define DMA2_IT_TE10                       ((uint32_t)0x20000800)
+#define DMA2_IT_GL11                       ((uint32_t)0x20001000)
+#define DMA2_IT_TC11                       ((uint32_t)0x20002000)
+#define DMA2_IT_HT11                       ((uint32_t)0x20004000)
+#define DMA2_IT_TE11                       ((uint32_t)0x20008000)
+#endif
 
 /* DMA_flags_definition */
 #define DMA1_FLAG_GL1                      ((uint32_t)0x00000001)
@@ -3091,8 +8407,1095 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 #define DMA1_FLAG_TC7                      ((uint32_t)0x02000000)
 #define DMA1_FLAG_HT7                      ((uint32_t)0x04000000)
 #define DMA1_FLAG_TE7                      ((uint32_t)0x08000000)
+#if defined(CH32V20x)
+#define DMA1_FLAG_GL8                      ((uint32_t)0x10000000)
+#define DMA1_FLAG_TC8                      ((uint32_t)0x20000000)
+#define DMA1_FLAG_HT8                      ((uint32_t)0x40000000)
+#define DMA1_FLAG_TE8                      ((uint32_t)0x80000000)
+#endif
+
+#if defined(CH32V10x) || defined(CH32V30x)
+#define DMA2_FLAG_GL1                      ((uint32_t)0x10000001)
+#define DMA2_FLAG_TC1                      ((uint32_t)0x10000002)
+#define DMA2_FLAG_HT1                      ((uint32_t)0x10000004)
+#define DMA2_FLAG_TE1                      ((uint32_t)0x10000008)
+#define DMA2_FLAG_GL2                      ((uint32_t)0x10000010)
+#define DMA2_FLAG_TC2                      ((uint32_t)0x10000020)
+#define DMA2_FLAG_HT2                      ((uint32_t)0x10000040)
+#define DMA2_FLAG_TE2                      ((uint32_t)0x10000080)
+#define DMA2_FLAG_GL3                      ((uint32_t)0x10000100)
+#define DMA2_FLAG_TC3                      ((uint32_t)0x10000200)
+#define DMA2_FLAG_HT3                      ((uint32_t)0x10000400)
+#define DMA2_FLAG_TE3                      ((uint32_t)0x10000800)
+#define DMA2_FLAG_GL4                      ((uint32_t)0x10001000)
+#define DMA2_FLAG_TC4                      ((uint32_t)0x10002000)
+#define DMA2_FLAG_HT4                      ((uint32_t)0x10004000)
+#define DMA2_FLAG_TE4                      ((uint32_t)0x10008000)
+#define DMA2_FLAG_GL5                      ((uint32_t)0x10010000)
+#define DMA2_FLAG_TC5                      ((uint32_t)0x10020000)
+#define DMA2_FLAG_HT5                      ((uint32_t)0x10040000)
+#define DMA2_FLAG_TE5                      ((uint32_t)0x10080000)
+#endif
+
+#if defined(CH32V30x)
+#define DMA2_FLAG_GL6                      ((uint32_t)0x10100000)
+#define DMA2_FLAG_TC6                      ((uint32_t)0x10200000)
+#define DMA2_FLAG_HT6                      ((uint32_t)0x10400000)
+#define DMA2_FLAG_TE6                      ((uint32_t)0x10800000)
+#define DMA2_FLAG_GL7                      ((uint32_t)0x11000000)
+#define DMA2_FLAG_TC7                      ((uint32_t)0x12000000)
+#define DMA2_FLAG_HT7                      ((uint32_t)0x14000000)
+#define DMA2_FLAG_TE7                      ((uint32_t)0x18000000)
+
+#define DMA2_FLAG_GL8                      ((uint32_t)0x20000001)
+#define DMA2_FLAG_TC8                      ((uint32_t)0x20000002)
+#define DMA2_FLAG_HT8                      ((uint32_t)0x20000004)
+#define DMA2_FLAG_TE8                      ((uint32_t)0x20000008)
+#define DMA2_FLAG_GL9                      ((uint32_t)0x20000010)
+#define DMA2_FLAG_TC9                      ((uint32_t)0x20000020)
+#define DMA2_FLAG_HT9                      ((uint32_t)0x20000040)
+#define DMA2_FLAG_TE9                      ((uint32_t)0x20000080)
+#define DMA2_FLAG_GL10                     ((uint32_t)0x20000100)
+#define DMA2_FLAG_TC10                     ((uint32_t)0x20000200)
+#define DMA2_FLAG_HT10                     ((uint32_t)0x20000400)
+#define DMA2_FLAG_TE10                     ((uint32_t)0x20000800)
+#define DMA2_FLAG_GL11                     ((uint32_t)0x20001000)
+#define DMA2_FLAG_TC11                     ((uint32_t)0x20002000)
+#define DMA2_FLAG_HT11                     ((uint32_t)0x20004000)
+#define DMA2_FLAG_TE11                     ((uint32_t)0x20008000)
+#endif
+
+#if defined(CH32V30x)
+/* ch32v00x_eth.h ------------------------------------------------------------*/
+
+#define PHY_10BASE_T_LINKED   1
+#define PHY_10BASE_T_NOT_LINKED   0
+
+#define DMA_TPS_Mask      ((uint32_t)0x00700000)
+#define DMA_RPS_Mask      ((uint32_t)0x000E0000)
+
+/* ETH delay.Just for Ethernet */
+#define _eth_delay_    ETH_Delay       /* Default _eth_delay_ function with less precise timing */
+
+/* definition for Ethernet frame */
+#define ETH_MAX_PACKET_SIZE    1536    /* ETH_HEADER + ETH_EXTRA + MAX_ETH_PAYLOAD + ETH_CRC */
+#define ETH_HEADER               14    /* 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+#define ETH_CRC                   4    /* Ethernet CRC */
+#define ETH_EXTRA                 2    /* Extra bytes in some cases */
+#define VLAN_TAG                  4    /* optional 802.1q VLAN Tag */
+#define MIN_ETH_PAYLOAD          46    /* Minimum Ethernet payload size */
+#define MAX_ETH_PAYLOAD        1500    /* Maximum Ethernet payload size */
+#define JUMBO_FRAME_PAYLOAD    9000    /* Jumbo frame payload size */
+
+/**
+   DMA Tx Desciptor
+  -----------------------------------------------------------------------------------------------
+  TDES0 | OWN(31) | CTRL[30:26] | Reserved[25:24] | CTRL[23:20] | Reserved[19:17] | Status[16:0] |
+  -----------------------------------------------------------------------------------------------
+  TDES1 | Reserved[31:29] | Buffer2 ByteCount[28:16] | Reserved[15:13] | Buffer1 ByteCount[12:0] |
+  -----------------------------------------------------------------------------------------------
+  TDES2 |                         Buffer1 Address [31:0]                                         |
+  -----------------------------------------------------------------------------------------------
+  TDES3 |                   Buffer2 Address [31:0] / Next Desciptor Address [31:0]               |
+  ------------------------------------------------------------------------------------------------
+*/
+
+
+/* Bit or field definition of TDES0 register (DMA Tx descriptor status register)*/
+#define ETH_DMATxDesc_OWN                     ((uint32_t)0x80000000)  /* OWN bit: descriptor is owned by DMA engine */
+#define ETH_DMATxDesc_IC                      ((uint32_t)0x40000000)  /* Interrupt on Completion */
+#define ETH_DMATxDesc_LS                      ((uint32_t)0x20000000)  /* Last Segment */
+#define ETH_DMATxDesc_FS                      ((uint32_t)0x10000000)  /* First Segment */
+#define ETH_DMATxDesc_DC                      ((uint32_t)0x08000000)  /* Disable CRC */
+#define ETH_DMATxDesc_DP                      ((uint32_t)0x04000000)  /* Disable Padding */
+#define ETH_DMATxDesc_TTSE                    ((uint32_t)0x02000000)  /* Transmit Time Stamp Enable */
+#define ETH_DMATxDesc_CIC                     ((uint32_t)0x00C00000)  /* Checksum Insertion Control: 4 cases */
+#define ETH_DMATxDesc_CIC_ByPass              ((uint32_t)0x00000000)  /* Do Nothing: Checksum Engine is bypassed */
+#define ETH_DMATxDesc_CIC_IPV4Header          ((uint32_t)0x00400000)  /* IPV4 header Checksum Insertion */
+#define ETH_DMATxDesc_CIC_TCPUDPICMP_Segment  ((uint32_t)0x00800000)  /* TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+#define ETH_DMATxDesc_CIC_TCPUDPICMP_Full     ((uint32_t)0x00C00000)  /* TCP/UDP/ICMP Checksum Insertion fully calculated */
+#define ETH_DMATxDesc_TER                     ((uint32_t)0x00200000)  /* Transmit End of Ring */
+#define ETH_DMATxDesc_TCH                     ((uint32_t)0x00100000)  /* Second Address Chained */
+#define ETH_DMATxDesc_TTSS                    ((uint32_t)0x00020000)  /* Tx Time Stamp Status */
+#define ETH_DMATxDesc_IHE                     ((uint32_t)0x00010000)  /* IP Header Error */
+#define ETH_DMATxDesc_ES                      ((uint32_t)0x00008000)  /* Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
+#define ETH_DMATxDesc_JT                      ((uint32_t)0x00004000)  /* Jabber Timeout */
+#define ETH_DMATxDesc_FF                      ((uint32_t)0x00002000)  /* Frame Flushed: DMA/MTL flushed the frame due to SW flush */
+#define ETH_DMATxDesc_PCE                     ((uint32_t)0x00001000)  /* Payload Checksum Error */
+#define ETH_DMATxDesc_LCA                     ((uint32_t)0x00000800)  /* Loss of Carrier: carrier lost during tramsmission */
+#define ETH_DMATxDesc_NC                      ((uint32_t)0x00000400)  /* No Carrier: no carrier signal from the tranceiver */
+#define ETH_DMATxDesc_LCO                     ((uint32_t)0x00000200)  /* Late Collision: transmission aborted due to collision */
+#define ETH_DMATxDesc_EC                      ((uint32_t)0x00000100)  /* Excessive Collision: transmission aborted after 16 collisions */
+#define ETH_DMATxDesc_VF                      ((uint32_t)0x00000080)  /* VLAN Frame */
+#define ETH_DMATxDesc_CC                      ((uint32_t)0x00000078)  /* Collision Count */
+#define ETH_DMATxDesc_ED                      ((uint32_t)0x00000004)  /* Excessive Deferral */
+#define ETH_DMATxDesc_UF                      ((uint32_t)0x00000002)  /* Underflow Error: late data arrival from the memory */
+#define ETH_DMATxDesc_DB                      ((uint32_t)0x00000001)  /* Deferred Bit */
+
+/* Field definition of TDES1 register */
+#define ETH_DMATxDesc_TBS2  ((uint32_t)0x1FFF0000)  /* Transmit Buffer2 Size */
+#define ETH_DMATxDesc_TBS1  ((uint32_t)0x00001FFF)  /* Transmit Buffer1 Size */
+
+/* Field definition of TDES2 register */
+#define ETH_DMATxDesc_B1AP  ((uint32_t)0xFFFFFFFF)  /* Buffer1 Address Pointer */
+
+/* Field definition of TDES3 register */
+#define ETH_DMATxDesc_B2AP  ((uint32_t)0xFFFFFFFF)  /* Buffer2 Address Pointer */
+
+/**
+  DMA Rx Desciptor
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES0 | OWN(31) |                                             Status [30:0]                                          |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES1 | CTRL(31) | Reserved[30:29] | Buffer2 ByteCount[28:16] | CTRL[15:14] | Reserved(13) | Buffer1 ByteCount[12:0] |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES2 |                                       Buffer1 Address [31:0]                                                 |
+  ---------------------------------------------------------------------------------------------------------------------
+  RDES3 |                          Buffer2 Address [31:0] / Next Desciptor Address [31:0]                              |
+  ----------------------------------------------------------------------------------------------------------------------
+*/
+
+/* Bit or field definition of RDES0 register (DMA Rx descriptor status register) */
+#define ETH_DMARxDesc_OWN         ((uint32_t)0x80000000)  /* OWN bit: descriptor is owned by DMA engine  */
+#define ETH_DMARxDesc_AFM         ((uint32_t)0x40000000)  /* DA Filter Fail for the rx frame  */
+#define ETH_DMARxDesc_FL          ((uint32_t)0x3FFF0000)  /* Receive descriptor frame length  */
+#define ETH_DMARxDesc_ES          ((uint32_t)0x00008000)  /* Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
+#define ETH_DMARxDesc_DE          ((uint32_t)0x00004000)  /* Desciptor error: no more descriptors for receive frame  */
+#define ETH_DMARxDesc_SAF         ((uint32_t)0x00002000)  /* SA Filter Fail for the received frame */
+#define ETH_DMARxDesc_LE          ((uint32_t)0x00001000)  /* Frame size not matching with length field */
+#define ETH_DMARxDesc_OE          ((uint32_t)0x00000800)  /* Overflow Error: Frame was damaged due to buffer overflow */
+#define ETH_DMARxDesc_VLAN        ((uint32_t)0x00000400)  /* VLAN Tag: received frame is a VLAN frame */
+#define ETH_DMARxDesc_FS          ((uint32_t)0x00000200)  /* First descriptor of the frame  */
+#define ETH_DMARxDesc_LS          ((uint32_t)0x00000100)  /* Last descriptor of the frame  */
+#define ETH_DMARxDesc_IPV4HCE     ((uint32_t)0x00000080)  /* IPC Checksum Error: Rx Ipv4 header checksum error   */
+#define ETH_DMARxDesc_LC          ((uint32_t)0x00000040)  /* Late collision occurred during reception   */
+#define ETH_DMARxDesc_FT          ((uint32_t)0x00000020)  /* Frame type - Ethernet, otherwise 802.3    */
+#define ETH_DMARxDesc_RWT         ((uint32_t)0x00000010)  /* Receive Watchdog Timeout: watchdog timer expired during reception    */
+#define ETH_DMARxDesc_RE          ((uint32_t)0x00000008)  /* Receive error: error reported by MII interface  */
+#define ETH_DMARxDesc_DBE         ((uint32_t)0x00000004)  /* Dribble bit error: frame contains non int multiple of 8 bits  */
+#define ETH_DMARxDesc_CE          ((uint32_t)0x00000002)  /* CRC error */
+#define ETH_DMARxDesc_MAMPCE      ((uint32_t)0x00000001)  /* Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
+
+/* Bit or field definition of RDES1 register */
+#define ETH_DMARxDesc_DIC   ((uint32_t)0x80000000)  /* Disable Interrupt on Completion */
+#define ETH_DMARxDesc_RBS2  ((uint32_t)0x1FFF0000)  /* Receive Buffer2 Size */
+#define ETH_DMARxDesc_RER   ((uint32_t)0x00008000)  /* Receive End of Ring */
+#define ETH_DMARxDesc_RCH   ((uint32_t)0x00004000)  /* Second Address Chained */
+#define ETH_DMARxDesc_RBS1  ((uint32_t)0x00001FFF)  /* Receive Buffer1 Size */
+
+/* Field definition of RDES2 register */
+#define ETH_DMARxDesc_B1AP  ((uint32_t)0xFFFFFFFF)  /* Buffer1 Address Pointer */
+
+/* Field definition of RDES3 register */
+#define ETH_DMARxDesc_B2AP  ((uint32_t)0xFFFFFFFF)  /* Buffer2 Address Pointer */
+
+/* Timeout threshold of Reading or writing PHY registers */
+#define PHY_READ_TO                     ((uint32_t)0x004FFFFF)
+#define PHY_WRITE_TO                    ((uint32_t)0x0004FFFF)
+
+/* Delay time after reset PHY */
+#define PHY_ResetDelay                  ((uint32_t)0x000FFFFF)
+
+/* Delay time after configure PHY */
+#define PHY_ConfigDelay                 ((uint32_t)0x00FFFFFF)
+
+/* PHY basic register */
+#define PHY_BCR                          0x0           /*PHY transceiver Basic Control Register */
+#define PHY_BSR                          0x01          /*PHY transceiver Basic Status Register*/
+#define PHY_ANAR                         0x04          /* Auto-Negotiation Advertisement Register */
+#define PHY_ANLPAR                       0x05          /* Auto-Negotiation Link Partner Base  Page Ability Register*/
+#define PHY_ANER                         0x06          /* Auto-Negotiation Expansion Register */
+#define PHY_BMCR                         PHY_BCR
+#define PHY_BMSR                         PHY_BSR
+#define PHY_STATUS                       0x10
+#define PHY_MDIX                         0x1E
+
+/* Bit or field definition for PHY basic control register */
+#define PHY_Reset                       ((uint16_t)0x8000)      /* PHY Reset */
+#define PHY_Loopback                    ((uint16_t)0x4000)      /* Select loop-back mode */
+#define PHY_FULLDUPLEX_100M             ((uint16_t)0x2100)      /* Set the full-duplex mode at 100 Mb/s */
+#define PHY_HALFDUPLEX_100M             ((uint16_t)0x2000)      /* Set the half-duplex mode at 100 Mb/s */
+#define PHY_FULLDUPLEX_10M              ((uint16_t)0x0100)      /* Set the full-duplex mode at 10 Mb/s */
+#define PHY_HALFDUPLEX_10M              ((uint16_t)0x0000)      /* Set the half-duplex mode at 10 Mb/s */
+#define PHY_AutoNegotiation             ((uint16_t)0x1000)      /* Enable auto-negotiation function */
+#define PHY_Restart_AutoNegotiation     ((uint16_t)0x0200)      /* Restart auto-negotiation function */
+#define PHY_Powerdown                   ((uint16_t)0x0800)      /* Select the power down mode */
+#define PHY_Isolate                     ((uint16_t)0x0400)      /* Isolate PHY from MII */
+
+/* Bit or field definition for PHY basic status register */
+#define PHY_AutoNego_Complete           ((uint16_t)0x0020)      /* Auto-Negotioation process completed */
+#define PHY_Linked_Status               ((uint16_t)0x0004)      /* Valid link established */
+#define PHY_Jabber_detection            ((uint16_t)0x0002)      /* Jabber condition detected */
+#define PHY_RMII_Mode                   ((uint16_t)0x0020)      /* RMII */
+
+
+/* Internal 10BASE-T PHY 50R*4 pull-up resistance enable or disable */
+#define ETH_Internal_Pull_Up_Res_Enable     ((uint32_t)0x00100000)
+#define ETH_Internal_Pull_Up_Res_Disable    ((uint32_t)0x00000000)
+
+/* MAC autoNegotiation enable or disable */
+#define ETH_AutoNegotiation_Enable     ((uint32_t)0x00000001)
+#define ETH_AutoNegotiation_Disable    ((uint32_t)0x00000000)
+
+/* MAC watchdog enable or disable */
+#define ETH_Watchdog_Enable       ((uint32_t)0x00000000)
+#define ETH_Watchdog_Disable      ((uint32_t)0x00800000)
+
+/* Bit description - MAC jabber enable or disable */
+#define ETH_Jabber_Enable    ((uint32_t)0x00000000)
+#define ETH_Jabber_Disable   ((uint32_t)0x00400000)
+
+/* Value of minimum IFG between frames during transmission */
+#define ETH_InterFrameGap_96Bit   ((uint32_t)0x00000000)  /* minimum IFG between frames during transmission is 96Bit */
+#define ETH_InterFrameGap_88Bit   ((uint32_t)0x00020000)  /* minimum IFG between frames during transmission is 88Bit */
+#define ETH_InterFrameGap_80Bit   ((uint32_t)0x00040000)  /* minimum IFG between frames during transmission is 80Bit */
+#define ETH_InterFrameGap_72Bit   ((uint32_t)0x00060000)  /* minimum IFG between frames during transmission is 72Bit */
+#define ETH_InterFrameGap_64Bit   ((uint32_t)0x00080000)  /* minimum IFG between frames during transmission is 64Bit */
+#define ETH_InterFrameGap_56Bit   ((uint32_t)0x000A0000)  /* minimum IFG between frames during transmission is 56Bit */
+#define ETH_InterFrameGap_48Bit   ((uint32_t)0x000C0000)  /* minimum IFG between frames during transmission is 48Bit */
+#define ETH_InterFrameGap_40Bit   ((uint32_t)0x000E0000)  /* minimum IFG between frames during transmission is 40Bit */
+
+/* MAC carrier sense enable or disable */
+#define ETH_CarrierSense_Enable   ((uint32_t)0x00000000)
+#define ETH_CarrierSense_Disable  ((uint32_t)0x00010000)
+
+/* MAC speed */
+#define ETH_Speed_10M        ((uint32_t)0x00000000)
+#define ETH_Speed_100M       ((uint32_t)0x00004000)
+#define ETH_Speed_1000M      ((uint32_t)0x00008000)
+
+/* MAC receive own enable or disable */
+#define ETH_ReceiveOwn_Enable     ((uint32_t)0x00000000)
+#define ETH_ReceiveOwn_Disable    ((uint32_t)0x00002000)
+
+/* MAC Loopback mode enable or disable */
+#define ETH_LoopbackMode_Enable        ((uint32_t)0x00001000)
+#define ETH_LoopbackMode_Disable       ((uint32_t)0x00000000)
+
+/* MAC fullDuplex or halfDuplex */
+#define ETH_Mode_FullDuplex       ((uint32_t)0x00000800)
+#define ETH_Mode_HalfDuplex       ((uint32_t)0x00000000)
+
+/* MAC offload checksum enable or disable */
+#define ETH_ChecksumOffload_Enable     ((uint32_t)0x00000400)
+#define ETH_ChecksumOffload_Disable    ((uint32_t)0x00000000)
+
+/* MAC transmission retry enable or disable */
+#define ETH_RetryTransmission_Enable   ((uint32_t)0x00000000)
+#define ETH_RetryTransmission_Disable  ((uint32_t)0x00000200)
+
+/* MAC automatic pad CRC strip enable or disable */
+#define ETH_AutomaticPadCRCStrip_Enable     ((uint32_t)0x00000080)
+#define ETH_AutomaticPadCRCStrip_Disable    ((uint32_t)0x00000000)
+
+/* MAC backoff limitation */
+#define ETH_BackOffLimit_10  ((uint32_t)0x00000000)
+#define ETH_BackOffLimit_8   ((uint32_t)0x00000020)
+#define ETH_BackOffLimit_4   ((uint32_t)0x00000040)
+#define ETH_BackOffLimit_1   ((uint32_t)0x00000060)
+
+/* MAC deferral check enable or disable */
+#define ETH_DeferralCheck_Enable       ((uint32_t)0x00000010)
+#define ETH_DeferralCheck_Disable      ((uint32_t)0x00000000)
+
+/* Bit description  : MAC receive all frame enable or disable */
+#define ETH_ReceiveAll_Enable     ((uint32_t)0x80000000)
+#define ETH_ReceiveAll_Disable    ((uint32_t)0x00000000)
+
+/* MAC backoff limitation */
+#define ETH_SourceAddrFilter_Normal_Enable       ((uint32_t)0x00000200)
+#define ETH_SourceAddrFilter_Inverse_Enable      ((uint32_t)0x00000300)
+#define ETH_SourceAddrFilter_Disable             ((uint32_t)0x00000000)
+
+/* MAC Pass control frames */
+#define ETH_PassControlFrames_BlockAll                ((uint32_t)0x00000040)  /* MAC filters all control frames from reaching the application */
+#define ETH_PassControlFrames_ForwardAll              ((uint32_t)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
+#define ETH_PassControlFrames_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+
+/* MAC broadcast frames reception */
+#define ETH_BroadcastFramesReception_Enable      ((uint32_t)0x00000000)
+#define ETH_BroadcastFramesReception_Disable     ((uint32_t)0x00000020)
+
+/* MAC destination address filter */
+#define ETH_DestinationAddrFilter_Normal    ((uint32_t)0x00000000)
+#define ETH_DestinationAddrFilter_Inverse   ((uint32_t)0x00000008)
+
+/* MAC Promiscuous mode enable or disable */
+#define ETH_PromiscuousMode_Enable     ((uint32_t)0x00000001)
+#define ETH_PromiscuousMode_Disable    ((uint32_t)0x00000000)
+
+/* MAC multicast frames filter */
+#define ETH_MulticastFramesFilter_PerfectHashTable    ((uint32_t)0x00000404)
+#define ETH_MulticastFramesFilter_HashTable           ((uint32_t)0x00000004)
+#define ETH_MulticastFramesFilter_Perfect             ((uint32_t)0x00000000)
+#define ETH_MulticastFramesFilter_None                ((uint32_t)0x00000010)
+
+/* MAC unicast frames filter */
+#define ETH_UnicastFramesFilter_PerfectHashTable ((uint32_t)0x00000402)
+#define ETH_UnicastFramesFilter_HashTable        ((uint32_t)0x00000002)
+#define ETH_UnicastFramesFilter_Perfect          ((uint32_t)0x00000000)
+
+/* Bit description  : MAC zero quanta pause */
+#define ETH_ZeroQuantaPause_Enable     ((uint32_t)0x00000000)
+#define ETH_ZeroQuantaPause_Disable    ((uint32_t)0x00000080)
+
+/* Field description  : MAC pause low threshold */
+#define ETH_PauseLowThreshold_Minus4        ((uint32_t)0x00000000)  /* Pause time minus 4 slot times */
+#define ETH_PauseLowThreshold_Minus28       ((uint32_t)0x00000010)  /* Pause time minus 28 slot times */
+#define ETH_PauseLowThreshold_Minus144      ((uint32_t)0x00000020)  /* Pause time minus 144 slot times */
+#define ETH_PauseLowThreshold_Minus256      ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */
+
+/* MAC unicast pause frame detect enable or disable*/
+#define ETH_UnicastPauseFrameDetect_Enable  ((uint32_t)0x00000008)
+#define ETH_UnicastPauseFrameDetect_Disable ((uint32_t)0x00000000)
+
+/* MAC receive flow control frame enable or disable */
+#define ETH_ReceiveFlowControl_Enable       ((uint32_t)0x00000004)
+#define ETH_ReceiveFlowControl_Disable      ((uint32_t)0x00000000)
+
+/* MAC transmit flow control enable or disable */
+#define ETH_TransmitFlowControl_Enable      ((uint32_t)0x00000002)
+#define ETH_TransmitFlowControl_Disable     ((uint32_t)0x00000000)
+
+/* MAC VLAN tag comparison */
+#define ETH_VLANTagComparison_12Bit    ((uint32_t)0x00010000)
+#define ETH_VLANTagComparison_16Bit    ((uint32_t)0x00000000)
+
+/* MAC flag */
+#define ETH_MAC_FLAG_TST     ((uint32_t)0x00000200)  /* Time stamp trigger flag (on MAC) */
+#define ETH_MAC_FLAG_MMCT    ((uint32_t)0x00000040)  /* MMC transmit flag  */
+#define ETH_MAC_FLAG_MMCR    ((uint32_t)0x00000020)  /* MMC receive flag */
+#define ETH_MAC_FLAG_MMC     ((uint32_t)0x00000010)  /* MMC flag (on MAC) */
+#define ETH_MAC_FLAG_PMT     ((uint32_t)0x00000008)  /* PMT flag (on MAC) */
+
+/* MAC interrupt */
+#define ETH_MAC_IT_TST       ((uint32_t)0x00000200)  /* Time stamp trigger interrupt (on MAC) */
+#define ETH_MAC_IT_MMCT      ((uint32_t)0x00000040)  /* MMC transmit interrupt */
+#define ETH_MAC_IT_MMCR      ((uint32_t)0x00000020)  /* MMC receive interrupt */
+#define ETH_MAC_IT_MMC       ((uint32_t)0x00000010)  /* MMC interrupt (on MAC) */
+#define ETH_MAC_IT_PMT       ((uint32_t)0x00000008)  /* PMT interrupt (on MAC) */
+
+/* MAC address */
+#define ETH_MAC_Address0     ((uint32_t)0x00000000)
+#define ETH_MAC_Address1     ((uint32_t)0x00000008)
+#define ETH_MAC_Address2     ((uint32_t)0x00000010)
+#define ETH_MAC_Address3     ((uint32_t)0x00000018)
+
+/* MAC address filter select */
+#define ETH_MAC_AddressFilter_SA       ((uint32_t)0x00000000)
+#define ETH_MAC_AddressFilter_DA       ((uint32_t)0x00000008)
+
+/* MAC address mask */
+#define ETH_MAC_AddressMask_Byte6      ((uint32_t)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+#define ETH_MAC_AddressMask_Byte5      ((uint32_t)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+#define ETH_MAC_AddressMask_Byte4      ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+#define ETH_MAC_AddressMask_Byte3      ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+#define ETH_MAC_AddressMask_Byte2      ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+#define ETH_MAC_AddressMask_Byte1      ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [70] */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          MAC Descriptor Register                                                                                                                                     */
+/*                                                                            */
+/******************************************************************************/
+
+/* DMA descriptor segment */
+#define ETH_DMATxDesc_LastSegment      ((uint32_t)0x40000000)  /* Last Segment */
+#define ETH_DMATxDesc_FirstSegment     ((uint32_t)0x20000000)  /* First Segment */
+
+/* DMA descriptor checksum setting */
+#define ETH_DMATxDesc_ChecksumByPass             ((uint32_t)0x00000000)   /* Checksum engine bypass */
+#define ETH_DMATxDesc_ChecksumIPV4Header         ((uint32_t)0x00400000)   /* IPv4 header checksum insertion  */
+#define ETH_DMATxDesc_ChecksumTCPUDPICMPSegment  ((uint32_t)0x00800000)   /* TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
+#define ETH_DMATxDesc_ChecksumTCPUDPICMPFull     ((uint32_t)0x00C00000)   /* TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+
+/* DMA RX & TX buffer */
+#define ETH_DMARxDesc_Buffer1     ((uint32_t)0x00000000)  /* DMA Rx Desc Buffer1 */
+#define ETH_DMARxDesc_Buffer2     ((uint32_t)0x00000001)  /* DMA Rx Desc Buffer2 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          ETH DMA Register                                                                                                                                    */
+/*                                                                            */
+/******************************************************************************/
+
+/* DMA drop TCPIP checksum error frame enable or disable */
+#define ETH_DropTCPIPChecksumErrorFrame_Enable   ((uint32_t)0x00000000)
+#define ETH_DropTCPIPChecksumErrorFrame_Disable  ((uint32_t)0x04000000)
+
+/* DMA receive store forward enable or disable */
+#define ETH_ReceiveStoreForward_Enable      ((uint32_t)0x02000000)
+#define ETH_ReceiveStoreForward_Disable     ((uint32_t)0x00000000)
+
+/* DMA flush received frame enable or disable */
+#define ETH_FlushReceivedFrame_Enable       ((uint32_t)0x00000000)
+#define ETH_FlushReceivedFrame_Disable      ((uint32_t)0x01000000)
+
+/* DMA transmit store forward enable or disable */
+#define ETH_TransmitStoreForward_Enable     ((uint32_t)0x00200000)
+#define ETH_TransmitStoreForward_Disable    ((uint32_t)0x00000000)
+
+/* DMA transmit threshold control */
+#define ETH_TransmitThresholdControl_64Bytes     ((uint32_t)0x00000000)  /* threshold level of the MTL Transmit FIFO is 64 Bytes */
+#define ETH_TransmitThresholdControl_128Bytes    ((uint32_t)0x00004000)  /* threshold level of the MTL Transmit FIFO is 128 Bytes */
+#define ETH_TransmitThresholdControl_192Bytes    ((uint32_t)0x00008000)  /* threshold level of the MTL Transmit FIFO is 192 Bytes */
+#define ETH_TransmitThresholdControl_256Bytes    ((uint32_t)0x0000C000)  /* threshold level of the MTL Transmit FIFO is 256 Bytes */
+#define ETH_TransmitThresholdControl_40Bytes     ((uint32_t)0x00010000)  /* threshold level of the MTL Transmit FIFO is 40 Bytes */
+#define ETH_TransmitThresholdControl_32Bytes     ((uint32_t)0x00014000)  /* threshold level of the MTL Transmit FIFO is 32 Bytes */
+#define ETH_TransmitThresholdControl_24Bytes     ((uint32_t)0x00018000)  /* threshold level of the MTL Transmit FIFO is 24 Bytes */
+#define ETH_TransmitThresholdControl_16Bytes     ((uint32_t)0x0001C000)  /* threshold level of the MTL Transmit FIFO is 16 Bytes */
+
+/* DMA forward error frames */
+#define ETH_ForwardErrorFrames_Enable       ((uint32_t)0x00000080)
+#define ETH_ForwardErrorFrames_Disable      ((uint32_t)0x00000000)
+
+/* DMA forward undersized good frames enable or disable */
+#define ETH_ForwardUndersizedGoodFrames_Enable   ((uint32_t)0x00000040)
+#define ETH_ForwardUndersizedGoodFrames_Disable  ((uint32_t)0x00000000)
+
+/* DMA receive threshold control */
+#define ETH_ReceiveThresholdControl_64Bytes      ((uint32_t)0x00000000)  /* threshold level of the MTL Receive FIFO is 64 Bytes */
+#define ETH_ReceiveThresholdControl_32Bytes      ((uint32_t)0x00000008)  /* threshold level of the MTL Receive FIFO is 32 Bytes */
+#define ETH_ReceiveThresholdControl_96Bytes      ((uint32_t)0x00000010)  /* threshold level of the MTL Receive FIFO is 96 Bytes */
+#define ETH_ReceiveThresholdControl_128Bytes     ((uint32_t)0x00000018)  /* threshold level of the MTL Receive FIFO is 128 Bytes */
+
+/* DMA second frame operate enable or disable */
+#define ETH_SecondFrameOperate_Enable       ((uint32_t)0x00000004)
+#define ETH_SecondFrameOperate_Disable      ((uint32_t)0x00000000)
+
+/* Address aligned beats enable or disable */
+#define ETH_AddressAlignedBeats_Enable      ((uint32_t)0x02000000)
+#define ETH_AddressAlignedBeats_Disable     ((uint32_t)0x00000000)
+
+/* DMA Fixed burst enable or disable */
+#define ETH_FixedBurst_Enable     ((uint32_t)0x00010000)
+#define ETH_FixedBurst_Disable    ((uint32_t)0x00000000)
+
+
+/* RX DMA burst length */
+#define ETH_RxDMABurstLength_1Beat          ((uint32_t)0x00020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 1 */
+#define ETH_RxDMABurstLength_2Beat          ((uint32_t)0x00040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 2 */
+#define ETH_RxDMABurstLength_4Beat          ((uint32_t)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RxDMABurstLength_8Beat          ((uint32_t)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RxDMABurstLength_16Beat         ((uint32_t)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RxDMABurstLength_32Beat         ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RxDMABurstLength_4xPBL_4Beat    ((uint32_t)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RxDMABurstLength_4xPBL_8Beat    ((uint32_t)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RxDMABurstLength_4xPBL_16Beat   ((uint32_t)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RxDMABurstLength_4xPBL_32Beat   ((uint32_t)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RxDMABurstLength_4xPBL_64Beat   ((uint32_t)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
+#define ETH_RxDMABurstLength_4xPBL_128Beat  ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
+
+
+/* TX DMA burst length */
+#define ETH_TxDMABurstLength_1Beat          ((uint32_t)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+#define ETH_TxDMABurstLength_2Beat          ((uint32_t)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+#define ETH_TxDMABurstLength_4Beat          ((uint32_t)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TxDMABurstLength_8Beat          ((uint32_t)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TxDMABurstLength_16Beat         ((uint32_t)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TxDMABurstLength_32Beat         ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TxDMABurstLength_4xPBL_4Beat    ((uint32_t)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TxDMABurstLength_4xPBL_8Beat    ((uint32_t)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TxDMABurstLength_4xPBL_16Beat   ((uint32_t)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TxDMABurstLength_4xPBL_32Beat   ((uint32_t)0x01000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TxDMABurstLength_4xPBL_64Beat   ((uint32_t)0x01001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+#define ETH_TxDMABurstLength_4xPBL_128Beat  ((uint32_t)0x01002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+
+/* DMA arbitration_round robin */
+#define ETH_DMAArbitration_RoundRobin_RxTx_1_1   ((uint32_t)0x00000000)
+#define ETH_DMAArbitration_RoundRobin_RxTx_2_1   ((uint32_t)0x00004000)
+#define ETH_DMAArbitration_RoundRobin_RxTx_3_1   ((uint32_t)0x00008000)
+#define ETH_DMAArbitration_RoundRobin_RxTx_4_1   ((uint32_t)0x0000C000)
+#define ETH_DMAArbitration_RxPriorTx             ((uint32_t)0x00000002)
+
+/* DMA interrupt FALG */
+#define ETH_DMA_FLAG_TST               ((uint32_t)0x20000000)  /* Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_FLAG_PMT               ((uint32_t)0x10000000)  /* PMT interrupt (on DMA) */
+#define ETH_DMA_FLAG_MMC               ((uint32_t)0x08000000)  /* MMC interrupt (on DMA) */
+#define ETH_DMA_FLAG_DataTransferError ((uint32_t)0x00800000)  /* Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMA_FLAG_ReadWriteError    ((uint32_t)0x01000000)  /* Error bits 0-write trnsf, 1-read transfr */
+#define ETH_DMA_FLAG_AccessError       ((uint32_t)0x02000000)  /* Error bits 0-data buffer, 1-desc. access */
+#define ETH_DMA_FLAG_NIS               ((uint32_t)0x00010000)  /* Normal interrupt summary flag */
+#define ETH_DMA_FLAG_AIS               ((uint32_t)0x00008000)  /* Abnormal interrupt summary flag */
+#define ETH_DMA_FLAG_ER                ((uint32_t)0x00004000)  /* Early receive flag */
+#define ETH_DMA_FLAG_FBE               ((uint32_t)0x00002000)  /* Fatal bus error flag */
+#define ETH_DMA_FLAG_ET                ((uint32_t)0x00000400)  /* Early transmit flag */
+#define ETH_DMA_FLAG_RWT               ((uint32_t)0x00000200)  /* Receive watchdog timeout flag */
+#define ETH_DMA_FLAG_RPS               ((uint32_t)0x00000100)  /* Receive process stopped flag */
+#define ETH_DMA_FLAG_RBU               ((uint32_t)0x00000080)  /* Receive buffer unavailable flag */
+#define ETH_DMA_FLAG_R                 ((uint32_t)0x00000040)  /* Receive flag */
+#define ETH_DMA_FLAG_TU                ((uint32_t)0x00000020)  /* Underflow flag */
+#define ETH_DMA_FLAG_RO                ((uint32_t)0x00000010)  /* Overflow flag */
+#define ETH_DMA_FLAG_TJT               ((uint32_t)0x00000008)  /* Transmit jabber timeout flag */
+#define ETH_DMA_FLAG_TBU               ((uint32_t)0x00000004)  /* Transmit buffer unavailable flag */
+#define ETH_DMA_FLAG_TPS               ((uint32_t)0x00000002)  /* Transmit process stopped flag */
+#define ETH_DMA_FLAG_T                 ((uint32_t)0x00000001)  /* Transmit flag */
+
+/* DMA interrupt */
+#define ETH_DMA_IT_PHYLINK   ((uint32_t)0x80000000)  /* Internal PHY link status change interrupt */
+#define ETH_DMA_IT_TST       ((uint32_t)0x20000000)  /* Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_IT_PMT       ((uint32_t)0x10000000)  /* PMT interrupt (on DMA) */
+#define ETH_DMA_IT_MMC       ((uint32_t)0x08000000)  /* MMC interrupt (on DMA) */
+#define ETH_DMA_IT_NIS       ((uint32_t)0x00010000)  /* Normal interrupt summary */
+#define ETH_DMA_IT_AIS       ((uint32_t)0x00008000)  /* Abnormal interrupt summary */
+#define ETH_DMA_IT_ER        ((uint32_t)0x00004000)  /* Early receive interrupt */
+#define ETH_DMA_IT_FBE       ((uint32_t)0x00002000)  /* Fatal bus error interrupt */
+#define ETH_DMA_IT_ET        ((uint32_t)0x00000400)  /* Early transmit interrupt */
+#define ETH_DMA_IT_RWT       ((uint32_t)0x00000200)  /* Receive watchdog timeout interrupt */
+#define ETH_DMA_IT_RPS       ((uint32_t)0x00000100)  /* Receive process stopped interrupt */
+#define ETH_DMA_IT_RBU       ((uint32_t)0x00000080)  /* Receive buffer unavailable interrupt */
+#define ETH_DMA_IT_R         ((uint32_t)0x00000040)  /* Receive interrupt */
+#define ETH_DMA_IT_TU        ((uint32_t)0x00000020)  /* Underflow interrupt */
+#define ETH_DMA_IT_RO        ((uint32_t)0x00000010)  /* Overflow interrupt */
+#define ETH_DMA_IT_TJT       ((uint32_t)0x00000008)  /* Transmit jabber timeout interrupt */
+#define ETH_DMA_IT_TBU       ((uint32_t)0x00000004)  /* Transmit buffer unavailable interrupt */
+#define ETH_DMA_IT_TPS       ((uint32_t)0x00000002)  /* Transmit process stopped interrupt */
+#define ETH_DMA_IT_T         ((uint32_t)0x00000001)  /* Transmit interrupt */
+
+/* DMA transmit process */
+#define ETH_DMA_TransmitProcess_Stopped     ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Tx Command issued */
+#define ETH_DMA_TransmitProcess_Fetching    ((uint32_t)0x00100000)  /* Running - fetching the Tx descriptor */
+#define ETH_DMA_TransmitProcess_Waiting     ((uint32_t)0x00200000)  /* Running - waiting for status */
+#define ETH_DMA_TransmitProcess_Reading     ((uint32_t)0x00300000)  /* Running - reading the data from host memory */
+#define ETH_DMA_TransmitProcess_Suspended   ((uint32_t)0x00600000)  /* Suspended - Tx Desciptor unavailabe */
+#define ETH_DMA_TransmitProcess_Closing     ((uint32_t)0x00700000)  /* Running - closing Rx descriptor */
+
+/* DMA receive Process */
+#define ETH_DMA_ReceiveProcess_Stopped      ((uint32_t)0x00000000)  /* Stopped - Reset or Stop Rx Command issued */
+#define ETH_DMA_ReceiveProcess_Fetching     ((uint32_t)0x00020000)  /* Running - fetching the Rx descriptor */
+#define ETH_DMA_ReceiveProcess_Waiting      ((uint32_t)0x00060000)  /* Running - waiting for packet */
+#define ETH_DMA_ReceiveProcess_Suspended    ((uint32_t)0x00080000)  /* Suspended - Rx Desciptor unavailable */
+#define ETH_DMA_ReceiveProcess_Closing      ((uint32_t)0x000A0000)  /* Running - closing descriptor */
+#define ETH_DMA_ReceiveProcess_Queuing      ((uint32_t)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+
+/* DMA overflow */
+#define ETH_DMA_Overflow_RxFIFOCounter      ((uint32_t)0x10000000)  /* Overflow bit for FIFO overflow counter */
+#define ETH_DMA_Overflow_MissedFrameCounter ((uint32_t)0x00010000)  /* Overflow bit for missed frame counter */
+
+
+/*********************************************************************************
+*                            Ethernet PMT defines
+**********************************************************************************/
+
+/* PMT flag */
+#define ETH_PMT_FLAG_WUFFRPR      ((uint32_t)0x80000000)  /* Wake-Up Frame Filter Register Poniter Reset */
+#define ETH_PMT_FLAG_WUFR         ((uint32_t)0x00000040)  /* Wake-Up Frame Received */
+#define ETH_PMT_FLAG_MPR          ((uint32_t)0x00000020)  /* Magic Packet Received */
+
+/*********************************************************************************
+*                            Ethernet MMC defines
+**********************************************************************************/
+
+/* MMC TX interrupt flag */
+#define ETH_MMC_IT_TGF       ((uint32_t)0x00200000)  /* When Tx good frame counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFMSC    ((uint32_t)0x00008000)  /* When Tx good multi col counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFSC     ((uint32_t)0x00004000)  /* When Tx good single col counter reaches half the maximum value */
+
+/* MMC RX interrupt flag */
+#define ETH_MMC_IT_RGUF      ((uint32_t)0x10020000)  /* When Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMC_IT_RFAE      ((uint32_t)0x10000040)  /* When Rx alignment error counter reaches half the maximum value */
+#define ETH_MMC_IT_RFCE      ((uint32_t)0x10000020)  /* When Rx crc error counter reaches half the maximum value */
+
+
+/* MMC description */
+#define ETH_MMCCR            ((uint32_t)0x00000100)  /* MMC CR register */
+#define ETH_MMCRIR           ((uint32_t)0x00000104)  /* MMC RIR register */
+#define ETH_MMCTIR           ((uint32_t)0x00000108)  /* MMC TIR register */
+#define ETH_MMCRIMR          ((uint32_t)0x0000010C)  /* MMC RIMR register */
+#define ETH_MMCTIMR          ((uint32_t)0x00000110)  /* MMC TIMR register */
+#define ETH_MMCTGFSCCR       ((uint32_t)0x0000014C)  /* MMC TGFSCCR register */
+#define ETH_MMCTGFMSCCR      ((uint32_t)0x00000150)  /* MMC TGFMSCCR register */
+#define ETH_MMCTGFCR         ((uint32_t)0x00000168)  /* MMC TGFCR register */
+#define ETH_MMCRFCECR        ((uint32_t)0x00000194)  /* MMC RFCECR register */
+#define ETH_MMCRFAECR        ((uint32_t)0x00000198)  /* MMC RFAECR register */
+#define ETH_MMCRGUFCR        ((uint32_t)0x000001C4)  /* MMC RGUFCR register */
+
+
+/*********************************************************************************
+*                            Ethernet PTP defines
+**********************************************************************************/
+
+/* PTP fine update method or coarse Update method */
+#define ETH_PTP_FineUpdate        ((uint32_t)0x00000001)  /* Fine Update method */
+#define ETH_PTP_CoarseUpdate      ((uint32_t)0x00000000)  /* Coarse Update method */
+
+
+/* PTP time stamp control */
+#define ETH_PTP_FLAG_TSARU        ((uint32_t)0x00000020)  /* Addend Register Update */
+#define ETH_PTP_FLAG_TSITE        ((uint32_t)0x00000010)  /* Time Stamp Interrupt Trigger */
+#define ETH_PTP_FLAG_TSSTU        ((uint32_t)0x00000008)  /* Time Stamp Update */
+#define ETH_PTP_FLAG_TSSTI        ((uint32_t)0x00000004)  /* Time Stamp Initialize */
+
+/* PTP positive/negative time value */
+#define ETH_PTP_PositiveTime      ((uint32_t)0x00000000)  /* Positive time value */
+#define ETH_PTP_NegativeTime      ((uint32_t)0x80000000)  /* Negative time value */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                PTP Register                                                                                                                           */
+/*                                                                            */
+/******************************************************************************/
+#define ETH_PTPTSCR     ((uint32_t)0x00000700)  /* PTP TSCR register */
+#define ETH_PTPSSIR     ((uint32_t)0x00000704)  /* PTP SSIR register */
+#define ETH_PTPTSHR     ((uint32_t)0x00000708)  /* PTP TSHR register */
+#define ETH_PTPTSLR     ((uint32_t)0x0000070C)  /* PTP TSLR register */
+#define ETH_PTPTSHUR    ((uint32_t)0x00000710)  /* PTP TSHUR register */
+#define ETH_PTPTSLUR    ((uint32_t)0x00000714)  /* PTP TSLUR register */
+#define ETH_PTPTSAR     ((uint32_t)0x00000718)  /* PTP TSAR register */
+#define ETH_PTPTTHR     ((uint32_t)0x0000071C)  /* PTP TTHR register */
+#define ETH_PTPTTLR     ((uint32_t)0x00000720)  /* PTP TTLR register */
+
+#define ETH_DMASR_TSTS       ((unsigned int)0x20000000)  /* Time-stamp trigger status */
+#define ETH_DMASR_PMTS       ((unsigned int)0x10000000)  /* PMT status */
+#define ETH_DMASR_MMCS       ((unsigned int)0x08000000)  /* MMC status */
+#define ETH_DMASR_EBS        ((unsigned int)0x03800000)  /* Error bits status */
+  #define ETH_DMASR_EBS_DescAccess      ((unsigned int)0x02000000)  /* Error bits 0-data buffer, 1-desc. access */
+  #define ETH_DMASR_EBS_ReadTransf      ((unsigned int)0x01000000)  /* Error bits 0-write trnsf, 1-read transfr */
+  #define ETH_DMASR_EBS_DataTransfTx    ((unsigned int)0x00800000)  /* Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMASR_TPS         ((unsigned int)0x00700000)  /* Transmit process state */
+  #define ETH_DMASR_TPS_Stopped         ((unsigned int)0x00000000)  /* Stopped - Reset or Stop Tx Command issued  */
+  #define ETH_DMASR_TPS_Fetching        ((unsigned int)0x00100000)  /* Running - fetching the Tx descriptor */
+  #define ETH_DMASR_TPS_Waiting         ((unsigned int)0x00200000)  /* Running - waiting for status */
+  #define ETH_DMASR_TPS_Reading         ((unsigned int)0x00300000)  /* Running - reading the data from host memory */
+  #define ETH_DMASR_TPS_Suspended       ((unsigned int)0x00600000)  /* Suspended - Tx Descriptor unavailabe */
+  #define ETH_DMASR_TPS_Closing         ((unsigned int)0x00700000)  /* Running - closing Rx descriptor */
+#define ETH_DMASR_RPS         ((unsigned int)0x000E0000)  /* Receive process state */
+  #define ETH_DMASR_RPS_Stopped         ((unsigned int)0x00000000)  /* Stopped - Reset or Stop Rx Command issued */
+  #define ETH_DMASR_RPS_Fetching        ((unsigned int)0x00020000)  /* Running - fetching the Rx descriptor */
+  #define ETH_DMASR_RPS_Waiting         ((unsigned int)0x00060000)  /* Running - waiting for packet */
+  #define ETH_DMASR_RPS_Suspended       ((unsigned int)0x00080000)  /* Suspended - Rx Descriptor unavailable */
+  #define ETH_DMASR_RPS_Closing         ((unsigned int)0x000A0000)  /* Running - closing descriptor */
+  #define ETH_DMASR_RPS_Queuing         ((unsigned int)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+#define ETH_DMASR_NIS        ((unsigned int)0x00010000)  /* Normal interrupt summary */
+#define ETH_DMASR_AIS        ((unsigned int)0x00008000)  /* Abnormal interrupt summary */
+#define ETH_DMASR_ERS        ((unsigned int)0x00004000)  /* Early receive status */
+#define ETH_DMASR_FBES       ((unsigned int)0x00002000)  /* Fatal bus error status */
+#define ETH_DMASR_ETS        ((unsigned int)0x00000400)  /* Early transmit status */
+#define ETH_DMASR_RWTS       ((unsigned int)0x00000200)  /* Receive watchdog timeout status */
+#define ETH_DMASR_RPSS       ((unsigned int)0x00000100)  /* Receive process stopped status */
+#define ETH_DMASR_RBUS       ((unsigned int)0x00000080)  /* Receive buffer unavailable status */
+#define ETH_DMASR_RS         ((unsigned int)0x00000040)  /* Receive status */
+#define ETH_DMASR_TUS        ((unsigned int)0x00000020)  /* Transmit underflow status */
+#define ETH_DMASR_ROS        ((unsigned int)0x00000010)  /* Receive overflow status */
+#define ETH_DMASR_TJTS       ((unsigned int)0x00000008)  /* Transmit jabber timeout status */
+#define ETH_DMASR_TBUS       ((unsigned int)0x00000004)  /* Transmit buffer unavailable status */
+#define ETH_DMASR_TPSS       ((unsigned int)0x00000002)  /* Transmit process stopped status */
+#define ETH_DMASR_TS         ((unsigned int)0x00000001)  /* Transmit status */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          ETH MAC Register                                                                                                                               */
+/*                                                                            */
+/******************************************************************************/
+#define ETH_MACCR_WD      ((unsigned int)0x00800000)  /* Watchdog disable */
+#define ETH_MACCR_JD      ((unsigned int)0x00400000)  /* Jabber disable */
+#define ETH_MACCR_IFG     ((unsigned int)0x000E0000)  /* Inter-frame gap */
+#define ETH_MACCR_IFG_96Bit     ((unsigned int)0x00000000)  /* Minimum IFG between frames during transmission is 96Bit */
+   #define ETH_MACCR_IFG_88Bit     ((unsigned int)0x00020000)  /* Minimum IFG between frames during transmission is 88Bit */
+   #define ETH_MACCR_IFG_80Bit     ((unsigned int)0x00040000)  /* Minimum IFG between frames during transmission is 80Bit */
+   #define ETH_MACCR_IFG_72Bit     ((unsigned int)0x00060000)  /* Minimum IFG between frames during transmission is 72Bit */
+   #define ETH_MACCR_IFG_64Bit     ((unsigned int)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */
+   #define ETH_MACCR_IFG_56Bit     ((unsigned int)0x000A0000)  /* Minimum IFG between frames during transmission is 56Bit */
+   #define ETH_MACCR_IFG_48Bit     ((unsigned int)0x000C0000)  /* Minimum IFG between frames during transmission is 48Bit */
+   #define ETH_MACCR_IFG_40Bit     ((unsigned int)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */
+#define ETH_MACCR_CSD     ((unsigned int)0x00010000)  /* Carrier sense disable (during transmission) */
+#define ETH_MACCR_FES     ((unsigned int)0x00004000)  /* Fast ethernet speed */
+#define ETH_MACCR_ROD     ((unsigned int)0x00002000)  /* Receive own disable */
+#define ETH_MACCR_LM      ((unsigned int)0x00001000)  /* loopback mode */
+#define ETH_MACCR_DM      ((unsigned int)0x00000800)  /* Duplex mode */
+#define ETH_MACCR_IPCO    ((unsigned int)0x00000400)  /* IP Checksum offload */
+#define ETH_MACCR_RD      ((unsigned int)0x00000200)  /* Retry disable */
+#define ETH_MACCR_APCS    ((unsigned int)0x00000080)  /* Automatic Pad/CRC stripping */
+#define ETH_MACCR_BL      ((unsigned int)0x00000060)  /* Back-off limit: random integer number (r) of slot time delays before reschedulinga transmission attempt during retries after a collision: 0 =< r <2^k */
+   #define ETH_MACCR_BL_10    ((unsigned int)0x00000000)  /* k = min (n, 10) */
+   #define ETH_MACCR_BL_8     ((unsigned int)0x00000020)  /* k = min (n, 8) */
+   #define ETH_MACCR_BL_4     ((unsigned int)0x00000040)  /* k = min (n, 4) */
+   #define ETH_MACCR_BL_1     ((unsigned int)0x00000060)  /* k = min (n, 1) */
+#define ETH_MACCR_DC      ((unsigned int)0x00000010)  /* Defferal check */
+#define ETH_MACCR_TE      ((unsigned int)0x00000008)  /* Transmitter enable */
+#define ETH_MACCR_RE      ((unsigned int)0x00000004)  /* Receiver enable */
+
+#define ETH_MACFFR_RA     ((unsigned int)0x80000000)  /* Receive all */
+#define ETH_MACFFR_HPF    ((unsigned int)0x00000400)  /* Hash or perfect filter */
+#define ETH_MACFFR_SAF    ((unsigned int)0x00000200)  /* Source address filter enable */
+#define ETH_MACFFR_SAIF   ((unsigned int)0x00000100)  /* SA inverse filtering */
+#define ETH_MACFFR_PCF    ((unsigned int)0x000000C0)  /* Pass control frames: 3 cases */
+   #define ETH_MACFFR_PCF_BlockAll                ((unsigned int)0x00000040)  /* MAC filters all control frames from reaching the application */
+   #define ETH_MACFFR_PCF_ForwardAll              ((unsigned int)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
+   #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((unsigned int)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+#define ETH_MACFFR_BFD    ((unsigned int)0x00000020)  /* Broadcast frame disable */
+#define ETH_MACFFR_PAM    ((unsigned int)0x00000010)  /* Pass all mutlicast */
+#define ETH_MACFFR_DAIF   ((unsigned int)0x00000008)  /* DA Inverse filtering */
+#define ETH_MACFFR_HM     ((unsigned int)0x00000004)  /* Hash multicast */
+#define ETH_MACFFR_HU     ((unsigned int)0x00000002)  /* Hash unicast */
+#define ETH_MACFFR_PM     ((unsigned int)0x00000001)  /* Promiscuous mode */
+
+#define ETH_MACHTHR_HTH   ((unsigned int)0xFFFFFFFF)  /* Hash table high */
+#define ETH_MACHTLR_HTL   ((unsigned int)0xFFFFFFFF)  /* Hash table low */
+
+#define ETH_MACMIIAR_PA   ((unsigned int)0x0000F800)  /* Physical layer address */
+#define ETH_MACMIIAR_MR   ((unsigned int)0x000007C0)  /* MII register in the selected PHY */
+#define ETH_MACMIIAR_CR   ((unsigned int)0x0000001C)  /* CR clock range: 6 cases */
+   #define ETH_MACMIIAR_CR_Div42   ((unsigned int)0x00000000)  /* HCLK:60-100 MHz; MDC clock= HCLK/42 */
+   #define ETH_MACMIIAR_CR_Div16   ((unsigned int)0x00000008)  /* HCLK:20-35 MHz; MDC clock= HCLK/16 */
+   #define ETH_MACMIIAR_CR_Div26   ((unsigned int)0x0000000C)  /* HCLK:35-60 MHz; MDC clock= HCLK/26 */
+#define ETH_MACMIIAR_MW   ((unsigned int)0x00000002)  /* MII write */
+#define ETH_MACMIIAR_MB   ((unsigned int)0x00000001)  /* MII busy */
+#define ETH_MACMIIDR_MD   ((unsigned int)0x0000FFFF)  /* MII data: read/write data from/to PHY */
+#define ETH_MACFCR_PT     ((unsigned int)0xFFFF0000)  /* Pause time */
+#define ETH_MACFCR_ZQPD   ((unsigned int)0x00000080)  /* Zero-quanta pause disable */
+#define ETH_MACFCR_PLT    ((unsigned int)0x00000030)  /* Pause low threshold: 4 cases */
+   #define ETH_MACFCR_PLT_Minus4   ((unsigned int)0x00000000)  /* Pause time minus 4 slot times */
+   #define ETH_MACFCR_PLT_Minus28  ((unsigned int)0x00000010)  /* Pause time minus 28 slot times */
+   #define ETH_MACFCR_PLT_Minus144 ((unsigned int)0x00000020)  /* Pause time minus 144 slot times */
+   #define ETH_MACFCR_PLT_Minus256 ((unsigned int)0x00000030)  /* Pause time minus 256 slot times */
+#define ETH_MACFCR_UPFD   ((unsigned int)0x00000008)  /* Unicast pause frame detect */
+#define ETH_MACFCR_RFCE   ((unsigned int)0x00000004)  /* Receive flow control enable */
+#define ETH_MACFCR_TFCE   ((unsigned int)0x00000002)  /* Transmit flow control enable */
+#define ETH_MACFCR_FCBBPA ((unsigned int)0x00000001)  /* Flow control busy/backpressure activate */
+
+#define ETH_MACVLANTR_VLANTC ((unsigned int)0x00010000)  /* 12-bit VLAN tag comparison */
+#define ETH_MACVLANTR_VLANTI ((unsigned int)0x0000FFFF)  /* VLAN tag identifier (for receive frames) */
+
+#define ETH_MACRWUFFR_D   ((unsigned int)0xFFFFFFFF)  /* Wake-up frame filter register data */
+/* Eight sequential Writes to this address (offset 0x28) will write all Wake-UpFrame Filter Registers.
+Eight sequential Reads from this address (offset 0x28) will read all Wake-UpFrame Filter Registers. */
+
+/*
+Wake-UpFrame Filter Reg0 : Filter 0 Byte Mask
+Wake-UpFrame Filter Reg1 : Filter 1 Byte Mask
+Wake-UpFrame Filter Reg2 : Filter 2 Byte Mask
+Wake-UpFrame Filter Reg3 : Filter 3 Byte Mask
+Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command -
+                           RSVD - Filter1 Command - RSVD - Filter0 Command
+Wake-UpFrame Filter Re5 : Filter3 Offset - Filter2 Offset - Filter1 Offset - Filter0 Offset
+Wake-UpFrame Filter Re6 : Filter1 CRC16 - Filter0 CRC16
+Wake-UpFrame Filter Re7 : Filter3 CRC16 - Filter2 CRC16 */
+
+#define ETH_MACPMTCSR_WFFRPR ((unsigned int)0x80000000)  /* Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_MACPMTCSR_GU     ((unsigned int)0x00000200)  /* Global Unicast */
+#define ETH_MACPMTCSR_WFR    ((unsigned int)0x00000040)  /* Wake-Up Frame Received */
+#define ETH_MACPMTCSR_MPR    ((unsigned int)0x00000020)  /* Magic Packet Received */
+#define ETH_MACPMTCSR_WFE    ((unsigned int)0x00000004)  /* Wake-Up Frame Enable */
+#define ETH_MACPMTCSR_MPE    ((unsigned int)0x00000002)  /* Magic Packet Enable */
+#define ETH_MACPMTCSR_PD     ((unsigned int)0x00000001)  /* Power Down */
+
+#define ETH_MACSR_TSTS      ((unsigned int)0x00000200)  /* Time stamp trigger status */
+#define ETH_MACSR_MMCTS     ((unsigned int)0x00000040)  /* MMC transmit status */
+#define ETH_MACSR_MMMCRS    ((unsigned int)0x00000020)  /* MMC receive status */
+#define ETH_MACSR_MMCS      ((unsigned int)0x00000010)  /* MMC status */
+#define ETH_MACSR_PMTS      ((unsigned int)0x00000008)  /* PMT status */
+
+#define ETH_MACIMR_TSTIM     ((unsigned int)0x00000200)  /* Time stamp trigger interrupt mask */
+#define ETH_MACIMR_PMTIM     ((unsigned int)0x00000008)  /* PMT interrupt mask */
+
+#define ETH_MACA0HR_MACA0H   ((unsigned int)0x0000FFFF)  /* MAC address0 high */
+
+#define ETH_MACA0LR_MACA0L   ((unsigned int)0xFFFFFFFF)  /* MAC address0 low */
+
+#define ETH_MACA1HR_AE       ((unsigned int)0x80000000)  /* Address enable */
+#define ETH_MACA1HR_SA       ((unsigned int)0x40000000)  /* Source address */
+#define ETH_MACA1HR_MBC      ((unsigned int)0x3F000000)  /* Mask byte control: bits to mask for comparison of the MAC Address bytes */
+   #define ETH_MACA1HR_MBC_HBits15_8    ((unsigned int)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+   #define ETH_MACA1HR_MBC_HBits7_0     ((unsigned int)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+   #define ETH_MACA1HR_MBC_LBits31_24   ((unsigned int)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+   #define ETH_MACA1HR_MBC_LBits23_16   ((unsigned int)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+   #define ETH_MACA1HR_MBC_LBits15_8    ((unsigned int)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+   #define ETH_MACA1HR_MBC_LBits7_0     ((unsigned int)0x01000000)  /* Mask MAC Address low reg bits [7:0] */
+#define ETH_MACA1HR_MACA1H   ((unsigned int)0x0000FFFF)  /* MAC address1 high */
+
+#define ETH_MACA1LR_MACA1L   ((unsigned int)0xFFFFFFFF)  /* MAC address1 low */
+
+#define ETH_MACA2HR_AE       ((unsigned int)0x80000000)  /* Address enable */
+#define ETH_MACA2HR_SA       ((unsigned int)0x40000000)  /* Source address */
+#define ETH_MACA2HR_MBC      ((unsigned int)0x3F000000)  /* Mask byte control */
+   #define ETH_MACA2HR_MBC_HBits15_8    ((unsigned int)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+   #define ETH_MACA2HR_MBC_HBits7_0     ((unsigned int)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+   #define ETH_MACA2HR_MBC_LBits31_24   ((unsigned int)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+   #define ETH_MACA2HR_MBC_LBits23_16   ((unsigned int)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+   #define ETH_MACA2HR_MBC_LBits15_8    ((unsigned int)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+   #define ETH_MACA2HR_MBC_LBits7_0     ((unsigned int)0x01000000)  /* Mask MAC Address low reg bits [70] */
+
+#define ETH_MACA2HR_MACA2H   ((unsigned int)0x0000FFFF)  /* MAC address1 high */
+#define ETH_MACA2LR_MACA2L   ((unsigned int)0xFFFFFFFF)  /* MAC address2 low */
+
+#define ETH_MACA3HR_AE       ((unsigned int)0x80000000)  /* Address enable */
+#define ETH_MACA3HR_SA       ((unsigned int)0x40000000)  /* Source address */
+#define ETH_MACA3HR_MBC      ((unsigned int)0x3F000000)  /* Mask byte control */
+   #define ETH_MACA3HR_MBC_HBits15_8    ((unsigned int)0x20000000)  /* Mask MAC Address high reg bits [15:8] */
+   #define ETH_MACA3HR_MBC_HBits7_0     ((unsigned int)0x10000000)  /* Mask MAC Address high reg bits [7:0] */
+   #define ETH_MACA3HR_MBC_LBits31_24   ((unsigned int)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
+   #define ETH_MACA3HR_MBC_LBits23_16   ((unsigned int)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
+   #define ETH_MACA3HR_MBC_LBits15_8    ((unsigned int)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
+   #define ETH_MACA3HR_MBC_LBits7_0     ((unsigned int)0x01000000)  /* Mask MAC Address low reg bits [70] */
+#define ETH_MACA3HR_MACA3H   ((unsigned int)0x0000FFFF)  /* MAC address3 high */
+#define ETH_MACA3LR_MACA3L   ((unsigned int)0xFFFFFFFF)  /* MAC address3 low */
+
+/******************************************************************************
+ *                          ETH MMC Register
+ ******************************************************************************/
+#define ETH_MMCCR_MCFHP      ((unsigned int)0x00000020)  /* MMC counter Full-Half preset */
+#define ETH_MMCCR_MCP        ((unsigned int)0x00000010)  /* MMC counter preset */
+#define ETH_MMCCR_MCF        ((unsigned int)0x00000008)  /* MMC Counter Freeze */
+#define ETH_MMCCR_ROR        ((unsigned int)0x00000004)  /* Reset on Read */
+#define ETH_MMCCR_CSR        ((unsigned int)0x00000002)  /* Counter Stop Rollover */
+#define ETH_MMCCR_CR         ((unsigned int)0x00000001)  /* Counters Reset */
+
+#define ETH_MMCRIR_RGUFS     ((unsigned int)0x00020000)  /* Set when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIR_RFAES     ((unsigned int)0x00000040)  /* Set when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIR_RFCES     ((unsigned int)0x00000020)  /* Set when Rx crc error counter reaches half the maximum value */
+
+#define ETH_MMCTIR_TGFS      ((unsigned int)0x00200000)  /* Set when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFMSCS   ((unsigned int)0x00008000)  /* Set when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIR_TGFSCS    ((unsigned int)0x00004000)  /* Set when Tx good single col counter reaches half the maximum value */
+
+#define ETH_MMCRIMR_RGUFM    ((unsigned int)0x00020000)  /* Mask the interrupt when Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFAEM    ((unsigned int)0x00000040)  /* Mask the interrupt when when Rx alignment error counter reaches half the maximum value */
+#define ETH_MMCRIMR_RFCEM    ((unsigned int)0x00000020)  /* Mask the interrupt when Rx crc error counter reaches half the maximum value */
+
+#define ETH_MMCTIMR_TGFM     ((unsigned int)0x00200000)  /* Mask the interrupt when Tx good frame count counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFMSCM  ((unsigned int)0x00008000)  /* Mask the interrupt when Tx good multi col counter reaches half the maximum value */
+#define ETH_MMCTIMR_TGFSCM   ((unsigned int)0x00004000)  /* Mask the interrupt when Tx good single col counter reaches half the maximum value */
+
+#define ETH_MMCTGFSCCR_TGFSCC     ((unsigned int)0xFFFFFFFF)  /* Number of successfully transmitted frames after a single collision in Half-duplex mode. */
+
+#define ETH_MMCTGFMSCCR_TGFMSCC   ((unsigned int)0xFFFFFFFF)  /* Number of successfully transmitted frames after more than a single collision in Half-duplex mode. */
+
+#define ETH_MMCTGFCR_TGFC    ((unsigned int)0xFFFFFFFF)  /* Number of good frames transmitted. */
+
+#define ETH_MMCRFCECR_RFCEC  ((unsigned int)0xFFFFFFFF)  /* Number of frames received with CRC error. */
+
+#define ETH_MMCRFAECR_RFAEC  ((unsigned int)0xFFFFFFFF)  /* Number of frames received with alignment (dribble) error */
+
+#define ETH_MMCRGUFCR_RGUFC  ((unsigned int)0xFFFFFFFF)  /* Number of good unicast frames received. */
+
+
+/******************************************************************************
+ *                          ETH Precise Clock Protocol Register
+ ******************************************************************************/
+#define ETH_PTPTSCR_TSCNT       ((unsigned int)0x00030000)  /* Time stamp clock node type */
+#define ETH_PTPTSSR_TSSMRME     ((unsigned int)0x00008000)  /* Time stamp snapshot for message relevant to master enable */
+#define ETH_PTPTSSR_TSSEME      ((unsigned int)0x00004000)  /* Time stamp snapshot for event message enable */
+#define ETH_PTPTSSR_TSSIPV4FE   ((unsigned int)0x00002000)  /* Time stamp snapshot for IPv4 frames enable */
+#define ETH_PTPTSSR_TSSIPV6FE   ((unsigned int)0x00001000)  /* Time stamp snapshot for IPv6 frames enable */
+#define ETH_PTPTSSR_TSSPTPOEFE  ((unsigned int)0x00000800)  /* Time stamp snapshot for PTP over ethernet frames enable */
+#define ETH_PTPTSSR_TSPTPPSV2E  ((unsigned int)0x00000400)  /* Time stamp PTP packet snooping for version2 format enable */
+#define ETH_PTPTSSR_TSSSR       ((unsigned int)0x00000200)  /* Time stamp Sub-seconds rollover */
+#define ETH_PTPTSSR_TSSARFE     ((unsigned int)0x00000100)  /* Time stamp snapshot for all received frames enable */
+
+#define ETH_PTPTSCR_TSARU    ((unsigned int)0x00000020)  /* Addend register update */
+#define ETH_PTPTSCR_TSITE    ((unsigned int)0x00000010)  /* Time stamp interrupt trigger enable */
+#define ETH_PTPTSCR_TSSTU    ((unsigned int)0x00000008)  /* Time stamp update */
+#define ETH_PTPTSCR_TSSTI    ((unsigned int)0x00000004)  /* Time stamp initialize */
+#define ETH_PTPTSCR_TSFCU    ((unsigned int)0x00000002)  /* Time stamp fine or coarse update */
+#define ETH_PTPTSCR_TSE      ((unsigned int)0x00000001)  /* Time stamp enable */
+
+#define ETH_PTPSSIR_STSSI    ((unsigned int)0x000000FF)  /* System time Sub-second increment value */
+
+#define ETH_PTPTSHR_STS      ((unsigned int)0xFFFFFFFF)  /* System Time second */
+
+#define ETH_PTPTSLR_STPNS    ((unsigned int)0x80000000)  /* System Time Positive or negative time */
+#define ETH_PTPTSLR_STSS     ((unsigned int)0x7FFFFFFF)  /* System Time sub-seconds */
+
+#define ETH_PTPTSHUR_TSUS    ((unsigned int)0xFFFFFFFF)  /* Time stamp update seconds */
+
+#define ETH_PTPTSLUR_TSUPNS  ((unsigned int)0x80000000)  /* Time stamp update Positive or negative time */
+#define ETH_PTPTSLUR_TSUSS   ((unsigned int)0x7FFFFFFF)  /* Time stamp update sub-seconds */
+
+#define ETH_PTPTSAR_TSA      ((unsigned int)0xFFFFFFFF)  /* Time stamp addend */
+
+#define ETH_PTPTTHR_TTSH     ((unsigned int)0xFFFFFFFF)  /* Target time stamp high */
+
+#define ETH_PTPTTLR_TTSL     ((unsigned int)0xFFFFFFFF)  /* Target time stamp low */
+
+#define ETH_PTPTSSR_TSTTR    ((unsigned int)0x00000020)  /* Time stamp target time reached */
+#define ETH_PTPTSSR_TSSO     ((unsigned int)0x00000010)  /* Time stamp seconds overflow */
+
+/******************************************************************************
+ *                       ETH DMA Register
+ ******************************************************************************/
+#define ETH_DMABMR_AAB       ((unsigned int)0x02000000)  /* Address-Aligned beats */
+#define ETH_DMABMR_FPM        ((unsigned int)0x01000000)  /* 4xPBL mode */
+#define ETH_DMABMR_USP       ((unsigned int)0x00800000)  /* Use separate PBL */
+#define ETH_DMABMR_RDP       ((unsigned int)0x007E0000)  /* RxDMA PBL */
+   #define ETH_DMABMR_RDP_1Beat    ((unsigned int)0x00020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 1 */
+   #define ETH_DMABMR_RDP_2Beat    ((unsigned int)0x00040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 2 */
+   #define ETH_DMABMR_RDP_4Beat    ((unsigned int)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+   #define ETH_DMABMR_RDP_8Beat    ((unsigned int)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+   #define ETH_DMABMR_RDP_16Beat   ((unsigned int)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+   #define ETH_DMABMR_RDP_32Beat   ((unsigned int)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+   #define ETH_DMABMR_RDP_4xPBL_4Beat   ((unsigned int)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
+   #define ETH_DMABMR_RDP_4xPBL_8Beat   ((unsigned int)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
+   #define ETH_DMABMR_RDP_4xPBL_16Beat  ((unsigned int)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
+   #define ETH_DMABMR_RDP_4xPBL_32Beat  ((unsigned int)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
+   #define ETH_DMABMR_RDP_4xPBL_64Beat  ((unsigned int)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
+   #define ETH_DMABMR_RDP_4xPBL_128Beat ((unsigned int)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
+#define ETH_DMABMR_FB        ((unsigned int)0x00010000)  /* Fixed Burst */
+#define ETH_DMABMR_RTPR      ((unsigned int)0x0000C000)  /* Rx Tx priority ratio */
+   #define ETH_DMABMR_RTPR_1_1     ((unsigned int)0x00000000)  /* Rx Tx priority ratio */
+   #define ETH_DMABMR_RTPR_2_1     ((unsigned int)0x00004000)  /* Rx Tx priority ratio */
+   #define ETH_DMABMR_RTPR_3_1     ((unsigned int)0x00008000)  /* Rx Tx priority ratio */
+   #define ETH_DMABMR_RTPR_4_1     ((unsigned int)0x0000C000)  /* Rx Tx priority ratio */
+#define ETH_DMABMR_PBL    ((unsigned int)0x00003F00)  /* Programmable burst length */
+   #define ETH_DMABMR_PBL_1Beat    ((unsigned int)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+   #define ETH_DMABMR_PBL_2Beat    ((unsigned int)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+   #define ETH_DMABMR_PBL_4Beat    ((unsigned int)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+   #define ETH_DMABMR_PBL_8Beat    ((unsigned int)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+   #define ETH_DMABMR_PBL_16Beat   ((unsigned int)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+   #define ETH_DMABMR_PBL_32Beat   ((unsigned int)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+   #define ETH_DMABMR_PBL_4xPBL_4Beat   ((unsigned int)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+   #define ETH_DMABMR_PBL_4xPBL_8Beat   ((unsigned int)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+   #define ETH_DMABMR_PBL_4xPBL_16Beat  ((unsigned int)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+   #define ETH_DMABMR_PBL_4xPBL_32Beat  ((unsigned int)0x01000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+   #define ETH_DMABMR_PBL_4xPBL_64Beat  ((unsigned int)0x01001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+   #define ETH_DMABMR_PBL_4xPBL_128Beat ((unsigned int)0x01002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+#define ETH_DMABMR_EDE       ((unsigned int)0x00000080)  /* Enhanced Descriptor Enable */
+#define ETH_DMABMR_DSL       ((unsigned int)0x0000007C)  /* Descriptor Skip Length */
+#define ETH_DMABMR_DA        ((unsigned int)0x00000002)  /* DMA arbitration scheme */
+#define ETH_DMABMR_SR        ((unsigned int)0x00000001)  /* Software reset */
+
+#define ETH_DMATPDR_TPD      ((unsigned int)0xFFFFFFFF)  /* Transmit poll demand */
+
+#define ETH_DMARPDR_RPD      ((unsigned int)0xFFFFFFFF)  /* Receive poll demand  */
+
+#define ETH_DMARDLAR_SRL     ((unsigned int)0xFFFFFFFF)  /* Start of receive list */
+
+#define ETH_DMATDLAR_STL     ((unsigned int)0xFFFFFFFF)  /* Start of transmit list */
+
+#define ETH_DMASR_TSTS       ((unsigned int)0x20000000)  /* Time-stamp trigger status */
+#define ETH_DMASR_PMTS       ((unsigned int)0x10000000)  /* PMT status */
+#define ETH_DMASR_MMCS       ((unsigned int)0x08000000)  /* MMC status */
+#define ETH_DMASR_EBS        ((unsigned int)0x03800000)  /* Error bits status */
+   #define ETH_DMASR_EBS_DescAccess      ((unsigned int)0x02000000)  /* Error bits 0-data buffer, 1-desc. access */
+   #define ETH_DMASR_EBS_ReadTransf      ((unsigned int)0x01000000)  /* Error bits 0-write trnsf, 1-read transfr */
+   #define ETH_DMASR_EBS_DataTransfTx    ((unsigned int)0x00800000)  /* Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMASR_TPS         ((unsigned int)0x00700000)  /* Transmit process state */
+   #define ETH_DMASR_TPS_Stopped         ((unsigned int)0x00000000)  /* Stopped - Reset or Stop Tx Command issued  */
+   #define ETH_DMASR_TPS_Fetching        ((unsigned int)0x00100000)  /* Running - fetching the Tx descriptor */
+   #define ETH_DMASR_TPS_Waiting         ((unsigned int)0x00200000)  /* Running - waiting for status */
+   #define ETH_DMASR_TPS_Reading         ((unsigned int)0x00300000)  /* Running - reading the data from host memory */
+   #define ETH_DMASR_TPS_Suspended       ((unsigned int)0x00600000)  /* Suspended - Tx Descriptor unavailabe */
+   #define ETH_DMASR_TPS_Closing         ((unsigned int)0x00700000)  /* Running - closing Rx descriptor */
+#define ETH_DMASR_RPS         ((unsigned int)0x000E0000)  /* Receive process state */
+   #define ETH_DMASR_RPS_Stopped         ((unsigned int)0x00000000)  /* Stopped - Reset or Stop Rx Command issued */
+   #define ETH_DMASR_RPS_Fetching        ((unsigned int)0x00020000)  /* Running - fetching the Rx descriptor */
+   #define ETH_DMASR_RPS_Waiting         ((unsigned int)0x00060000)  /* Running - waiting for packet */
+   #define ETH_DMASR_RPS_Suspended       ((unsigned int)0x00080000)  /* Suspended - Rx Descriptor unavailable */
+   #define ETH_DMASR_RPS_Closing         ((unsigned int)0x000A0000)  /* Running - closing descriptor */
+   #define ETH_DMASR_RPS_Queuing         ((unsigned int)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+#define ETH_DMASR_NIS        ((unsigned int)0x00010000)  /* Normal interrupt summary */
+#define ETH_DMASR_AIS        ((unsigned int)0x00008000)  /* Abnormal interrupt summary */
+#define ETH_DMASR_ERS        ((unsigned int)0x00004000)  /* Early receive status */
+#define ETH_DMASR_FBES       ((unsigned int)0x00002000)  /* Fatal bus error status */
+#define ETH_DMASR_ETS        ((unsigned int)0x00000400)  /* Early transmit status */
+#define ETH_DMASR_RWTS       ((unsigned int)0x00000200)  /* Receive watchdog timeout status */
+#define ETH_DMASR_RPSS       ((unsigned int)0x00000100)  /* Receive process stopped status */
+#define ETH_DMASR_RBUS       ((unsigned int)0x00000080)  /* Receive buffer unavailable status */
+#define ETH_DMASR_RS         ((unsigned int)0x00000040)  /* Receive status */
+#define ETH_DMASR_TUS        ((unsigned int)0x00000020)  /* Transmit underflow status */
+#define ETH_DMASR_ROS        ((unsigned int)0x00000010)  /* Receive overflow status */
+#define ETH_DMASR_TJTS       ((unsigned int)0x00000008)  /* Transmit jabber timeout status */
+#define ETH_DMASR_TBUS       ((unsigned int)0x00000004)  /* Transmit buffer unavailable status */
+#define ETH_DMASR_TPSS       ((unsigned int)0x00000002)  /* Transmit process stopped status */
+#define ETH_DMASR_TS         ((unsigned int)0x00000001)  /* Transmit status */
+
+#define ETH_DMAOMR_DTCEFD    ((unsigned int)0x04000000)  /* Disable Dropping of TCP/IP checksum error frames */
+#define ETH_DMAOMR_RSF       ((unsigned int)0x02000000)  /* Receive store and forward */
+#define ETH_DMAOMR_DFRF      ((unsigned int)0x01000000)  /* Disable flushing of received frames */
+#define ETH_DMAOMR_TSF       ((unsigned int)0x00200000)  /* Transmit store and forward */
+#define ETH_DMAOMR_FTF       ((unsigned int)0x00100000)  /* Flush transmit FIFO */
+#define ETH_DMAOMR_TTC       ((unsigned int)0x0001C000)  /* Transmit threshold control */
+   #define ETH_DMAOMR_TTC_64Bytes       ((unsigned int)0x00000000)  /* threshold level of the MTL Transmit FIFO is 64 Bytes */
+   #define ETH_DMAOMR_TTC_128Bytes      ((unsigned int)0x00004000)  /* threshold level of the MTL Transmit FIFO is 128 Bytes */
+   #define ETH_DMAOMR_TTC_192Bytes      ((unsigned int)0x00008000)  /* threshold level of the MTL Transmit FIFO is 192 Bytes */
+   #define ETH_DMAOMR_TTC_256Bytes      ((unsigned int)0x0000C000)  /* threshold level of the MTL Transmit FIFO is 256 Bytes */
+   #define ETH_DMAOMR_TTC_40Bytes       ((unsigned int)0x00010000)  /* threshold level of the MTL Transmit FIFO is 40 Bytes */
+   #define ETH_DMAOMR_TTC_32Bytes       ((unsigned int)0x00014000)  /* threshold level of the MTL Transmit FIFO is 32 Bytes */
+   #define ETH_DMAOMR_TTC_24Bytes       ((unsigned int)0x00018000)  /* threshold level of the MTL Transmit FIFO is 24 Bytes */
+   #define ETH_DMAOMR_TTC_16Bytes       ((unsigned int)0x0001C000)  /* threshold level of the MTL Transmit FIFO is 16 Bytes */
+#define ETH_DMAOMR_ST        ((unsigned int)0x00002000)  /* Start/stop transmission command */
+#define ETH_DMAOMR_FEF       ((unsigned int)0x00000080)  /* Forward error frames */
+#define ETH_DMAOMR_FUGF      ((unsigned int)0x00000040)  /* Forward undersized good frames */
+#define ETH_DMAOMR_RTC       ((unsigned int)0x00000018)  /* receive threshold control */
+   #define ETH_DMAOMR_RTC_64Bytes       ((unsigned int)0x00000000)  /* threshold level of the MTL Receive FIFO is 64 Bytes */
+   #define ETH_DMAOMR_RTC_32Bytes       ((unsigned int)0x00000008)  /* threshold level of the MTL Receive FIFO is 32 Bytes */
+   #define ETH_DMAOMR_RTC_96Bytes       ((unsigned int)0x00000010)  /* threshold level of the MTL Receive FIFO is 96 Bytes */
+   #define ETH_DMAOMR_RTC_128Bytes      ((unsigned int)0x00000018)  /* threshold level of the MTL Receive FIFO is 128 Bytes */
+#define ETH_DMAOMR_OSF       ((unsigned int)0x00000004)  /* operate on second frame */
+#define ETH_DMAOMR_SR        ((unsigned int)0x00000002)  /* Start/stop receive */
+
+#define ETH_DMAIER_NISE      ((unsigned int)0x00010000)  /* Normal interrupt summary enable */
+#define ETH_DMAIER_AISE      ((unsigned int)0x00008000)  /* Abnormal interrupt summary enable */
+#define ETH_DMAIER_ERIE      ((unsigned int)0x00004000)  /* Early receive interrupt enable */
+#define ETH_DMAIER_FBEIE     ((unsigned int)0x00002000)  /* Fatal bus error interrupt enable */
+#define ETH_DMAIER_ETIE      ((unsigned int)0x00000400)  /* Early transmit interrupt enable */
+#define ETH_DMAIER_RWTIE     ((unsigned int)0x00000200)  /* Receive watchdog timeout interrupt enable */
+#define ETH_DMAIER_RPSIE     ((unsigned int)0x00000100)  /* Receive process stopped interrupt enable */
+#define ETH_DMAIER_RBUIE     ((unsigned int)0x00000080)  /* Receive buffer unavailable interrupt enable */
+#define ETH_DMAIER_RIE       ((unsigned int)0x00000040)  /* Receive interrupt enable */
+#define ETH_DMAIER_TUIE      ((unsigned int)0x00000020)  /* Transmit Underflow interrupt enable */
+#define ETH_DMAIER_ROIE      ((unsigned int)0x00000010)  /* Receive Overflow interrupt enable */
+#define ETH_DMAIER_TJTIE     ((unsigned int)0x00000008)  /* Transmit jabber timeout interrupt enable */
+#define ETH_DMAIER_TBUIE     ((unsigned int)0x00000004)  /* Transmit buffer unavailable interrupt enable */
+#define ETH_DMAIER_TPSIE     ((unsigned int)0x00000002)  /* Transmit process stopped interrupt enable */
+#define ETH_DMAIER_TIE       ((unsigned int)0x00000001)  /* Transmit interrupt enable */
+
+#define ETH_DMAMFBOCR_OFOC   ((unsigned int)0x10000000)  /* Overflow bit for FIFO overflow counter */
+#define ETH_DMAMFBOCR_MFA    ((unsigned int)0x0FFE0000)  /* Number of frames missed by the application */
+#define ETH_DMAMFBOCR_OMFC   ((unsigned int)0x00010000)  /* Overflow bit for missed frame counter */
+#define ETH_DMAMFBOCR_MFC    ((unsigned int)0x0000FFFF)  /* Number of frames missed by the controller */
+
+#define ETH_DMACHTDR_HTDAP   ((unsigned int)0xFFFFFFFF)  /* Host transmit descriptor address pointer */
+#define ETH_DMACHRDR_HRDAP   ((unsigned int)0xFFFFFFFF)  /* Host receive descriptor address pointer */
+#define ETH_DMACHTBAR_HTBAP  ((unsigned int)0xFFFFFFFF)  /* Host transmit buffer address pointer */
+#define ETH_DMACHRBAR_HRBAP  ((unsigned int)0xFFFFFFFF)  /* Host receive buffer address pointer */
+
+
+#define ETH_MAC_ADDR_HBASE   (ETH_MAC_BASE + 0x40)   /* ETHERNET MAC address high offset */
+#define ETH_MAC_ADDR_LBASE    (ETH_MAC_BASE + 0x44)  /* ETHERNET MAC address low offset */
+
+/* ETHERNET MACMIIAR register Mask */
+#define MACMIIAR_CR_MASK    ((uint32_t)0xFFFFFFE3)
+
+/* ETHERNET MACCR register Mask */
+#define MACCR_CLEAR_MASK    ((uint32_t)0xFF20810F)
+
+/* ETHERNET MACFCR register Mask */
+#define MACFCR_CLEAR_MASK   ((uint32_t)0x0000FF41)
+
+/* ETHERNET DMAOMR register Mask */
+#define DMAOMR_CLEAR_MASK   ((uint32_t)0xF8DE3F23)
+
+/* ETHERNET Remote Wake-up frame register length */
+#define ETH_WAKEUP_REGISTER_LENGTH      8
+
+/* ETHERNET Missed frames counter Shift */
+#define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT     17
+
+/* ETHERNET DMA Tx descriptors Collision Count Shift */
+#define  ETH_DMATXDESC_COLLISION_COUNTSHIFT        3
+
+/* ETHERNET DMA Tx descriptors Buffer2 Size Shift */
+#define  ETH_DMATXDESC_BUFFER2_SIZESHIFT           16
+
+/* ETHERNET DMA Rx descriptors Frame Length Shift */
+#define  ETH_DMARXDESC_FRAME_LENGTHSHIFT           16
+
+/* ETHERNET DMA Rx descriptors Buffer2 Size Shift */
+#define  ETH_DMARXDESC_BUFFER2_SIZESHIFT           16
+
+/* ETHERNET errors */
+#define  ETH_ERROR              ((uint32_t)0)
+#define  ETH_SUCCESS            ((uint32_t)1)
+#endif
 
 /* ch32v00x_exti.h -----------------------------------------------------------*/
+
+#ifndef __ASSEMBLER__
 
 /* EXTI mode enumeration */
 typedef enum
@@ -3109,6 +9512,8 @@ typedef enum
     EXTI_Trigger_Rising_Falling = 0x10
 } EXTITrigger_TypeDef;
 
+#endif
+
 /* EXTI_Lines */
 #define EXTI_Line0     ((uint32_t)0x00001) /* External interrupt line 0 */
 #define EXTI_Line1     ((uint32_t)0x00002) /* External interrupt line 1 */
@@ -3120,11 +9525,37 @@ typedef enum
 #define EXTI_Line7     ((uint32_t)0x00080) /* External interrupt line 7 */
 #define EXTI_Line8     ((uint32_t)0x00100) /* External interrupt line 8 Connected to the PVD Output */
 #define EXTI_Line9     ((uint32_t)0x00200) /* External interrupt line 9 Connected to the PWR Auto Wake-up event*/
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_Line10    ((uint32_t)0x00400)  /* External interrupt line 10 */
+#define EXTI_Line11    ((uint32_t)0x00800)  /* External interrupt line 11 */
+#define EXTI_Line12    ((uint32_t)0x01000)  /* External interrupt line 12 */
+#define EXTI_Line13    ((uint32_t)0x02000)  /* External interrupt line 13 */
+#define EXTI_Line14    ((uint32_t)0x04000)  /* External interrupt line 14 */
+#define EXTI_Line15    ((uint32_t)0x08000)  /* External interrupt line 15 */
+#endif
+#if defined(CH32V20x) || defined(CH32V30x)
+#define EXTI_Line16    ((uint32_t)0x10000)  /* External interrupt line 16 Connected to the PVD Output */
+#define EXTI_Line17    ((uint32_t)0x20000)  /* External interrupt line 17 Connected to the RTC Alarm event */
+#define EXTI_Line18    ((uint32_t)0x40000)  /* External interrupt line 18 Connected to the USBD Device \
+                                               Wakeup from suspend event */
+#define EXTI_Line19    ((uint32_t)0x80000)  /* External interrupt line 19 Connected to the Ethernet Wakeup event */
+#define EXTI_Line20    ((uint32_t)0x100000) /* External interrupt line 20 Connected to the USBFS Wakeup event */
 
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+  #define EXTI_Line21    ((uint32_t)0x200000) /* External interrupt line 21 Connected to the OSCCAL Wakeup event */
+#endif
+
+#elif defined(CH32V10x)
+#define EXTI_Line16    ((uint32_t)0x10000) /* External interrupt line 16 Connected to the PVD Output */
+#define EXTI_Line17    ((uint32_t)0x20000) /* External interrupt line 17 Connected to the RTC Alarm event */
+#define EXTI_Line18    ((uint32_t)0x40000)
+#define EXTI_Line19    ((uint32_t)0x80000) /* External interrupt line 19 Connected to the USBHD Wakeup event */
+#endif
 
 /* ch32v00x_flash.h ----------------------------------------------------------*/
 
 
+#ifndef __ASSEMBLER__
 /* FLASH Status */
 typedef enum
 {
@@ -3134,13 +9565,26 @@ typedef enum
     FLASH_COMPLETE,
     FLASH_TIMEOUT
 } FLASH_Status;
+#endif
 
-
+#if defined(CH32V003) || defined(CH32V10x)
 /* Flash_Latency */
 #define FLASH_Latency_0                  ((uint32_t)0x00000000) /* FLASH Zero Latency cycle */
 #define FLASH_Latency_1                  ((uint32_t)0x00000001) /* FLASH One Latency cycle */
 #define FLASH_Latency_2                  ((uint32_t)0x00000002) /* FLASH Two Latency cycles */
+#endif
 
+#if defined(CH32V10x)
+/* Half_Cycle_Enable_Disable */
+#define FLASH_HalfCycleAccess_Enable     ((uint32_t)0x00000008) /* FLASH Half Cycle Enable */
+#define FLASH_HalfCycleAccess_Disable    ((uint32_t)0x00000000) /* FLASH Half Cycle Disable */
+
+/* Prefetch_Buffer_Enable_Disable */
+#define FLASH_PrefetchBuffer_Enable      ((uint32_t)0x00000010) /* FLASH Prefetch Buffer Enable */
+#define FLASH_PrefetchBuffer_Disable     ((uint32_t)0x00000000) /* FLASH Prefetch Buffer Disable */
+#endif
+
+#ifdef CH32V003
 /* Values to be used with CH32V00x devices (1page = 64Byte) */
 #define FLASH_WRProt_Pages0to15          ((uint32_t)0x00000001) /* CH32 Low and Medium density devices: Write protection of page 0 to 15 */
 #define FLASH_WRProt_Pages16to31         ((uint32_t)0x00000002) /* CH32 Low and Medium density devices: Write protection of page 16 to 31 */
@@ -3161,6 +9605,87 @@ typedef enum
 
 #define FLASH_WRProt_AllPages            ((uint32_t)0x0000FFFF) /* Write protection of all Pages */
 
+#elif defined(CH32V20x) || defined(CH32V30x)
+/* Write Protect */
+#define FLASH_WRProt_Sectors0          ((uint32_t)0x00000001) /* Write protection of setor 0  */
+#define FLASH_WRProt_Sectors1          ((uint32_t)0x00000002) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors2          ((uint32_t)0x00000004) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors3          ((uint32_t)0x00000008) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors4          ((uint32_t)0x00000010) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors5          ((uint32_t)0x00000020) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors6          ((uint32_t)0x00000040) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors7          ((uint32_t)0x00000080) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors8          ((uint32_t)0x00000100) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors9          ((uint32_t)0x00000200) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors10         ((uint32_t)0x00000400) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors11         ((uint32_t)0x00000800) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors12         ((uint32_t)0x00001000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors13         ((uint32_t)0x00002000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors14         ((uint32_t)0x00004000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors15         ((uint32_t)0x00008000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors16         ((uint32_t)0x00010000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors17         ((uint32_t)0x00020000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors18         ((uint32_t)0x00040000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors19         ((uint32_t)0x00080000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors20         ((uint32_t)0x00100000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors21         ((uint32_t)0x00200000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors22         ((uint32_t)0x00400000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors23         ((uint32_t)0x00800000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors24         ((uint32_t)0x01000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors25         ((uint32_t)0x02000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors26         ((uint32_t)0x04000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors27         ((uint32_t)0x08000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors28         ((uint32_t)0x10000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors29         ((uint32_t)0x20000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors30         ((uint32_t)0x40000000) /* Write protection of setor 0 */
+#define FLASH_WRProt_Sectors31to127    ((uint32_t)0x80000000) /* Write protection of page 62 to 255 */
+
+#define FLASH_WRProt_AllSectors        ((uint32_t)0xFFFFFFFF) /* Write protection of all Sectors */
+
+#elif defined(CH32V10x)
+
+/* Values to be used with CH32V10x Low and Medium density devices */
+#define FLASH_WRProt_Pages0to3           ((uint32_t)0x00000001) /* CH32 Low and Medium density devices: Write protection of page 0 to 3 */
+#define FLASH_WRProt_Pages4to7           ((uint32_t)0x00000002) /* CH32 Low and Medium density devices: Write protection of page 4 to 7 */
+#define FLASH_WRProt_Pages8to11          ((uint32_t)0x00000004) /* CH32 Low and Medium density devices: Write protection of page 8 to 11 */
+#define FLASH_WRProt_Pages12to15         ((uint32_t)0x00000008) /* CH32 Low and Medium density devices: Write protection of page 12 to 15 */
+#define FLASH_WRProt_Pages16to19         ((uint32_t)0x00000010) /* CH32 Low and Medium density devices: Write protection of page 16 to 19 */
+#define FLASH_WRProt_Pages20to23         ((uint32_t)0x00000020) /* CH32 Low and Medium density devices: Write protection of page 20 to 23 */
+#define FLASH_WRProt_Pages24to27         ((uint32_t)0x00000040) /* CH32 Low and Medium density devices: Write protection of page 24 to 27 */
+#define FLASH_WRProt_Pages28to31         ((uint32_t)0x00000080) /* CH32 Low and Medium density devices: Write protection of page 28 to 31 */
+
+/* Values to be used with CH32V10x Medium-density devices */
+#define FLASH_WRProt_Pages32to35         ((uint32_t)0x00000100) /* CH32 Medium-density devices: Write protection of page 32 to 35 */
+#define FLASH_WRProt_Pages36to39         ((uint32_t)0x00000200) /* CH32 Medium-density devices: Write protection of page 36 to 39 */
+#define FLASH_WRProt_Pages40to43         ((uint32_t)0x00000400) /* CH32 Medium-density devices: Write protection of page 40 to 43 */
+#define FLASH_WRProt_Pages44to47         ((uint32_t)0x00000800) /* CH32 Medium-density devices: Write protection of page 44 to 47 */
+#define FLASH_WRProt_Pages48to51         ((uint32_t)0x00001000) /* CH32 Medium-density devices: Write protection of page 48 to 51 */
+#define FLASH_WRProt_Pages52to55         ((uint32_t)0x00002000) /* CH32 Medium-density devices: Write protection of page 52 to 55 */
+#define FLASH_WRProt_Pages56to59         ((uint32_t)0x00004000) /* CH32 Medium-density devices: Write protection of page 56 to 59 */
+#define FLASH_WRProt_Pages60to63         ((uint32_t)0x00008000) /* CH32 Medium-density devices: Write protection of page 60 to 63 */
+#define FLASH_WRProt_Pages64to67         ((uint32_t)0x00010000) /* CH32 Medium-density devices: Write protection of page 64 to 67 */
+#define FLASH_WRProt_Pages68to71         ((uint32_t)0x00020000) /* CH32 Medium-density devices: Write protection of page 68 to 71 */
+#define FLASH_WRProt_Pages72to75         ((uint32_t)0x00040000) /* CH32 Medium-density devices: Write protection of page 72 to 75 */
+#define FLASH_WRProt_Pages76to79         ((uint32_t)0x00080000) /* CH32 Medium-density devices: Write protection of page 76 to 79 */
+#define FLASH_WRProt_Pages80to83         ((uint32_t)0x00100000) /* CH32 Medium-density devices: Write protection of page 80 to 83 */
+#define FLASH_WRProt_Pages84to87         ((uint32_t)0x00200000) /* CH32 Medium-density devices: Write protection of page 84 to 87 */
+#define FLASH_WRProt_Pages88to91         ((uint32_t)0x00400000) /* CH32 Medium-density devices: Write protection of page 88 to 91 */
+#define FLASH_WRProt_Pages92to95         ((uint32_t)0x00800000) /* CH32 Medium-density devices: Write protection of page 92 to 95 */
+#define FLASH_WRProt_Pages96to99         ((uint32_t)0x01000000) /* CH32 Medium-density devices: Write protection of page 96 to 99 */
+#define FLASH_WRProt_Pages100to103       ((uint32_t)0x02000000) /* CH32 Medium-density devices: Write protection of page 100 to 103 */
+#define FLASH_WRProt_Pages104to107       ((uint32_t)0x04000000) /* CH32 Medium-density devices: Write protection of page 104 to 107 */
+#define FLASH_WRProt_Pages108to111       ((uint32_t)0x08000000) /* CH32 Medium-density devices: Write protection of page 108 to 111 */
+#define FLASH_WRProt_Pages112to115       ((uint32_t)0x10000000) /* CH32 Medium-density devices: Write protection of page 112 to 115 */
+#define FLASH_WRProt_Pages116to119       ((uint32_t)0x20000000) /* CH32 Medium-density devices: Write protection of page 115 to 119 */
+#define FLASH_WRProt_Pages120to123       ((uint32_t)0x40000000) /* CH32 Medium-density devices: Write protection of page 120 to 123 */
+#define FLASH_WRProt_Pages124to127       ((uint32_t)0x80000000) /* CH32 Medium-density devices: Write protection of page 124 to 127 */
+
+#define FLASH_WRProt_Pages62to255        ((uint32_t)0x80000000) /* CH32 Medium-density devices: Write protection of page 62 to 255 */
+
+#define FLASH_WRProt_AllPages            ((uint32_t)0xFFFFFFFF) /* Write protection of all Pages */
+
+#endif // defined(CH32V10x)
+
 /* Option_Bytes_IWatchdog */
 #define OB_IWDG_SW                       ((uint16_t)0x0001) /* Software IWDG selected */
 #define OB_IWDG_HW                       ((uint16_t)0x0000) /* Hardware IWDG selected */
@@ -3173,11 +9698,13 @@ typedef enum
 #define OB_STDBY_NoRST                   ((uint16_t)0x0004) /* No reset generated when entering in STANDBY */
 #define OB_STDBY_RST                     ((uint16_t)0x0000) /* Reset generated when entering in STANDBY */
 
+#ifdef CH32V003
 /* Option_Bytes_RST_ENandDT */
 #define OB_RST_NoEN                      ((uint16_t)0x0018) /* Reset IO disable (PD7)*/
 #define OB_RST_EN_DT12ms                 ((uint16_t)0x0010) /* Reset IO enable (PD7) and  Ignore delay time 12ms */
 #define OB_RST_EN_DT1ms                  ((uint16_t)0x0008) /* Reset IO enable (PD7) and  Ignore delay time 1ms */
 #define OB_RST_EN_DT128ms                ((uint16_t)0x0000) /* Reset IO enable (PD7) and  Ignore delay time 128ms */
+#endif
 
 /* FLASH_Interrupts */
 #define FLASH_IT_ERROR                   ((uint32_t)0x00000400) /* FPEC error interrupt source */
@@ -3188,29 +9715,139 @@ typedef enum
 /* FLASH_Flags */
 #define FLASH_FLAG_BSY                   ((uint32_t)0x00000001) /* FLASH Busy flag */
 #define FLASH_FLAG_EOP                   ((uint32_t)0x00000020) /* FLASH End of Operation flag */
+#if defined(CH32V10x)
+#define FLASH_FLAG_PGERR                 ((uint32_t)0x00000004) /* FLASH Program error flag */
+#endif
 #define FLASH_FLAG_WRPRTERR              ((uint32_t)0x00000010) /* FLASH Write protected error flag */
 #define FLASH_FLAG_OPTERR                ((uint32_t)0x00000001) /* FLASH Option Byte error flag */
 
 #define FLASH_FLAG_BANK1_BSY             FLASH_FLAG_BSY       /* FLASH BANK1 Busy flag*/
 #define FLASH_FLAG_BANK1_EOP             FLASH_FLAG_EOP       /* FLASH BANK1 End of Operation flag */
+#if defined(CH32V10x)
+#define FLASH_FLAG_BANK1_PGERR           FLASH_FLAG_PGERR     /* FLASH BANK1 Program error flag */
+#endif
 #define FLASH_FLAG_BANK1_WRPRTERR        FLASH_FLAG_WRPRTERR  /* FLASH BANK1 Write protected error flag */
 
+#if defined(CH32V20x) || defined(CH32V30x)
+/* FLASH_Access_CLK */
+#define FLASH_Access_SYSTEM_HALF      ((uint32_t)0x00000000) /* FLASH Enhance Clock = SYSTEM */
+#define FLASH_Access_SYSTEM           ((uint32_t)0x02000000) /* Enhance_CLK = SYSTEM/2 */
+#endif
+
+#if defined(CH32V003)
 /* System_Reset_Start_Mode */
 #define Start_Mode_USER                  ((uint32_t)0x00000000)
 #define Start_Mode_BOOT                  ((uint32_t)0x00004000)
+#endif
 
+#if defined(CH32V30x)
+
+/* ch32v30x_fsmc.h ------------------------------------------------------------*/
+
+/* FSMC_NORSRAM_Bank */
+#define FSMC_Bank1_NORSRAM1                             ((uint32_t)0x00000000)
+
+/* FSMC_NAND_Bank */
+#define FSMC_Bank2_NAND                                 ((uint32_t)0x00000010)
+
+/* FSMC_Data_Address_Bus_Multiplexing */
+#define FSMC_DataAddressMux_Disable                     ((uint32_t)0x00000000)
+#define FSMC_DataAddressMux_Enable                      ((uint32_t)0x00000002)
+
+/* FSMC_Memory_Type */
+#define FSMC_MemoryType_SRAM                            ((uint32_t)0x00000000)
+#define FSMC_MemoryType_PSRAM                           ((uint32_t)0x00000004)
+#define FSMC_MemoryType_NOR                             ((uint32_t)0x00000008)
+
+/* FSMC_Data_Width */
+#define FSMC_MemoryDataWidth_8b                         ((uint32_t)0x00000000)
+#define FSMC_MemoryDataWidth_16b                        ((uint32_t)0x00000010)
+
+/* FSMC_Burst_Access_Mode */
+#define FSMC_BurstAccessMode_Disable                    ((uint32_t)0x00000000)
+#define FSMC_BurstAccessMode_Enable                     ((uint32_t)0x00000100)
+
+/* FSMC_AsynchronousWait */
+#define FSMC_AsynchronousWait_Disable                   ((uint32_t)0x00000000)
+#define FSMC_AsynchronousWait_Enable                    ((uint32_t)0x00008000)
+
+/* FSMC_Wait_Signal_Polarity */
+#define FSMC_WaitSignalPolarity_Low                     ((uint32_t)0x00000000)
+#define FSMC_WaitSignalPolarity_High                    ((uint32_t)0x00000200)
+
+/* FSMC_Wrap_Mode */
+#define FSMC_WrapMode_Disable                           ((uint32_t)0x00000000)
+#define FSMC_WrapMode_Enable                            ((uint32_t)0x00000400)
+
+/* FSMC_Wait_Timing */
+#define FSMC_WaitSignalActive_BeforeWaitState           ((uint32_t)0x00000000)
+#define FSMC_WaitSignalActive_DuringWaitState           ((uint32_t)0x00000800)
+
+/* FSMC_Write_Operation */
+#define FSMC_WriteOperation_Disable                     ((uint32_t)0x00000000)
+#define FSMC_WriteOperation_Enable                      ((uint32_t)0x00001000)
+
+/* FSMC_Wait_Signal */
+#define FSMC_WaitSignal_Disable                         ((uint32_t)0x00000000)
+#define FSMC_WaitSignal_Enable                          ((uint32_t)0x00002000)
+
+/* FSMC_Extended_Mode */
+#define FSMC_ExtendedMode_Disable                       ((uint32_t)0x00000000)
+#define FSMC_ExtendedMode_Enable                        ((uint32_t)0x00004000)
+
+/* FSMC_Write_Burst */
+#define FSMC_WriteBurst_Disable                         ((uint32_t)0x00000000)
+#define FSMC_WriteBurst_Enable                          ((uint32_t)0x00080000)
+
+/* FSMC_Access_Mode */
+#define FSMC_AccessMode_A                               ((uint32_t)0x00000000)
+#define FSMC_AccessMode_B                               ((uint32_t)0x10000000)
+#define FSMC_AccessMode_C                               ((uint32_t)0x20000000)
+#define FSMC_AccessMode_D                               ((uint32_t)0x30000000)
+
+/* FSMC_Wait_feature */
+#define FSMC_Waitfeature_Disable                        ((uint32_t)0x00000000)
+#define FSMC_Waitfeature_Enable                         ((uint32_t)0x00000002)
+
+/* FSMC_ECC */
+#define FSMC_ECC_Disable                                ((uint32_t)0x00000000)
+#define FSMC_ECC_Enable                                 ((uint32_t)0x00000040)
+
+/* FSMC_ECC_Page_Size */
+#define FSMC_ECCPageSize_256Bytes                       ((uint32_t)0x00000000)
+#define FSMC_ECCPageSize_512Bytes                       ((uint32_t)0x00020000)
+#define FSMC_ECCPageSize_1024Bytes                      ((uint32_t)0x00040000)
+#define FSMC_ECCPageSize_2048Bytes                      ((uint32_t)0x00060000)
+#define FSMC_ECCPageSize_4096Bytes                      ((uint32_t)0x00080000)
+#define FSMC_ECCPageSize_8192Bytes                      ((uint32_t)0x000A0000)
+
+/* FSMC_Interrupt_sources */
+#define FSMC_IT_RisingEdge                              ((uint32_t)0x00000008)
+#define FSMC_IT_Level                                   ((uint32_t)0x00000010)
+#define FSMC_IT_FallingEdge                             ((uint32_t)0x00000020)
+
+/* FSMC_Flags */
+#define FSMC_FLAG_RisingEdge                            ((uint32_t)0x00000001)
+#define FSMC_FLAG_Level                                 ((uint32_t)0x00000002)
+#define FSMC_FLAG_FallingEdge                           ((uint32_t)0x00000004)
+#define FSMC_FLAG_FEMPT                                 ((uint32_t)0x00000040)
+
+#endif
 
 /* ch32v00x_gpio.h ------------------------------------------------------------*/
+
+#ifndef __ASSEMBLER__
 
 /* Output Maximum frequency selection */
 typedef enum
 {
-    GPIO_Speed_10MHz = 1,
-    GPIO_Speed_2MHz,
-    GPIO_Speed_50MHz
+	GPIO_Speed_In = 0,
+	GPIO_Speed_10MHz,
+	GPIO_Speed_2MHz,
+	GPIO_Speed_50MHz
 } GPIOSpeed_TypeDef;
 
-#define GPIO_SPEED_IN 0
+#endif
 
 #define GPIO_CNF_IN_ANALOG   0
 #define GPIO_CNF_IN_FLOATING 4
@@ -3235,6 +9872,7 @@ typedef enum
 } GPIOMode_TypeDef;
 */
 
+#ifndef __ASSEMBLER__
 
 /* Bit_SET and Bit_RESET enumeration */
 typedef enum
@@ -3242,6 +9880,8 @@ typedef enum
     Bit_RESET = 0,
     Bit_SET
 } BitAction;
+
+#endif
 
 /* GPIO_pins_define */
 #define GPIO_Pin_0                     ((uint16_t)0x0001) /* Pin 0 selected */
@@ -3252,9 +9892,21 @@ typedef enum
 #define GPIO_Pin_5                     ((uint16_t)0x0020) /* Pin 5 selected */
 #define GPIO_Pin_6                     ((uint16_t)0x0040) /* Pin 6 selected */
 #define GPIO_Pin_7                     ((uint16_t)0x0080) /* Pin 7 selected */
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define GPIO_Pin_8                      ((uint16_t)0x0100) /* Pin 8 selected */
+#define GPIO_Pin_9                      ((uint16_t)0x0200) /* Pin 9 selected */
+#define GPIO_Pin_10                     ((uint16_t)0x0400) /* Pin 10 selected */
+#define GPIO_Pin_11                     ((uint16_t)0x0800) /* Pin 11 selected */
+#define GPIO_Pin_12                     ((uint16_t)0x1000) /* Pin 12 selected */
+#define GPIO_Pin_13                     ((uint16_t)0x2000) /* Pin 13 selected */
+#define GPIO_Pin_14                     ((uint16_t)0x4000) /* Pin 14 selected */
+#define GPIO_Pin_15                     ((uint16_t)0x8000) /* Pin 15 selected */
+#endif
 #define GPIO_Pin_All                   ((uint16_t)0xFFFF) /* All pins selected */
 
 /* GPIO_Remap_define */
+#ifdef CH32V003
+
 #define GPIO_Remap_SPI1                ((uint32_t)0x00000001) /* SPI1 Alternate Function mapping */
 #define GPIO_PartialRemap_I2C1         ((uint32_t)0x10000002) /* I2C1 Partial Alternate Function mapping */
 #define GPIO_FullRemap_I2C1            ((uint32_t)0x10400002) /* I2C1 Full Alternate Function mapping */
@@ -3273,10 +9925,106 @@ typedef enum
 #define GPIO_Remap_LSI_CAL             ((uint32_t)0x00200080) /* LSI calibration Alternate Function mapping */
 #define GPIO_Remap_SDI_Disable         ((uint32_t)0x00300400) /* SDI Disabled */
 
+#elif defined(CH32V20x) || defined(CH32V30x)
+
+/* PCFR1 */
+#define GPIO_Remap_SPI1                 ((uint32_t)0x00000001) /* SPI1 Alternate Function mapping */
+#define GPIO_Remap_I2C1                 ((uint32_t)0x00000002) /* I2C1 Alternate Function mapping */
+#define GPIO_Remap_USART1               ((uint32_t)0x00000004) /* USART1 Alternate Function mapping low bit */
+#define GPIO_Remap_USART2               ((uint32_t)0x00000008) /* USART2 Alternate Function mapping */
+#define GPIO_PartialRemap_USART3        ((uint32_t)0x00140010) /* USART3 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART3           ((uint32_t)0x00140030) /* USART3 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM1          ((uint32_t)0x00160040) /* TIM1 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM1             ((uint32_t)0x001600C0) /* TIM1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM2         ((uint32_t)0x00180100) /* TIM2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM2         ((uint32_t)0x00180200) /* TIM2 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_TIM2             ((uint32_t)0x00180300) /* TIM2 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM3          ((uint32_t)0x001A0800) /* TIM3 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM3             ((uint32_t)0x001A0C00) /* TIM3 Full Alternate Function mapping */
+#define GPIO_Remap_TIM4                 ((uint32_t)0x00001000) /* TIM4 Alternate Function mapping */
+#define GPIO_Remap1_CAN1                ((uint32_t)0x001D4000) /* CAN1 Alternate Function mapping */
+#define GPIO_Remap2_CAN1                ((uint32_t)0x001D6000) /* CAN1 Alternate Function mapping */
+#define GPIO_Remap_PD01                 ((uint32_t)0x00008000) /* PD01 Alternate Function mapping */
+#define GPIO_Remap_TIM5CH4_LSI          ((uint32_t)0x00200001) /* LSI connected to TIM5 Channel4 input capture for calibration */
+#define GPIO_Remap_ADC1_ETRGINJ         ((uint32_t)0x00200002) /* ADC1 External Trigger Injected Conversion remapping */
+#define GPIO_Remap_ADC1_ETRGREG         ((uint32_t)0x00200004) /* ADC1 External Trigger Regular Conversion remapping */
+#define GPIO_Remap_ADC2_ETRGINJ         ((uint32_t)0x00200008) /* ADC2 External Trigger Injected Conversion remapping */
+#define GPIO_Remap_ADC2_ETRGREG         ((uint32_t)0x00200010) /* ADC2 External Trigger Regular Conversion remapping */
+#define GPIO_Remap_ETH                  ((uint32_t)0x00200020) /* Ethernet remapping (only for Connectivity line devices) */
+#define GPIO_Remap_CAN2                 ((uint32_t)0x00200040) /* CAN2 remapping (only for Connectivity line devices) */
+#define GPIO_Remap_MII_RMII_SEL         ((uint32_t)0x00200080) /* MII or RMII selection */
+#define GPIO_Remap_SWJ_Disable          ((uint32_t)0x00300400) /* Full SWJ Disabled (JTAG-DP + SW-DP) */
+#define GPIO_Remap_SPI3                 ((uint32_t)0x00201000) /* SPI3/I2S3 Alternate Function mapping (only for Connectivity line devices) */
+#define GPIO_Remap_TIM2ITR1_PTP_SOF     ((uint32_t)0x00202000) /* Ethernet PTP output or USB OTG SOF (Start of Frame) connected \
+                                                                  to TIM2 Internal Trigger 1 for calibration                    \
+                                                                  (only for Connectivity line devices) */
+#define GPIO_Remap_PTP_PPS              ((uint32_t)0x00204000) /* Ethernet MAC PPS_PTS output on PB05 (only for Connectivity line devices) */
+
+/* PCFR2 */
+#define GPIO_Remap_TIM8                 ((uint32_t)0x80000004) /* TIM8 Alternate Function mapping */
+#define GPIO_PartialRemap_TIM9          ((uint32_t)0x80130008) /* TIM9 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM9             ((uint32_t)0x80130010) /* TIM9 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM10         ((uint32_t)0x80150020) /* TIM10 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM10            ((uint32_t)0x80150040) /* TIM10 Full Alternate Function mapping */
+#define GPIO_Remap_FSMC_NADV            ((uint32_t)0x80000400) /* FSMC_NADV Alternate Function mapping */
+#define GPIO_PartialRemap_USART4        ((uint32_t)0x80300001) /* USART4 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART4           ((uint32_t)0x80300002) /* USART4 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART5        ((uint32_t)0x80320004) /* USART5 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART5           ((uint32_t)0x80320008) /* USART5 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART6        ((uint32_t)0x80340010) /* USART6 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART6           ((uint32_t)0x80340020) /* USART6 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART7        ((uint32_t)0x80360040) /* USART7 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART7           ((uint32_t)0x80360080) /* USART7 Full Alternate Function mapping */
+#define GPIO_PartialRemap_USART8        ((uint32_t)0x80380100) /* USART8 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART8           ((uint32_t)0x80380200) /* USART8 Full Alternate Function mapping */
+#define GPIO_Remap_USART1_HighBit       ((uint32_t)0x80200400) /* USART1 Alternate Function mapping high bit */
+
+#elif defined(CH32V10x)
+
+/* GPIO_Remap_define */
+#define GPIO_Remap_SPI1                ((uint32_t)0x00000001) /* SPI1 Alternate Function mapping */
+#define GPIO_Remap_I2C1                ((uint32_t)0x00000002) /* I2C1 Alternate Function mapping */
+#define GPIO_Remap_USART1              ((uint32_t)0x00000004) /* USART1 Alternate Function mapping */
+#define GPIO_Remap_USART2              ((uint32_t)0x00000008) /* USART2 Alternate Function mapping */
+#define GPIO_PartialRemap_USART3       ((uint32_t)0x00140010) /* USART3 Partial Alternate Function mapping */
+#define GPIO_FullRemap_USART3          ((uint32_t)0x00140030) /* USART3 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM1         ((uint32_t)0x00160040) /* TIM1 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM1            ((uint32_t)0x001600C0) /* TIM1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM2        ((uint32_t)0x00180100) /* TIM2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM2        ((uint32_t)0x00180200) /* TIM2 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_TIM2            ((uint32_t)0x00180300) /* TIM2 Full Alternate Function mapping */
+#define GPIO_PartialRemap_TIM3         ((uint32_t)0x001A0800) /* TIM3 Partial Alternate Function mapping */
+#define GPIO_FullRemap_TIM3            ((uint32_t)0x001A0C00) /* TIM3 Full Alternate Function mapping */
+#define GPIO_Remap_TIM4                ((uint32_t)0x00001000) /* TIM4 Alternate Function mapping */
+#define GPIO_Remap1_CAN1               ((uint32_t)0x001D4000) /* CAN1 Alternate Function mapping */
+#define GPIO_Remap2_CAN1               ((uint32_t)0x001D6000) /* CAN1 Alternate Function mapping */
+#define GPIO_Remap_PD01                ((uint32_t)0x00008000) /* PD01 Alternate Function mapping */
+#define GPIO_Remap_ADC1_ETRGINJ        ((uint32_t)0x00200002) /* ADC1 External Trigger Injected Conversion remapping */
+#define GPIO_Remap_ADC1_ETRGREG        ((uint32_t)0x00200004) /* ADC1 External Trigger Regular Conversion remapping */
+#define GPIO_Remap_SWJ_Disable         ((uint32_t)0x00300400) /* Full SWJ Disabled (JTAG-DP + SW-DP) */
+#define GPIO_Remap_TIM2ITR1_PTP_SOF    ((uint32_t)0x00202000) /* Ethernet PTP output or USB OTG SOF (Start of Frame) connected \
+                                                                 to TIM2 Internal Trigger 1 for calibration                    \
+                                                                 (only for Connectivity line devices) */
+#define GPIO_Remap_TIM1_DMA            ((uint32_t)0x80000010) /* TIM1 DMA requests mapping (only for Value line devices) */
+#define GPIO_Remap_TIM67_DAC_DMA       ((uint32_t)0x80000800) /* TIM6/TIM7 and DAC DMA requests remapping (only for High density Value line devices) */
+#define GPIO_Remap_MISC                ((uint32_t)0x80002000) /* Miscellaneous Remap (DMA2 Channel5 Position and DAC Trigger remapping, \
+                                                                   only for High density Value line devices) */
+
+#endif // defined(CH32V10x)
+
 /* GPIO_Port_Sources */
 #define GPIO_PortSourceGPIOA           ((uint8_t)0x00)
 #define GPIO_PortSourceGPIOC           ((uint8_t)0x02)
 #define GPIO_PortSourceGPIOD           ((uint8_t)0x03)
+#if defined(CH32X03x)
+#define GPIO_PortSourceGPIOB            ((uint8_t)0x01)
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define GPIO_PortSourceGPIOB            ((uint8_t)0x01)
+#define GPIO_PortSourceGPIOD            ((uint8_t)0x03)
+#define GPIO_PortSourceGPIOE            ((uint8_t)0x04)
+#define GPIO_PortSourceGPIOF            ((uint8_t)0x05)
+#define GPIO_PortSourceGPIOG            ((uint8_t)0x06)
+#endif
 
 /* GPIO_Pin_sources */
 #define GPIO_PinSource0                ((uint8_t)0x00)
@@ -3287,11 +10035,31 @@ typedef enum
 #define GPIO_PinSource5                ((uint8_t)0x05)
 #define GPIO_PinSource6                ((uint8_t)0x06)
 #define GPIO_PinSource7                ((uint8_t)0x07)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
+#define GPIO_PinSource8                 ((uint8_t)0x08)
+#define GPIO_PinSource9                 ((uint8_t)0x09)
+#define GPIO_PinSource10                ((uint8_t)0x0A)
+#define GPIO_PinSource11                ((uint8_t)0x0B)
+#define GPIO_PinSource12                ((uint8_t)0x0C)
+#define GPIO_PinSource13                ((uint8_t)0x0D)
+#define GPIO_PinSource14                ((uint8_t)0x0E)
+#define GPIO_PinSource15                ((uint8_t)0x0F)
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x)
+/* Ethernet_Media_Interface */
+#define GPIO_ETH_MediaInterface_MII     ((u32)0x00000000)
+#define GPIO_ETH_MediaInterface_RMII    ((u32)0x00000001)
+#endif
 
 /* ch32v00x_i2c.h ------------------------------------------------------------*/
 
 /* I2C_mode */
 #define I2C_Mode_I2C                                         ((uint16_t)0x0000)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define I2C_Mode_SMBusDevice                                 ((uint16_t)0x0002)
+#define I2C_Mode_SMBusHost                                   ((uint16_t)0x000A)
+#endif
 
 /* I2C_duty_cycle_in_fast_mode */
 #define I2C_DutyCycle_16_9                                   ((uint16_t)0x4000) /* I2C fast mode Tlow/Thigh = 16/9 */
@@ -3318,6 +10086,13 @@ typedef enum
 #define I2C_Register_STAR1                                   ((uint8_t)0x14)
 #define I2C_Register_STAR2                                   ((uint8_t)0x18)
 #define I2C_Register_CKCFGR                                  ((uint8_t)0x1C)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define I2C_Register_RTR                                     ((uint8_t)0x20)
+
+/* I2C_SMBus_alert_pin_level */
+#define I2C_SMBusAlert_Low                                   ((uint16_t)0x2000)
+#define I2C_SMBusAlert_High                                  ((uint16_t)0xDFFF)
+#endif
 
 /* I2C_PEC_position */
 #define I2C_PECPosition_Next                                 ((uint16_t)0x0800)
@@ -3348,12 +10123,20 @@ typedef enum
 
 /* SR2 register flags  */
 #define I2C_FLAG_DUALF                                       ((uint32_t)0x00800000)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define I2C_FLAG_SMBHOST                                     ((uint32_t)0x00400000)
+#define I2C_FLAG_SMBDEFAULT                                  ((uint32_t)0x00200000)
+#endif
 #define I2C_FLAG_GENCALL                                     ((uint32_t)0x00100000)
 #define I2C_FLAG_TRA                                         ((uint32_t)0x00040000)
 #define I2C_FLAG_BUSY                                        ((uint32_t)0x00020000)
 #define I2C_FLAG_MSL                                         ((uint32_t)0x00010000)
 
 /* SR1 register flags */
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define I2C_FLAG_SMBALERT                                    ((uint32_t)0x10008000)
+#define I2C_FLAG_TIMEOUT                                     ((uint32_t)0x10004000)
+#endif
 #define I2C_FLAG_PECERR                                      ((uint32_t)0x10001000)
 #define I2C_FLAG_OVR                                         ((uint32_t)0x10000800)
 #define I2C_FLAG_AF                                          ((uint32_t)0x10000400)
@@ -3561,10 +10344,22 @@ typedef enum
 #define NVIC_PriorityGroup_3           ((uint32_t)0x03)
 #define NVIC_PriorityGroup_4           ((uint32_t)0x04)
 
-
+#if !defined(CH32V10x)
 /* ch32v00x_opa.h ------------------------------------------------------------*/
 
 /* Editor's note: I don't know if this is actually useful */
+#ifndef __ASSEMBLER__
+
+#if defined(CH32V20x) || defined(CH32V30x)
+/* OPA member enumeration */
+typedef enum
+{
+    OPA1 = 0,
+    OPA2,
+    OPA3,
+    OPA4
+} OPA_Num_TypeDef;
+#endif
 
 /* OPA PSEL enumeration */
 typedef enum
@@ -3580,19 +10375,42 @@ typedef enum
     CHN1
 } OPA_NSEL_TypeDef;
 
+#if defined(CH32V20x) || defined(CH32V30x)
+/* OPA out channel enumeration */
+typedef enum
+{
+    OUT_IO_OUT0 = 0,
+    OUT_IO_OUT1
+} OPA_Mode_TypeDef;
+#endif
+
 
 /* OPA Init Structure definition */
+#ifdef CH32V003
 typedef struct
 {
     OPA_PSEL_TypeDef PSEL;    /* Specifies the positive channel of OPA */
     OPA_NSEL_TypeDef NSEL;    /* Specifies the negative channel of OPA */
 } OPA_InitTypeDef;
+#elif defined(CH32V20x) || defined(CH32V30x)
+typedef struct
+{
+    OPA_Num_TypeDef  OPA_NUM; /* Specifies the members of OPA */
+    OPA_PSEL_TypeDef PSEL;    /* Specifies the positive channel of OPA */
+    OPA_NSEL_TypeDef NSEL;    /* Specifies the negative channel of OPA */
+    OPA_Mode_TypeDef Mode;    /* Specifies the mode of OPA */
+} OPA_InitTypeDef;
+#endif
 
+#endif
 
 /* ch32v00x_pwr.h ------------------------------------------------------------*/
 
+#endif
 
+#ifdef CH32V003
 /* PVD_detection_level  */
+
 #define PWR_PVDLevel_2V9          ((uint32_t)0x00000000)
 #define PWR_PVDLevel_3V1          ((uint32_t)0x00000020)
 #define PWR_PVDLevel_3V3          ((uint32_t)0x00000040)
@@ -3626,6 +10444,33 @@ typedef struct
 /* PWR_Flag */
 #define PWR_FLAG_PVDO             ((uint32_t)0x00000004)
 
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* PVD_detection_level  */
+#define PWR_PVDLevel_2V2          ((uint32_t)0x00000000)
+#define PWR_PVDLevel_2V3          ((uint32_t)0x00000020)
+#define PWR_PVDLevel_2V4          ((uint32_t)0x00000040)
+#define PWR_PVDLevel_2V5          ((uint32_t)0x00000060)
+#define PWR_PVDLevel_2V6          ((uint32_t)0x00000080)
+#define PWR_PVDLevel_2V7          ((uint32_t)0x000000A0)
+#define PWR_PVDLevel_2V8          ((uint32_t)0x000000C0)
+#define PWR_PVDLevel_2V9          ((uint32_t)0x000000E0)
+
+/* Regulator_state_is_STOP_mode */
+#define PWR_Regulator_ON          ((uint32_t)0x00000000)
+#define PWR_Regulator_LowPower    ((uint32_t)0x00000001)
+
+/* STOP_mode_entry */
+#define PWR_STOPEntry_WFI         ((uint8_t)0x01)
+#define PWR_STOPEntry_WFE         ((uint8_t)0x02)
+
+/* PWR_Flag */
+#define PWR_FLAG_WU               ((uint32_t)0x00000001)
+#define PWR_FLAG_SB               ((uint32_t)0x00000002)
+#define PWR_FLAG_PVDO             ((uint32_t)0x00000004)
+
+#endif
+
 
 /* ch32v00x_rcc.h ------------------------------------------------------------*/
 
@@ -3635,14 +10480,167 @@ typedef struct
 #define RCC_HSE_ON                       ((uint32_t)0x00010000)
 #define RCC_HSE_Bypass                   ((uint32_t)0x00040000)
 
+#ifdef CH32V003
+
 /* PLL_entry_clock_source */
 #define RCC_PLLSource_HSI_MUL2           ((uint32_t)0x00000000)
 #define RCC_PLLSource_HSE_MUL2           ((uint32_t)0x00030000)
+
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* PLL_entry_clock_source */
+#define RCC_PLLSource_HSI_Div2          ((uint32_t)0x00000000)
+
+#if defined(CH32V20x) || defined(CH32V30x_D8) || defined(CH32V10x)
+
+#define RCC_PLLSource_HSE_Div1          ((uint32_t)0x00010000)
+#define RCC_PLLSource_HSE_Div2          ((uint32_t)0x00030000)
+
+#else
+
+#define RCC_PLLSource_PREDIV1            ((uint32_t)0x00010000)
+
+#endif
+
+#if defined(CH32V20x) || defined(CH32V30x_D8) || defined(CH32V10x)
+
+/* PLL_multiplication_factor for other CH32V20x  */
+#define RCC_PLLMul_2                    ((uint32_t)0x00000000)
+#define RCC_PLLMul_3                    ((uint32_t)0x00040000)
+#define RCC_PLLMul_4                    ((uint32_t)0x00080000)
+#define RCC_PLLMul_5                    ((uint32_t)0x000C0000)
+#define RCC_PLLMul_6                    ((uint32_t)0x00100000)
+#define RCC_PLLMul_7                    ((uint32_t)0x00140000)
+#define RCC_PLLMul_8                    ((uint32_t)0x00180000)
+#define RCC_PLLMul_9                    ((uint32_t)0x001C0000)
+#define RCC_PLLMul_10                   ((uint32_t)0x00200000)
+#define RCC_PLLMul_11                   ((uint32_t)0x00240000)
+#define RCC_PLLMul_12                   ((uint32_t)0x00280000)
+#define RCC_PLLMul_13                   ((uint32_t)0x002C0000)
+#define RCC_PLLMul_14                   ((uint32_t)0x00300000)
+#define RCC_PLLMul_15                   ((uint32_t)0x00340000)
+#define RCC_PLLMul_16                   ((uint32_t)0x00380000)
+
+#if !defined(CH32V10x)
+#define RCC_PLLMul_18                   ((uint32_t)0x003C0000)
+#endif
+
+#else
+
+#define RCC_PLLMul_18_EXTEN              ((uint32_t)0x00000000)
+#define RCC_PLLMul_3_EXTEN               ((uint32_t)0x00040000)
+#define RCC_PLLMul_4_EXTEN               ((uint32_t)0x00080000)
+#define RCC_PLLMul_5_EXTEN               ((uint32_t)0x000C0000)
+#define RCC_PLLMul_6_EXTEN               ((uint32_t)0x00100000)
+#define RCC_PLLMul_7_EXTEN               ((uint32_t)0x00140000)
+#define RCC_PLLMul_8_EXTEN               ((uint32_t)0x00180000)
+#define RCC_PLLMul_9_EXTEN               ((uint32_t)0x001C0000)
+#define RCC_PLLMul_10_EXTEN              ((uint32_t)0x00200000)
+#define RCC_PLLMul_11_EXTEN              ((uint32_t)0x00240000)
+#define RCC_PLLMul_12_EXTEN              ((uint32_t)0x00280000)
+#define RCC_PLLMul_13_EXTEN              ((uint32_t)0x002C0000)
+#define RCC_PLLMul_14_EXTEN              ((uint32_t)0x00300000)
+#define RCC_PLLMul_6_5_EXTEN             ((uint32_t)0x00340000)
+#define RCC_PLLMul_15_EXTEN              ((uint32_t)0x00380000)
+#define RCC_PLLMul_16_EXTEN              ((uint32_t)0x003C0000)
+
+#endif // defined(CH32V20x) || defined(CH32V30x_D8) || defined(CH32V10x)
+
+/* PREDIV1_division_factor */
+#ifdef CH32V30x_D8C
+#define RCC_PREDIV1_Div1                 ((uint32_t)0x00000000)
+#define RCC_PREDIV1_Div2                 ((uint32_t)0x00000001)
+#define RCC_PREDIV1_Div3                 ((uint32_t)0x00000002)
+#define RCC_PREDIV1_Div4                 ((uint32_t)0x00000003)
+#define RCC_PREDIV1_Div5                 ((uint32_t)0x00000004)
+#define RCC_PREDIV1_Div6                 ((uint32_t)0x00000005)
+#define RCC_PREDIV1_Div7                 ((uint32_t)0x00000006)
+#define RCC_PREDIV1_Div8                 ((uint32_t)0x00000007)
+#define RCC_PREDIV1_Div9                 ((uint32_t)0x00000008)
+#define RCC_PREDIV1_Div10                ((uint32_t)0x00000009)
+#define RCC_PREDIV1_Div11                ((uint32_t)0x0000000A)
+#define RCC_PREDIV1_Div12                ((uint32_t)0x0000000B)
+#define RCC_PREDIV1_Div13                ((uint32_t)0x0000000C)
+#define RCC_PREDIV1_Div14                ((uint32_t)0x0000000D)
+#define RCC_PREDIV1_Div15                ((uint32_t)0x0000000E)
+#define RCC_PREDIV1_Div16                ((uint32_t)0x0000000F)
+
+#endif
+
+/* PREDIV1_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_PREDIV1_Source_HSE           ((uint32_t)0x00000000)
+#define RCC_PREDIV1_Source_PLL2          ((uint32_t)0x00010000)
+#endif
+
+/* PREDIV2_division_factor */
+#ifdef CH32V30x_D8C
+#define RCC_PREDIV2_Div1                 ((uint32_t)0x00000000)
+#define RCC_PREDIV2_Div2                 ((uint32_t)0x00000010)
+#define RCC_PREDIV2_Div3                 ((uint32_t)0x00000020)
+#define RCC_PREDIV2_Div4                 ((uint32_t)0x00000030)
+#define RCC_PREDIV2_Div5                 ((uint32_t)0x00000040)
+#define RCC_PREDIV2_Div6                 ((uint32_t)0x00000050)
+#define RCC_PREDIV2_Div7                 ((uint32_t)0x00000060)
+#define RCC_PREDIV2_Div8                 ((uint32_t)0x00000070)
+#define RCC_PREDIV2_Div9                 ((uint32_t)0x00000080)
+#define RCC_PREDIV2_Div10                ((uint32_t)0x00000090)
+#define RCC_PREDIV2_Div11                ((uint32_t)0x000000A0)
+#define RCC_PREDIV2_Div12                ((uint32_t)0x000000B0)
+#define RCC_PREDIV2_Div13                ((uint32_t)0x000000C0)
+#define RCC_PREDIV2_Div14                ((uint32_t)0x000000D0)
+#define RCC_PREDIV2_Div15                ((uint32_t)0x000000E0)
+#define RCC_PREDIV2_Div16                ((uint32_t)0x000000F0)
+#endif
+
+/* PLL2_multiplication_factor */
+#ifdef CH32V30x_D8C
+#define RCC_PLL2Mul_2_5                  ((uint32_t)0x00000000)
+#define RCC_PLL2Mul_12_5                 ((uint32_t)0x00000100)
+#define RCC_PLL2Mul_4                    ((uint32_t)0x00000200)
+#define RCC_PLL2Mul_5                    ((uint32_t)0x00000300)
+#define RCC_PLL2Mul_6                    ((uint32_t)0x00000400)
+#define RCC_PLL2Mul_7                    ((uint32_t)0x00000500)
+#define RCC_PLL2Mul_8                    ((uint32_t)0x00000600)
+#define RCC_PLL2Mul_9                    ((uint32_t)0x00000700)
+#define RCC_PLL2Mul_10                   ((uint32_t)0x00000800)
+#define RCC_PLL2Mul_11                   ((uint32_t)0x00000900)
+#define RCC_PLL2Mul_12                   ((uint32_t)0x00000A00)
+#define RCC_PLL2Mul_13                   ((uint32_t)0x00000B00)
+#define RCC_PLL2Mul_14                   ((uint32_t)0x00000C00)
+#define RCC_PLL2Mul_15                   ((uint32_t)0x00000D00)
+#define RCC_PLL2Mul_16                   ((uint32_t)0x00000E00)
+#define RCC_PLL2Mul_20                   ((uint32_t)0x00000F00)
+#endif
+
+/* PLL3_multiplication_factor */
+#ifdef CH32V30x_D8C
+#define RCC_PLL3Mul_2_5                  ((uint32_t)0x00000000)
+#define RCC_PLL3Mul_12_5                 ((uint32_t)0x00001000)
+#define RCC_PLL3Mul_4                    ((uint32_t)0x00002000)
+#define RCC_PLL3Mul_5                    ((uint32_t)0x00003000)
+#define RCC_PLL3Mul_6                    ((uint32_t)0x00004000)
+#define RCC_PLL3Mul_7                    ((uint32_t)0x00005000)
+#define RCC_PLL3Mul_8                    ((uint32_t)0x00006000)
+#define RCC_PLL3Mul_9                    ((uint32_t)0x00007000)
+#define RCC_PLL3Mul_10                   ((uint32_t)0x00008000)
+#define RCC_PLL3Mul_11                   ((uint32_t)0x00009000)
+#define RCC_PLL3Mul_12                   ((uint32_t)0x0000A000)
+#define RCC_PLL3Mul_13                   ((uint32_t)0x0000B000)
+#define RCC_PLL3Mul_14                   ((uint32_t)0x0000C000)
+#define RCC_PLL3Mul_15                   ((uint32_t)0x0000D000)
+#define RCC_PLL3Mul_16                   ((uint32_t)0x0000E000)
+#define RCC_PLL3Mul_20                   ((uint32_t)0x0000F000)
+#endif
+
+#endif
 
 /* System_clock_source */
 #define RCC_SYSCLKSource_HSI             ((uint32_t)0x00000000)
 #define RCC_SYSCLKSource_HSE             ((uint32_t)0x00000001)
 #define RCC_SYSCLKSource_PLLCLK          ((uint32_t)0x00000002)
+
+#ifdef CH32V003
 
 /* AHB_clock_source */
 #define RCC_SYSCLK_Div1                  ((uint32_t)0x00000000)
@@ -3659,12 +10657,84 @@ typedef struct
 #define RCC_SYSCLK_Div128                ((uint32_t)0x000000E0)
 #define RCC_SYSCLK_Div256                ((uint32_t)0x000000F0)
 
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* AHB_clock_source */
+#define RCC_SYSCLK_Div1                 ((uint32_t)0x00000000)
+#define RCC_SYSCLK_Div2                 ((uint32_t)0x00000080)
+#define RCC_SYSCLK_Div4                 ((uint32_t)0x00000090)
+#define RCC_SYSCLK_Div8                 ((uint32_t)0x000000A0)
+#define RCC_SYSCLK_Div16                ((uint32_t)0x000000B0)
+#define RCC_SYSCLK_Div64                ((uint32_t)0x000000C0)
+#define RCC_SYSCLK_Div128               ((uint32_t)0x000000D0)
+#define RCC_SYSCLK_Div256               ((uint32_t)0x000000E0)
+#define RCC_SYSCLK_Div512               ((uint32_t)0x000000F0)
+
+/* APB1_APB2_clock_source */
+#define RCC_HCLK_Div1                   ((uint32_t)0x00000000)
+#define RCC_HCLK_Div2                   ((uint32_t)0x00000400)
+#define RCC_HCLK_Div4                   ((uint32_t)0x00000500)
+#define RCC_HCLK_Div8                   ((uint32_t)0x00000600)
+#define RCC_HCLK_Div16                  ((uint32_t)0x00000700)
+
+#endif
+
 /* RCC_Interrupt_source */
 #define RCC_IT_LSIRDY                    ((uint8_t)0x01)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define RCC_IT_LSERDY                   ((uint8_t)0x02)
+#endif
 #define RCC_IT_HSIRDY                    ((uint8_t)0x04)
 #define RCC_IT_HSERDY                    ((uint8_t)0x08)
 #define RCC_IT_PLLRDY                    ((uint8_t)0x10)
 #define RCC_IT_CSS                       ((uint8_t)0x80)
+
+#ifdef CH32V30x_D8C
+#define RCC_IT_PLL2RDY                   ((uint8_t)0x20)
+#define RCC_IT_PLL3RDY                   ((uint8_t)0x40)
+#endif
+
+#if defined(CH32V20x)
+
+/* USB_Device_clock_source */
+#define RCC_USBCLKSource_PLLCLK_Div1    ((uint8_t)0x00)
+#define RCC_USBCLKSource_PLLCLK_Div2    ((uint8_t)0x01)
+#define RCC_USBCLKSource_PLLCLK_Div3    ((uint8_t)0x02)
+
+#ifdef CH32V20x_D8W
+  #define RCC_USBCLKSource_PLLCLK_Div5    ((uint8_t)0x03)
+#endif
+
+#endif
+
+#if defined(CH32V10x)
+/* USB_Device_clock_source */
+#define RCC_USBCLKSource_PLLCLK_1Div5    ((uint8_t)0x00)
+#define RCC_USBCLKSource_PLLCLK_Div1     ((uint8_t)0x01)
+#endif
+
+#if defined(CH32V30x)
+
+/* USB_OTG_FS_clock_source */
+#define RCC_OTGFSCLKSource_PLLCLK_Div1   ((uint8_t)0x00)
+#define RCC_OTGFSCLKSource_PLLCLK_Div2   ((uint8_t)0x01)
+#define RCC_OTGFSCLKSource_PLLCLK_Div3   ((uint8_t)0x02)
+
+/* I2S2_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_I2S2CLKSource_SYSCLK         ((uint8_t)0x00)
+#define RCC_I2S2CLKSource_PLL3_VCO       ((uint8_t)0x01)
+#endif
+
+/* I2S3_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_I2S3CLKSource_SYSCLK         ((uint8_t)0x00)
+#define RCC_I2S3CLKSource_PLL3_VCO       ((uint8_t)0x01)
+#endif
+
+#endif
+
+#ifdef CH32V003
 
 /* ADC_clock_source */
 #define RCC_PCLK2_Div2                   ((uint32_t)0x00000000)
@@ -3680,6 +10750,28 @@ typedef struct
 #define RCC_PCLK2_Div96                  ((uint32_t)0x0000B800)
 #define RCC_PCLK2_Div128                 ((uint32_t)0x0000F800)
 
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* ADC_clock_source */
+#define RCC_PCLK2_Div2                 ((uint32_t)0x00000000)
+#define RCC_PCLK2_Div4                 ((uint32_t)0x00004000)
+#define RCC_PCLK2_Div6                 ((uint32_t)0x00008000)
+#define RCC_PCLK2_Div8                 ((uint32_t)0x0000C000)
+
+/* LSE_configuration */
+#define RCC_LSE_OFF                    ((uint8_t)0x00)
+#define RCC_LSE_ON                     ((uint8_t)0x01)
+#define RCC_LSE_Bypass                 ((uint8_t)0x04)
+
+/* RTC_clock_source */
+#define RCC_RTCCLKSource_LSE           ((uint32_t)0x00000100)
+#define RCC_RTCCLKSource_LSI           ((uint32_t)0x00000200)
+#define RCC_RTCCLKSource_HSE_Div128    ((uint32_t)0x00000300)
+
+#endif
+
+#if defined(CH32V003) || defined(CH32X03x)
+
 /* AHB_peripheral */
 #define RCC_AHBPeriph_DMA1               ((uint32_t)0x00000001)
 #define RCC_AHBPeriph_SRAM               ((uint32_t)0x00000004)
@@ -3687,6 +10779,9 @@ typedef struct
 /* APB2_peripheral */
 #define RCC_APB2Periph_AFIO              ((uint32_t)0x00000001)
 #define RCC_APB2Periph_GPIOA             ((uint32_t)0x00000004)
+#ifdef CH32X03x
+#define RCC_APB2Periph_GPIOB             ((uint32_t)0x00000008)
+#endif
 #define RCC_APB2Periph_GPIOC             ((uint32_t)0x00000010)
 #define RCC_APB2Periph_GPIOD             ((uint32_t)0x00000020)
 #define RCC_APB2Periph_ADC1              ((uint32_t)0x00000200)
@@ -3700,17 +10795,144 @@ typedef struct
 #define RCC_APB1Periph_I2C1              ((uint32_t)0x00200000)
 #define RCC_APB1Periph_PWR               ((uint32_t)0x10000000)
 
+#if defined(CH32X03x)
+
+/* APB2_peripheral */
+#define RCC_APB2Periph_GPIOB             ((uint32_t)0x00000008)
+
+#define RCC_APB1Periph_TIM3              ((uint32_t)0x00000002)
+#define RCC_APB1Periph_USART2            ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3            ((uint32_t)0x00040000)
+#define RCC_APB1Periph_UART4             ((uint32_t)0x00080000)
+
+#endif
+
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* AHB_peripheral */
+#define RCC_AHBPeriph_DMA1             ((uint32_t)0x00000001)
+#define RCC_AHBPeriph_DMA2             ((uint32_t)0x00000002)
+#define RCC_AHBPeriph_SRAM             ((uint32_t)0x00000004)
+
+#if defined(CH32V10x)
+#define RCC_AHBPeriph_FLITF            ((uint32_t)0x00000010)
+#endif
+
+#define RCC_AHBPeriph_CRC              ((uint32_t)0x00000040)
+#define RCC_AHBPeriph_FSMC             ((uint32_t)0x00000100)
+
+#if !defined(CH32V10x)
+#define RCC_AHBPeriph_RNG              ((uint32_t)0x00000200)
+#endif
+
+#define RCC_AHBPeriph_SDIO             ((uint32_t)0x00000400)
+
+#if !defined(CH32V10x)
+#define RCC_AHBPeriph_USBHS            ((uint32_t)0x00000800)
+#define RCC_AHBPeriph_OTG_FS           ((uint32_t)0x00001000)
+#else
+#define RCC_AHBPeriph_USBHD            ((uint32_t)0x00001000)
+#endif
+
+#if defined(CH32V30x)
+#define RCC_AHBPeriph_DVP                ((uint32_t)0x00002000)
+#define RCC_AHBPeriph_ETH_MAC            ((uint32_t)0x00004000)
+#define RCC_AHBPeriph_ETH_MAC_Tx         ((uint32_t)0x00008000)
+#define RCC_AHBPeriph_ETH_MAC_Rx         ((uint32_t)0x00010000)
+#endif
+
+#ifdef CH32V20x_D8W
+#define RCC_AHBPeriph_BLE_CRC          ((uint32_t)0x00030040)
+#endif
+
+/* APB2_peripheral */
+#define RCC_APB2Periph_AFIO            ((uint32_t)0x00000001)
+#define RCC_APB2Periph_GPIOA           ((uint32_t)0x00000004)
+#define RCC_APB2Periph_GPIOB           ((uint32_t)0x00000008)
+#define RCC_APB2Periph_GPIOC           ((uint32_t)0x00000010)
+#define RCC_APB2Periph_GPIOD           ((uint32_t)0x00000020)
+#define RCC_APB2Periph_GPIOE           ((uint32_t)0x00000040)
+#define RCC_APB2Periph_ADC1            ((uint32_t)0x00000200)
+#define RCC_APB2Periph_ADC2            ((uint32_t)0x00000400)
+#define RCC_APB2Periph_TIM1            ((uint32_t)0x00000800)
+#define RCC_APB2Periph_SPI1            ((uint32_t)0x00001000)
+#define RCC_APB2Periph_TIM8            ((uint32_t)0x00002000)
+#define RCC_APB2Periph_USART1          ((uint32_t)0x00004000)
+#if !defined(CH32V10x)
+#define RCC_APB2Periph_TIM9            ((uint32_t)0x00080000)
+#define RCC_APB2Periph_TIM10           ((uint32_t)0x00100000)
+#else
+#define RCC_APB2Periph_ADC3              ((uint32_t)0x00008000)
+#define RCC_APB2Periph_TIM15             ((uint32_t)0x00010000)
+#define RCC_APB2Periph_TIM16             ((uint32_t)0x00020000)
+#define RCC_APB2Periph_TIM17             ((uint32_t)0x00040000)
+#define RCC_APB2Periph_TIM9              ((uint32_t)0x00080000)
+#define RCC_APB2Periph_TIM10             ((uint32_t)0x00100000)
+#define RCC_APB2Periph_TIM11             ((uint32_t)0x00200000)
+#endif
+
+/* APB1_peripheral */
+#define RCC_APB1Periph_TIM2            ((uint32_t)0x00000001)
+#define RCC_APB1Periph_TIM3            ((uint32_t)0x00000002)
+#define RCC_APB1Periph_TIM4            ((uint32_t)0x00000004)
+#define RCC_APB1Periph_TIM5            ((uint32_t)0x00000008)
+#define RCC_APB1Periph_TIM6            ((uint32_t)0x00000010)
+#define RCC_APB1Periph_TIM7            ((uint32_t)0x00000020)
+#if !defined(CH32V10x)
+#define RCC_APB1Periph_UART6           ((uint32_t)0x00000040)
+#define RCC_APB1Periph_UART7           ((uint32_t)0x00000080)
+#define RCC_APB1Periph_UART8           ((uint32_t)0x00000100)
+#else
+#define RCC_APB1Periph_TIM12             ((uint32_t)0x00000040)
+#define RCC_APB1Periph_TIM13             ((uint32_t)0x00000080)
+#define RCC_APB1Periph_TIM14             ((uint32_t)0x00000100)
+#endif
+#define RCC_APB1Periph_WWDG            ((uint32_t)0x00000800)
+#define RCC_APB1Periph_SPI2            ((uint32_t)0x00004000)
+#define RCC_APB1Periph_SPI3            ((uint32_t)0x00008000)
+#define RCC_APB1Periph_USART2          ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3          ((uint32_t)0x00040000)
+#define RCC_APB1Periph_UART4           ((uint32_t)0x00080000)
+#define RCC_APB1Periph_UART5           ((uint32_t)0x00100000)
+#define RCC_APB1Periph_I2C1            ((uint32_t)0x00200000)
+#define RCC_APB1Periph_I2C2            ((uint32_t)0x00400000)
+#define RCC_APB1Periph_USB             ((uint32_t)0x00800000)
+#define RCC_APB1Periph_CAN1            ((uint32_t)0x02000000)
+#define RCC_APB1Periph_CAN2            ((uint32_t)0x04000000)
+#define RCC_APB1Periph_BKP             ((uint32_t)0x08000000)
+#define RCC_APB1Periph_PWR             ((uint32_t)0x10000000)
+#define RCC_APB1Periph_DAC             ((uint32_t)0x20000000)
+#if defined(CH32V10x)
+#define RCC_APB1Periph_CEC               ((uint32_t)0x40000000)
+#endif
+
+#endif
+
 /* Clock_source_to_output_on_MCO_pin */
 #define RCC_MCO_NoClock                  ((uint8_t)0x00)
 #define RCC_MCO_SYSCLK                   ((uint8_t)0x04)
 #define RCC_MCO_HSI                      ((uint8_t)0x05)
 #define RCC_MCO_HSE                      ((uint8_t)0x06)
+#ifdef CH32V003
 #define RCC_MCO_PLLCLK                   ((uint8_t)0x07)
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define RCC_MCO_PLLCLK_Div2            	 ((uint8_t)0x07)
+#endif
+
+#ifdef CH32V30x_D8C
+#define RCC_MCO_PLL2CLK                  ((uint8_t)0x08)
+#define RCC_MCO_PLL3CLK_Div2             ((uint8_t)0x09)
+#define RCC_MCO_XT1                      ((uint8_t)0x0A)
+#define RCC_MCO_PLL3CLK                  ((uint8_t)0x0B)
+#endif
 
 /* RCC_Flag */
 #define RCC_FLAG_HSIRDY                  ((uint8_t)0x21)
 #define RCC_FLAG_HSERDY                  ((uint8_t)0x31)
 #define RCC_FLAG_PLLRDY                  ((uint8_t)0x39)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define RCC_FLAG_LSERDY                	 ((uint8_t)0x41)
+#endif
 #define RCC_FLAG_LSIRDY                  ((uint8_t)0x61)
 #define RCC_FLAG_PINRST                  ((uint8_t)0x7A)
 #define RCC_FLAG_PORRST                  ((uint8_t)0x7B)
@@ -3719,10 +10941,282 @@ typedef struct
 #define RCC_FLAG_WWDGRST                 ((uint8_t)0x7E)
 #define RCC_FLAG_LPWRRST                 ((uint8_t)0x7F)
 
+#ifdef CH32V30x_D8C
+#define RCC_FLAG_PLL2RDY                 ((uint8_t)0x3B)
+#define RCC_FLAG_PLL3RDY                 ((uint8_t)0x3D)
+#endif
+
 /* SysTick_clock_source */
 #define SysTick_CLKSource_HCLK_Div8      ((uint32_t)0xFFFFFFFB)
 #define SysTick_CLKSource_HCLK           ((uint32_t)0x00000004)
 
+/* RNG_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_RNGCLKSource_SYSCLK          ((uint32_t)0x00)
+#define RCC_RNGCLKSource_PLL3_VCO        ((uint32_t)0x01)
+#endif
+
+/* ETH1G_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_ETH1GCLKSource_PLL2_VCO      ((uint32_t)0x00)
+#define RCC_ETH1GCLKSource_PLL3_VCO      ((uint32_t)0x01)
+#define RCC_ETH1GCLKSource_PB1_IN        ((uint32_t)0x02)
+#endif
+
+#if defined(CH32V20x)
+
+/* USBFS_clock_source */
+#define RCC_USBPLL_Div1                ((uint32_t)0x00)
+#define RCC_USBPLL_Div2                ((uint32_t)0x01)
+#define RCC_USBPLL_Div3                ((uint32_t)0x02)
+#define RCC_USBPLL_Div4                ((uint32_t)0x03)
+#define RCC_USBPLL_Div5                ((uint32_t)0x04)
+#define RCC_USBPLL_Div6                ((uint32_t)0x05)
+#define RCC_USBPLL_Div7                ((uint32_t)0x06)
+#define RCC_USBPLL_Div8                ((uint32_t)0x07)
+
+/* ETH_clock_source */
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+  #define RCC_ETHCLK_Div1    ((uint32_t)0x00)
+  #define RCC_ETHCLK_Div2    ((uint32_t)0x01)
+#endif
+
+#endif // defined(CH32V20x)
+
+#if defined(CH32V30x)
+
+/* USBFS_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_USBPLL_Div1                  ((uint32_t)0x00)
+#define RCC_USBPLL_Div2                  ((uint32_t)0x01)
+#define RCC_USBPLL_Div3                  ((uint32_t)0x02)
+#define RCC_USBPLL_Div4                  ((uint32_t)0x03)
+#define RCC_USBPLL_Div5                  ((uint32_t)0x04)
+#define RCC_USBPLL_Div6                  ((uint32_t)0x05)
+#define RCC_USBPLL_Div7                  ((uint32_t)0x06)
+#define RCC_USBPLL_Div8                  ((uint32_t)0x07)
+
+#endif
+
+/* USBHSPLL_clock_source */
+#ifdef CH32V30x_D8C
+#define RCC_HSBHSPLLCLKSource_HSE        ((uint32_t)0x00)
+#define RCC_HSBHSPLLCLKSource_HSI        ((uint32_t)0x01)
+
+#endif
+
+/* USBHSPLLCKREF_clock_select */
+#ifdef CH32V30x_D8C
+#define RCC_USBHSPLLCKREFCLK_3M          ((uint32_t)0x00)
+#define RCC_USBHSPLLCKREFCLK_4M          ((uint32_t)0x01)
+#define RCC_USBHSPLLCKREFCLK_8M          ((uint32_t)0x02)
+#define RCC_USBHSPLLCKREFCLK_5M          ((uint32_t)0x03)
+
+#endif
+
+/* OTGUSBCLK48M_clock_source */
+#define RCC_USBCLK48MCLKSource_PLLCLK    ((uint32_t)0x00)
+#define RCC_USBCLK48MCLKSource_USBPHY    ((uint32_t)0x01)
+
+#endif
+
+#if defined(CH32V30x)
+
+/* ch32v00x_rng.h ------------------------------------------------------------*/
+
+/* RNG_flags_definition*/
+#define RNG_FLAG_DRDY               ((uint8_t)0x0001) /* Data ready */
+#define RNG_FLAG_CECS               ((uint8_t)0x0002) /* Clock error current status */
+#define RNG_FLAG_SECS               ((uint8_t)0x0004) /* Seed error current status */
+
+/* RNG_interrupts_definition */
+#define RNG_IT_CEI                  ((uint8_t)0x20) /* Clock error interrupt */
+#define RNG_IT_SEI                  ((uint8_t)0x40) /* Seed error interrupt */
+
+#endif
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+/* ch32v00x_rtc.h ------------------------------------------------------------*/
+/* RTC_interrupts_define */
+#define RTC_IT_OW         ((uint16_t)0x0004) /* Overflow interrupt */
+#define RTC_IT_ALR        ((uint16_t)0x0002) /* Alarm interrupt */
+#define RTC_IT_SEC        ((uint16_t)0x0001) /* Second interrupt */
+
+/* RTC_interrupts_flags */
+#define RTC_FLAG_RTOFF    ((uint16_t)0x0020) /* RTC Operation OFF flag */
+#define RTC_FLAG_RSF      ((uint16_t)0x0008) /* Registers Synchronized flag */
+#define RTC_FLAG_OW       ((uint16_t)0x0004) /* Overflow flag */
+#define RTC_FLAG_ALR      ((uint16_t)0x0002) /* Alarm flag */
+#define RTC_FLAG_SEC      ((uint16_t)0x0001) /* Second flag */
+
+#if defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+#define RB_OSC32K_HTUNE       (0x1FE0)
+#define RB_OSC32K_LTUNE       (0x1F)
+
+#define RB_OSC_CAL_HALT       (0x80)
+#define RB_OSC_CAL_EN         (0x02)
+#define RB_OSC_CAL_INT_EN     (0x01)
+
+#define RB_OSC_CAL_OV_CNT     (0xFF)
+
+#define RB_OSC_CAL_IF_END     (1 << 15)
+#define RB_OSC_CAL_CNT_OV     (1 << 14)
+#define RB_OSC_CAL_CNT        (0x3FFF)
+
+#define RB_CAL_LP_EN          (1 << 6)
+#define RB_CAL_WKUP_EN        (1 << 5)
+#define RB_OSC_HALT_MD        (1 << 4)
+#define RB_OSC_CNT_VLU        (0x0F)
+
+
+#ifdef CLK_OSC32K
+#if ( CLK_OSC32K == 1 )
+#define CAB_LSIFQ       32000
+#else
+#define CAB_LSIFQ       32768
+#endif
+#else
+#define CAB_LSIFQ       32000
+#endif
+#endif // defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+
+#if defined(CH32V30x)
+/* ch32v00x_sdio.h -----------------------------------------------------------*/
+
+/* SDIO_Clock_Edge */
+#define SDIO_ClockEdge_Rising               ((uint32_t)0x00000000)
+#define SDIO_ClockEdge_Falling              ((uint32_t)0x00002000)
+
+/* SDIO_Clock_Bypass */
+#define SDIO_ClockBypass_Disable             ((uint32_t)0x00000000)
+#define SDIO_ClockBypass_Enable              ((uint32_t)0x00000400)
+
+/* SDIO_Clock_Power_Save */
+#define SDIO_ClockPowerSave_Disable         ((uint32_t)0x00000000)
+#define SDIO_ClockPowerSave_Enable          ((uint32_t)0x00000200)
+
+/* SDIO_Bus_Wide */
+#define SDIO_BusWide_1b                     ((uint32_t)0x00000000)
+#define SDIO_BusWide_4b                     ((uint32_t)0x00000800)
+#define SDIO_BusWide_8b                     ((uint32_t)0x00001000)
+
+/* SDIO_Hardware_Flow_Control */
+#define SDIO_HardwareFlowControl_Disable    ((uint32_t)0x00000000)
+#define SDIO_HardwareFlowControl_Enable     ((uint32_t)0x00004000)
+
+/* SDIO_Power_State */
+#define SDIO_PowerState_OFF                 ((uint32_t)0x00000000)
+#define SDIO_PowerState_ON                  ((uint32_t)0x00000003)
+
+/* SDIO_Interrupt_sources */
+#define SDIO_IT_CCRCFAIL                    ((uint32_t)0x00000001)
+#define SDIO_IT_DCRCFAIL                    ((uint32_t)0x00000002)
+#define SDIO_IT_CTIMEOUT                    ((uint32_t)0x00000004)
+#define SDIO_IT_DTIMEOUT                    ((uint32_t)0x00000008)
+#define SDIO_IT_TXUNDERR                    ((uint32_t)0x00000010)
+#define SDIO_IT_RXOVERR                     ((uint32_t)0x00000020)
+#define SDIO_IT_CMDREND                     ((uint32_t)0x00000040)
+#define SDIO_IT_CMDSENT                     ((uint32_t)0x00000080)
+#define SDIO_IT_DATAEND                     ((uint32_t)0x00000100)
+#define SDIO_IT_STBITERR                    ((uint32_t)0x00000200)
+#define SDIO_IT_DBCKEND                     ((uint32_t)0x00000400)
+#define SDIO_IT_CMDACT                      ((uint32_t)0x00000800)
+#define SDIO_IT_TXACT                       ((uint32_t)0x00001000)
+#define SDIO_IT_RXACT                       ((uint32_t)0x00002000)
+#define SDIO_IT_TXFIFOHE                    ((uint32_t)0x00004000)
+#define SDIO_IT_RXFIFOHF                    ((uint32_t)0x00008000)
+#define SDIO_IT_TXFIFOF                     ((uint32_t)0x00010000)
+#define SDIO_IT_RXFIFOF                     ((uint32_t)0x00020000)
+#define SDIO_IT_TXFIFOE                     ((uint32_t)0x00040000)
+#define SDIO_IT_RXFIFOE                     ((uint32_t)0x00080000)
+#define SDIO_IT_TXDAVL                      ((uint32_t)0x00100000)
+#define SDIO_IT_RXDAVL                      ((uint32_t)0x00200000)
+#define SDIO_IT_SDIOIT                      ((uint32_t)0x00400000)
+#define SDIO_IT_CEATAEND                    ((uint32_t)0x00800000)
+
+/* SDIO_Response_Type */
+#define SDIO_Response_No                    ((uint32_t)0x00000000)
+#define SDIO_Response_Short                 ((uint32_t)0x00000040)
+#define SDIO_Response_Long                  ((uint32_t)0x000000C0)
+
+/* SDIO_Wait_Interrupt_State */
+#define SDIO_Wait_No                        ((uint32_t)0x00000000)
+#define SDIO_Wait_IT                        ((uint32_t)0x00000100)
+#define SDIO_Wait_Pend                      ((uint32_t)0x00000200)
+
+/* SDIO_CPSM_State */
+#define SDIO_CPSM_Disable                    ((uint32_t)0x00000000)
+#define SDIO_CPSM_Enable                     ((uint32_t)0x00000400)
+
+/* SDIO_Response_Registers */
+#define SDIO_RESP1                          ((uint32_t)0x00000000)
+#define SDIO_RESP2                          ((uint32_t)0x00000004)
+#define SDIO_RESP3                          ((uint32_t)0x00000008)
+#define SDIO_RESP4                          ((uint32_t)0x0000000C)
+
+/* SDIO_Data_Block_Size */
+#define SDIO_DataBlockSize_1b               ((uint32_t)0x00000000)
+#define SDIO_DataBlockSize_2b               ((uint32_t)0x00000010)
+#define SDIO_DataBlockSize_4b               ((uint32_t)0x00000020)
+#define SDIO_DataBlockSize_8b               ((uint32_t)0x00000030)
+#define SDIO_DataBlockSize_16b              ((uint32_t)0x00000040)
+#define SDIO_DataBlockSize_32b              ((uint32_t)0x00000050)
+#define SDIO_DataBlockSize_64b              ((uint32_t)0x00000060)
+#define SDIO_DataBlockSize_128b             ((uint32_t)0x00000070)
+#define SDIO_DataBlockSize_256b             ((uint32_t)0x00000080)
+#define SDIO_DataBlockSize_512b             ((uint32_t)0x00000090)
+#define SDIO_DataBlockSize_1024b            ((uint32_t)0x000000A0)
+#define SDIO_DataBlockSize_2048b            ((uint32_t)0x000000B0)
+#define SDIO_DataBlockSize_4096b            ((uint32_t)0x000000C0)
+#define SDIO_DataBlockSize_8192b            ((uint32_t)0x000000D0)
+#define SDIO_DataBlockSize_16384b           ((uint32_t)0x000000E0)
+
+/* SDIO_Transfer_Direction */
+#define SDIO_TransferDir_ToCard             ((uint32_t)0x00000000)
+#define SDIO_TransferDir_ToSDIO             ((uint32_t)0x00000002)
+
+/* SDIO_Transfer_Type */
+#define SDIO_TransferMode_Block             ((uint32_t)0x00000000)
+#define SDIO_TransferMode_Stream            ((uint32_t)0x00000004)
+
+/* SDIO_DPSM_State */
+#define SDIO_DPSM_Disable                    ((uint32_t)0x00000000)
+#define SDIO_DPSM_Enable                     ((uint32_t)0x00000001)
+
+/* SDIO_Flags */
+#define SDIO_FLAG_CCRCFAIL                  ((uint32_t)0x00000001)
+#define SDIO_FLAG_DCRCFAIL                  ((uint32_t)0x00000002)
+#define SDIO_FLAG_CTIMEOUT                  ((uint32_t)0x00000004)
+#define SDIO_FLAG_DTIMEOUT                  ((uint32_t)0x00000008)
+#define SDIO_FLAG_TXUNDERR                  ((uint32_t)0x00000010)
+#define SDIO_FLAG_RXOVERR                   ((uint32_t)0x00000020)
+#define SDIO_FLAG_CMDREND                   ((uint32_t)0x00000040)
+#define SDIO_FLAG_CMDSENT                   ((uint32_t)0x00000080)
+#define SDIO_FLAG_DATAEND                   ((uint32_t)0x00000100)
+#define SDIO_FLAG_STBITERR                  ((uint32_t)0x00000200)
+#define SDIO_FLAG_DBCKEND                   ((uint32_t)0x00000400)
+#define SDIO_FLAG_CMDACT                    ((uint32_t)0x00000800)
+#define SDIO_FLAG_TXACT                     ((uint32_t)0x00001000)
+#define SDIO_FLAG_RXACT                     ((uint32_t)0x00002000)
+#define SDIO_FLAG_TXFIFOHE                  ((uint32_t)0x00004000)
+#define SDIO_FLAG_RXFIFOHF                  ((uint32_t)0x00008000)
+#define SDIO_FLAG_TXFIFOF                   ((uint32_t)0x00010000)
+#define SDIO_FLAG_RXFIFOF                   ((uint32_t)0x00020000)
+#define SDIO_FLAG_TXFIFOE                   ((uint32_t)0x00040000)
+#define SDIO_FLAG_RXFIFOE                   ((uint32_t)0x00080000)
+#define SDIO_FLAG_TXDAVL                    ((uint32_t)0x00100000)
+#define SDIO_FLAG_RXDAVL                    ((uint32_t)0x00200000)
+#define SDIO_FLAG_SDIOIT                    ((uint32_t)0x00400000)
+#define SDIO_FLAG_CEATAEND                  ((uint32_t)0x00800000)
+
+/* SDIO_Read_Wait_Mode */
+#define SDIO_ReadWaitMode_CLK               ((uint32_t)0x00000001)
+#define SDIO_ReadWaitMode_DATA2             ((uint32_t)0x00000000)
+
+#endif
 
 /* ch32v00x_spi.h ------------------------------------------------------------*/
 
@@ -3734,7 +11228,7 @@ typedef struct
 #define SPI_Direction_1Line_Tx             ((uint16_t)0xC000)
 
 /* SPI_mode */
-#define SPI_Mode_Master                    ((uint16_t)0x0104)
+#define SPI_Mode_Master                    ((uint16_t)0x0104) /* Sets MSTR, as well as SSI, which is required for Master Mode */
 #define SPI_Mode_Slave                     ((uint16_t)0x0000)
 
 /* SPI_data_size */
@@ -3765,6 +11259,50 @@ typedef struct
 
 /* SPI_MSB transmission */
 #define SPI_FirstBit_MSB                   ((uint16_t)0x0000)
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define SPI_FirstBit_LSB                   ((uint16_t)0x0080)
+
+/* I2S_Mode */
+#define I2S_Mode_SlaveTx                   ((uint16_t)0x0000)
+#define I2S_Mode_SlaveRx                   ((uint16_t)0x0100)
+#define I2S_Mode_MasterTx                  ((uint16_t)0x0200)
+#define I2S_Mode_MasterRx                  ((uint16_t)0x0300)
+
+/* I2S_Standard */
+#define I2S_Standard_Phillips              ((uint16_t)0x0000)
+#define I2S_Standard_MSB                   ((uint16_t)0x0010)
+#define I2S_Standard_LSB                   ((uint16_t)0x0020)
+#define I2S_Standard_PCMShort              ((uint16_t)0x0030)
+#define I2S_Standard_PCMLong               ((uint16_t)0x00B0)
+
+/* I2S_Data_Format */
+#define I2S_DataFormat_16b                 ((uint16_t)0x0000)
+#define I2S_DataFormat_16bextended         ((uint16_t)0x0001)
+#define I2S_DataFormat_24b                 ((uint16_t)0x0003)
+#define I2S_DataFormat_32b                 ((uint16_t)0x0005)
+
+/* I2S_MCLK_Output */
+#define I2S_MCLKOutput_Enable              ((uint16_t)0x0200)
+#define I2S_MCLKOutput_Disable             ((uint16_t)0x0000)
+
+/* I2S_Audio_Frequency */
+#define I2S_AudioFreq_192k                 ((uint32_t)192000)
+#define I2S_AudioFreq_96k                  ((uint32_t)96000)
+#define I2S_AudioFreq_48k                  ((uint32_t)48000)
+#define I2S_AudioFreq_44k                  ((uint32_t)44100)
+#define I2S_AudioFreq_32k                  ((uint32_t)32000)
+#define I2S_AudioFreq_22k                  ((uint32_t)22050)
+#define I2S_AudioFreq_16k                  ((uint32_t)16000)
+#define I2S_AudioFreq_11k                  ((uint32_t)11025)
+#define I2S_AudioFreq_8k                   ((uint32_t)8000)
+#define I2S_AudioFreq_Default              ((uint32_t)2)
+
+/* I2S_Clock_Polarity */
+#define I2S_CPOL_Low                       ((uint16_t)0x0000)
+#define I2S_CPOL_High                      ((uint16_t)0x0008)
+
+#endif
 
 /* SPI_I2S_DMA_transfer_requests */
 #define SPI_I2S_DMAReq_Tx                  ((uint16_t)0x0002)
@@ -4178,6 +11716,1069 @@ typedef struct
 #define USART_FLAG_FE                        ((uint16_t)0x0002)
 #define USART_FLAG_PE                        ((uint16_t)0x0001)
 
+// While not truly CH32X035, we can re-use some of the USB register defs.
+#if defined(CH32V10x) | defined(CH32X03x)
+/* ch32v10x_usb.h ------------------------------------------------------------*/
+
+#ifndef NULL
+  #define NULL    0
+#endif
+
+#ifndef VOID
+  #define VOID    void
+#endif
+#ifndef CONST
+  #define CONST    const
+#endif
+#ifndef BOOL
+typedef unsigned char BOOL;
+#endif
+#ifndef BOOLEAN
+typedef unsigned char BOOLEAN;
+#endif
+#ifndef CHAR
+typedef char CHAR;
+#endif
+#ifndef INT8
+typedef char INT8;
+#endif
+#ifndef INT16
+typedef short INT16;
+#endif
+#ifndef INT32
+typedef long INT32;
+#endif
+#ifndef UINT8
+typedef unsigned char UINT8;
+#endif
+#ifndef UINT16
+typedef unsigned short UINT16;
+#endif
+#ifndef UINT32
+typedef unsigned long UINT32;
+#endif
+#ifndef UINT8V
+typedef unsigned char volatile UINT8V;
+#endif
+#ifndef UINT16V
+typedef unsigned short volatile UINT16V;
+#endif
+#ifndef UINT32V
+typedef unsigned long volatile UINT32V;
+#endif
+
+#ifndef PVOID
+typedef void *PVOID;
+#endif
+#ifndef PCHAR
+typedef char *PCHAR;
+#endif
+#ifndef PCHAR
+typedef const char *PCCHAR;
+#endif
+#ifndef PINT8
+typedef char *PINT8;
+#endif
+#ifndef PINT16
+typedef short *PINT16;
+#endif
+#ifndef PINT32
+typedef long *PINT32;
+#endif
+#ifndef PUINT8
+typedef unsigned char *PUINT8;
+#endif
+#ifndef PUINT16
+typedef unsigned short *PUINT16;
+#endif
+#ifndef PUINT32
+typedef unsigned long *PUINT32;
+#endif
+#ifndef PUINT8V
+typedef volatile unsigned char *PUINT8V;
+#endif
+#ifndef PUINT16V
+typedef volatile unsigned short *PUINT16V;
+#endif
+#ifndef PUINT32V
+typedef volatile unsigned long *PUINT32V;
+#endif
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+/*       USB  */
+#define R32_USB_CONTROL      (*((PUINT32V)(0x40023400))) // USB control & interrupt enable & device address
+#define R8_USB_CTRL          (*((PUINT8V)(0x40023400)))  // USB base control
+#define RB_UC_HOST_MODE      0x80                        // enable USB host mode: 0=device mode, 1=host mode
+#define RB_UC_LOW_SPEED      0x40                        // enable USB low speed: 0=12Mbps, 1=1.5Mbps
+#define RB_UC_DEV_PU_EN      0x20                        // USB device enable and internal pullup resistance enable
+#define RB_UC_SYS_CTRL1      0x20                        // USB system control high bit
+#define RB_UC_SYS_CTRL0      0x10                        // USB system control low bit
+#define MASK_UC_SYS_CTRL     0x30                        // bit mask of USB system control
+// bUC_HOST_MODE & bUC_SYS_CTRL1 & bUC_SYS_CTRL0: USB system control
+//   0 00: disable USB device and disable internal pullup resistance
+//   0 01: enable USB device and disable internal pullup resistance, need external pullup resistance
+//   0 1x: enable USB device and enable internal pullup resistance
+//   1 00: enable USB host and normal status
+//   1 01: enable USB host and force UDP/UDM output SE0 state
+//   1 10: enable USB host and force UDP/UDM output J state
+//   1 11: enable USB host and force UDP/UDM output resume or K state
+#define RB_UC_INT_BUSY       0x08           // enable automatic responding busy for device mode or automatic pause for host mode during interrupt flag UIF_TRANSFER valid
+#define RB_UC_RESET_SIE      0x04           // force reset USB SIE, need software clear
+#define RB_UC_CLR_ALL        0x02           // force clear FIFO and count of USB
+#define RB_UC_DMA_EN         0x01           // DMA enable and DMA interrupt enable for USB
+
+#define R8_UDEV_CTRL         (*((PUINT8V)(0x40023401))) // USB device physical prot control
+#define RB_UD_PD_DIS         0x80                       // disable USB UDP/UDM pulldown resistance: 0=enable pulldown, 1=disable
+#define RB_UD_DP_PIN         0x20                       // ReadOnly: indicate current UDP pin level
+#define RB_UD_DM_PIN         0x10                       // ReadOnly: indicate current UDM pin level
+#define RB_UD_LOW_SPEED      0x04                       // enable USB physical port low speed: 0=full speed, 1=low speed
+#define RB_UD_GP_BIT         0x02                       // general purpose bit
+#define RB_UD_PORT_EN        0x01                       // enable USB physical port I/O: 0=disable, 1=enable
+
+#define R8_UHOST_CTRL        R8_UDEV_CTRL   // USB host physical prot control
+#define RB_UH_PD_DIS         0x80           // disable USB UDP/UDM pulldown resistance: 0=enable pulldown, 1=disable
+#define RB_UH_DP_PIN         0x20           // ReadOnly: indicate current UDP pin level
+#define RB_UH_DM_PIN         0x10           // ReadOnly: indicate current UDM pin level
+#define RB_UH_LOW_SPEED      0x04           // enable USB port low speed: 0=full speed, 1=low speed
+#define RB_UH_BUS_RESET      0x02           // control USB bus reset: 0=normal, 1=force bus reset
+#define RB_UH_PORT_EN        0x01           // enable USB port: 0=disable, 1=enable port, automatic disabled if USB device detached
+
+#define R8_USB_INT_EN        (*((PUINT8V)(0x40023402))) // USB interrupt enable
+#define RB_UIE_DEV_SOF       0x80                       // enable interrupt for SOF received for USB device mode
+#define RB_UIE_DEV_NAK       0x40                       // enable interrupt for NAK responded for USB device mode
+#define RB_UIE_FIFO_OV       0x10                       // enable interrupt for FIFO overflow
+#define RB_UIE_HST_SOF       0x08                       // enable interrupt for host SOF timer action for USB host mode
+#define RB_UIE_SUSPEND       0x04                       // enable interrupt for USB suspend or resume event
+#define RB_UIE_TRANSFER      0x02                       // enable interrupt for USB transfer completion
+#define RB_UIE_DETECT        0x01                       // enable interrupt for USB device detected event for USB host mode
+#define RB_UIE_BUS_RST       0x01                       // enable interrupt for USB bus reset event for USB device mode
+
+#define R8_USB_DEV_AD        (*((PUINT8V)(0x40023403))) // USB device address
+#define RB_UDA_GP_BIT        0x80                       // general purpose bit
+#define MASK_USB_ADDR        0x7F                       // bit mask for USB device address
+
+#define R32_USB_STATUS       (*((PUINT32V)(0x40023404))) // USB miscellaneous status & interrupt flag & interrupt status
+#define R8_USB_MIS_ST        (*((PUINT8V)(0x40023405)))  // USB miscellaneous status
+#define RB_UMS_SOF_PRES      0x80                        // RO, indicate host SOF timer presage status
+#define RB_UMS_SOF_ACT       0x40                        // RO, indicate host SOF timer action status for USB host
+#define RB_UMS_SIE_FREE      0x20                        // RO, indicate USB SIE free status
+#define RB_UMS_R_FIFO_RDY    0x10                        // RO, indicate USB receiving FIFO ready status (not empty)
+#define RB_UMS_BUS_RESET     0x08                        // RO, indicate USB bus reset status
+#define RB_UMS_SUSPEND       0x04                        // RO, indicate USB suspend status
+#define RB_UMS_DM_LEVEL      0x02                        // RO, indicate UDM level saved at device attached to USB host
+#define RB_UMS_DEV_ATTACH    0x01                        // RO, indicate device attached status on USB host
+
+#define R8_USB_INT_FG        (*((PUINT8V)(0x40023406))) // USB interrupt flag
+#define RB_U_IS_NAK          0x80                       // RO, indicate current USB transfer is NAK received
+#define RB_U_TOG_OK          0x40                       // RO, indicate current USB transfer toggle is OK
+#define RB_U_SIE_FREE        0x20                       // RO, indicate USB SIE free status
+#define RB_UIF_FIFO_OV       0x10                       // FIFO overflow interrupt flag for USB, direct bit address clear or write 1 to clear
+#define RB_UIF_HST_SOF       0x08                       // host SOF timer interrupt flag for USB host, direct bit address clear or write 1 to clear
+#define RB_UIF_SUSPEND       0x04                       // USB suspend or resume event interrupt flag, direct bit address clear or write 1 to clear
+#define RB_UIF_TRANSFER      0x02                       // USB transfer completion interrupt flag, direct bit address clear or write 1 to clear
+#define RB_UIF_DETECT        0x01                       // device detected event interrupt flag for USB host mode, direct bit address clear or write 1 to clear
+#define RB_UIF_BUS_RST       0x01                       // bus reset event interrupt flag for USB device mode, direct bit address clear or write 1 to clear
+
+#define R8_USB_INT_ST        (*((PUINT8V)(0x40023407))) // USB interrupt status
+#define RB_UIS_IS_NAK        0x80                       // RO, indicate current USB transfer is NAK received for USB device mode
+#define RB_UIS_TOG_OK        0x40                       // RO, indicate current USB transfer toggle is OK
+#define RB_UIS_TOKEN1        0x20                       // RO, current token PID code bit 1 received for USB device mode
+#define RB_UIS_TOKEN0        0x10                       // RO, current token PID code bit 0 received for USB device mode
+#define MASK_UIS_TOKEN       0x30                       // RO, bit mask of current token PID code received for USB device mode
+#define UIS_TOKEN_OUT        0x00
+#define UIS_TOKEN_SOF        0x10
+#define UIS_TOKEN_IN         0x20
+#define UIS_TOKEN_SETUP      0x30
+// bUIS_TOKEN1 & bUIS_TOKEN0: current token PID code received for USB device mode
+//   00: OUT token PID received
+//   01: SOF token PID received
+//   10: IN token PID received
+//   11: SETUP token PID received
+#define MASK_UIS_ENDP        0x0F           // RO, bit mask of current transfer endpoint number for USB device mode
+#define MASK_UIS_H_RES       0x0F           // RO, bit mask of current transfer handshake response for USB host mode: 0000=no response, time out from device, others=handshake response PID received
+
+#define R16_USB_RX_LEN       (*((PUINT16V)(0x40023408))) // USB receiving length
+#define MASK_UIS_RX_LEN      0x3FF                       // RO, bit mask of current receive length(10 bits for ch32v10x)
+#define R32_USB_BUF_MODE     (*((PUINT32V)(0x4002340c))) // USB endpoint buffer mode
+#define R8_UEP4_1_MOD        (*((PUINT8V)(0x4002340c)))  // endpoint 4/1 mode
+#define RB_UEP1_RX_EN        0x80                        // enable USB endpoint 1 receiving (OUT)
+#define RB_UEP1_TX_EN        0x40                        // enable USB endpoint 1 transmittal (IN)
+#define RB_UEP1_BUF_MOD      0x10                        // buffer mode of USB endpoint 1
+// bUEPn_RX_EN & bUEPn_TX_EN & bUEPn_BUF_MOD: USB endpoint 1/2/3 buffer mode, buffer start address is UEPn_DMA
+//   0 0 x:  disable endpoint and disable buffer
+//   1 0 0:  64 bytes buffer for receiving (OUT endpoint)
+//   1 0 1:  dual 64 bytes buffer by toggle bit bUEP_R_TOG selection for receiving (OUT endpoint), total=128bytes
+//   0 1 0:  64 bytes buffer for transmittal (IN endpoint)
+//   0 1 1:  dual 64 bytes buffer by toggle bit bUEP_T_TOG selection for transmittal (IN endpoint), total=128bytes
+//   1 1 0:  64 bytes buffer for receiving (OUT endpoint) + 64 bytes buffer for transmittal (IN endpoint), total=128bytes
+//   1 1 1:  dual 64 bytes buffer by bUEP_R_TOG selection for receiving (OUT endpoint) + dual 64 bytes buffer by bUEP_T_TOG selection for transmittal (IN endpoint), total=256bytes
+#define RB_UEP4_RX_EN        0x08           // enable USB endpoint 4 receiving (OUT)
+#define RB_UEP4_TX_EN        0x04           // enable USB endpoint 4 transmittal (IN)
+// bUEP4_RX_EN & bUEP4_TX_EN: USB endpoint 4 buffer mode, buffer start address is UEP0_DMA
+//   0 0:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint)
+//   1 0:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint) + 64 bytes buffer for endpoint 4 receiving (OUT endpoint), total=128bytes
+//   0 1:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint) + 64 bytes buffer for endpoint 4 transmittal (IN endpoint), total=128bytes
+//   1 1:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint)
+//           + 64 bytes buffer for endpoint 4 receiving (OUT endpoint) + 64 bytes buffer for endpoint 4 transmittal (IN endpoint), total=192bytes
+
+#define R8_UEP2_3_MOD        (*((PUINT8V)(0x4002340d))) // endpoint 2/3 mode
+#define RB_UEP3_RX_EN        0x80                       // enable USB endpoint 3 receiving (OUT)
+#define RB_UEP3_TX_EN        0x40                       // enable USB endpoint 3 transmittal (IN)
+#define RB_UEP3_BUF_MOD      0x10                       // buffer mode of USB endpoint 3
+#define RB_UEP2_RX_EN        0x08                       // enable USB endpoint 2 receiving (OUT)
+#define RB_UEP2_TX_EN        0x04                       // enable USB endpoint 2 transmittal (IN)
+#define RB_UEP2_BUF_MOD      0x01                       // buffer mode of USB endpoint 2
+
+#define R8_UH_EP_MOD         R8_UEP2_3_MOD  //host endpoint mode
+#define RB_UH_EP_TX_EN       0x40           // enable USB host OUT endpoint transmittal
+#define RB_UH_EP_TBUF_MOD    0x10           // buffer mode of USB host OUT endpoint
+// bUH_EP_TX_EN & bUH_EP_TBUF_MOD: USB host OUT endpoint buffer mode, buffer start address is UH_TX_DMA
+//   0 x:  disable endpoint and disable buffer
+//   1 0:  64 bytes buffer for transmittal (OUT endpoint)
+//   1 1:  dual 64 bytes buffer by toggle bit bUH_T_TOG selection for transmittal (OUT endpoint), total=128bytes
+#define RB_UH_EP_RX_EN       0x08           // enable USB host IN endpoint receiving
+#define RB_UH_EP_RBUF_MOD    0x01           // buffer mode of USB host IN endpoint
+// bUH_EP_RX_EN & bUH_EP_RBUF_MOD: USB host IN endpoint buffer mode, buffer start address is UH_RX_DMA
+//   0 x:  disable endpoint and disable buffer
+//   1 0:  64 bytes buffer for receiving (IN endpoint)
+//   1 1:  dual 64 bytes buffer by toggle bit bUH_R_TOG selection for receiving (IN endpoint), total=128bytes
+
+#define R8_UEP5_6_MOD        (*((PUINT8V)(0x4002340e))) // endpoint 5/6 mode
+#define RB_UEP6_RX_EN        0x80                       // enable USB endpoint 6 receiving (OUT)
+#define RB_UEP6_TX_EN        0x40                       // enable USB endpoint 6 transmittal (IN)
+#define RB_UEP6_BUF_MOD      0x10                       // buffer mode of USB endpoint 6
+#define RB_UEP5_RX_EN        0x08                       // enable USB endpoint 5 receiving (OUT)
+#define RB_UEP5_TX_EN        0x04                       // enable USB endpoint 5 transmittal (IN)
+#define RB_UEP5_BUF_MOD      0x01                       // buffer mode of USB endpoint 5
+
+#define R8_UEP7_MOD          (*((PUINT8V)(0x4002340f))) // endpoint 7 mode
+#define RB_UEP7_RX_EN        0x08                       // enable USB endpoint 7 receiving (OUT)
+#define RB_UEP7_TX_EN        0x04                       // enable USB endpoint 7 transmittal (IN)
+#define RB_UEP7_BUF_MOD      0x01                       // buffer mode of USB endpoint 7
+
+#define R16_UEP0_DMA         (*((PUINT16V)(0x40023410))) // endpoint 0 DMA buffer address
+#define R16_UEP1_DMA         (*((PUINT16V)(0x40023414))) // endpoint 1 DMA buffer address
+#define R16_UEP2_DMA         (*((PUINT16V)(0x40023418))) // endpoint 2 DMA buffer address
+#define R16_UH_RX_DMA        R16_UEP2_DMA                // host rx endpoint buffer high address
+#define R16_UEP3_DMA         (*((PUINT16V)(0x4002341c))) // endpoint 3 DMA buffer address
+
+#define R16_UEP4_DMA         (*((PUINT16V)(0x40023420))) // endpoint 4 DMA buffer address
+#define R16_UEP5_DMA         (*((PUINT16V)(0x40023424))) // endpoint 5 DMA buffer address
+#define R16_UEP6_DMA         (*((PUINT16V)(0x40023428))) // endpoint 6 DMA buffer address
+#define R16_UEP7_DMA         (*((PUINT16V)(0x4002342c))) // endpoint 7 DMA buffer address
+
+#define R16_UH_TX_DMA        R16_UEP3_DMA                // host tx endpoint buffer high address
+#define R32_USB_EP0_CTRL     (*((PUINT32V)(0x40023430))) // endpoint 0 control & transmittal length
+#define R8_UEP0_T_LEN        (*((PUINT8V)(0x40023430)))  // endpoint 0 transmittal length
+#define R8_UEP0_CTRL         (*((PUINT8V)(0x40023432)))  // endpoint 0 control
+#define R32_USB_EP1_CTRL     (*((PUINT32V)(0x40023434))) // endpoint 1 control & transmittal length
+#define R16_UEP1_T_LEN       (*((PUINT16V)(0x40023434))) // endpoint 1 transmittal length(16-bits for ch32v10x)
+#define R8_UEP1_CTRL         (*((PUINT8V)(0x40023436)))  // endpoint 1 control
+#define RB_UEP_R_TOG         0x80                        // expected data toggle flag of USB endpoint X receiving (OUT): 0=DATA0, 1=DATA1
+#define RB_UEP_T_TOG         0x40                        // prepared data toggle flag of USB endpoint X transmittal (IN): 0=DATA0, 1=DATA1
+#define RB_UEP_AUTO_TOG      0x10                        // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define RB_UEP_R_RES1        0x08                        // handshake response type high bit for USB endpoint X receiving (OUT)
+#define RB_UEP_R_RES0        0x04                        // handshake response type low bit for USB endpoint X receiving (OUT)
+#define MASK_UEP_R_RES       0x0C                        // bit mask of handshake response type for USB endpoint X receiving (OUT)
+#define UEP_R_RES_ACK        0x00
+#define UEP_R_RES_TOUT       0x04
+#define UEP_R_RES_NAK        0x08
+#define UEP_R_RES_STALL      0x0C
+// RB_UEP_R_RES1 & RB_UEP_R_RES0: handshake response type for USB endpoint X receiving (OUT)
+//   00: ACK (ready)
+//   01: no response, time out to host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+#define RB_UEP_T_RES1        0x02           // handshake response type high bit for USB endpoint X transmittal (IN)
+#define RB_UEP_T_RES0        0x01           // handshake response type low bit for USB endpoint X transmittal (IN)
+#define MASK_UEP_T_RES       0x03           // bit mask of handshake response type for USB endpoint X transmittal (IN)
+#define UEP_T_RES_ACK        0x00
+#define UEP_T_RES_TOUT       0x01
+#define UEP_T_RES_NAK        0x02
+#define UEP_T_RES_STALL      0x03
+// bUEP_T_RES1 & bUEP_T_RES0: handshake response type for USB endpoint X transmittal (IN)
+//   00: DATA0 or DATA1 then expecting ACK (ready)
+//   01: DATA0 or DATA1 then expecting no response, time out from host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+
+#define R8_UH_SETUP          R8_UEP1_CTRL   // host aux setup
+#define RB_UH_PRE_PID_EN     0x80           // USB host PRE PID enable for low speed device via hub
+#define RB_UH_SOF_EN         0x40           // USB host automatic SOF enable
+
+#define R32_USB_EP2_CTRL     (*((PUINT32V)(0x40023438))) // endpoint 2 control & transmittal length
+#define R16_UEP2_T_LEN       (*((PUINT16V)(0x40023438))) // endpoint 2 transmittal length(16-bits for ch32v10x)
+#define R8_UEP2_CTRL         (*((PUINT8V)(0x4002343a)))  // endpoint 2 control
+
+#define R8_UH_EP_PID         (*((PUINT8V)(0x40023438)))  // host endpoint and PID
+#define MASK_UH_TOKEN        0xF0           // bit mask of token PID for USB host transfer
+#define MASK_UH_ENDP         0x0F           // bit mask of endpoint number for USB host transfer
+
+#define R8_UH_RX_CTRL        R8_UEP2_CTRL   // host receiver endpoint control
+#define RB_UH_R_TOG          0x80           // expected data toggle flag of host receiving (IN): 0=DATA0, 1=DATA1
+#define RB_UH_R_AUTO_TOG     0x10           // enable automatic toggle after successful transfer completion: 0=manual toggle, 1=automatic toggle
+#define RB_UH_R_RES          0x04           // prepared handshake response type for host receiving (IN): 0=ACK (ready), 1=no response, time out to device, for isochronous transactions
+
+#define R32_USB_EP3_CTRL     (*((PUINT32V)(0x4002343c))) // endpoint 3 control & transmittal length
+#define R16_UEP3_T_LEN       (*((PUINT16V)(0x4002343c))) // endpoint 3 transmittal length(16-bits for ch32v10x)
+#define R8_UEP3_CTRL         (*((PUINT8V)(0x4002343e)))  // endpoint 3 control
+#define R8_UH_TX_LEN         (*((PUINT16V)(0x4002343c))) //R8_UEP3_T_LEN				// host transmittal endpoint transmittal length
+
+#define R8_UH_TX_CTRL        R8_UEP3_CTRL   // host transmittal endpoint control
+#define RB_UH_T_TOG          0x40           // prepared data toggle flag of host transmittal (SETUP/OUT): 0=DATA0, 1=DATA1
+#define RB_UH_T_AUTO_TOG     0x10           // enable automatic toggle after successful transfer completion: 0=manual toggle, 1=automatic toggle
+#define RB_UH_T_RES          0x01           // expected handshake response type for host transmittal (SETUP/OUT): 0=ACK (ready), 1=no response, time out from device, for isochronous transactions
+
+#define R32_USB_EP4_CTRL     (*((PUINT32V)(0x40023440))) // endpoint 4 control & transmittal length
+#define R16_UEP4_T_LEN       (*((PUINT16V)(0x40023440))) // endpoint 4 transmittal length(16-bits for ch32v10x)
+#define R8_UEP4_CTRL         (*((PUINT8V)(0x40023442)))  // endpoint 4 control
+
+#define R32_USB_EP5_CTRL     (*((PUINT32V)(0x40023444))) // endpoint 5 control & transmittal length
+#define R16_UEP5_T_LEN       (*((PUINT16V)(0x40023444))) // endpoint 5 transmittal length(16-bits for ch32v10x)
+#define R8_UEP5_CTRL         (*((PUINT8V)(0x40023446)))  // endpoint 5 control
+
+#define R32_USB_EP6_CTRL     (*((PUINT32V)(0x40023448))) // endpoint 6 control & transmittal length
+#define R16_UEP6_T_LEN       (*((PUINT16V)(0x40023448))) // endpoint 6 transmittal length(16-bits for ch32v10x)
+#define R8_UEP6_CTRL         (*((PUINT8V)(0x4002344a)))  // endpoint 6 control
+
+#define R32_USB_EP7_CTRL     (*((PUINT32V)(0x4002344c))) // endpoint 7 control & transmittal length
+#define R16_UEP7_T_LEN       (*((PUINT16V)(0x4002344c))) // endpoint 7 transmittal length(16-bits for ch32v10x)
+#define R8_UEP7_CTRL         (*((PUINT8V)(0x4002344e)))  // endpoint 7 control
+
+/* ch32v10x_usb_host.h -----------------------------------------------------------*/
+
+#define ERR_SUCCESS            0x00
+#define ERR_USB_CONNECT        0x15
+#define ERR_USB_DISCON         0x16
+#define ERR_USB_BUF_OVER       0x17
+#define ERR_USB_DISK_ERR       0x1F
+#define ERR_USB_TRANSFER       0x20
+#define ERR_USB_UNSUPPORT      0xFB
+#define ERR_USB_UNKNOWN        0xFE
+#define ERR_AOA_PROTOCOL       0x41
+
+#define ROOT_DEV_DISCONNECT    0
+#define ROOT_DEV_CONNECTED     1
+#define ROOT_DEV_FAILED        2
+#define ROOT_DEV_SUCCESS       3
+#define DEV_TYPE_KEYBOARD      (USB_DEV_CLASS_HID | 0x20)
+#define DEV_TYPE_MOUSE         (USB_DEV_CLASS_HID | 0x30)
+#define DEF_AOA_DEVICE         0xF0
+#define DEV_TYPE_UNKNOW        0xFF
+
+#define HUB_MAX_PORTS          4
+#define WAIT_USB_TOUT_200US    3000
+
+#endif
+
+/* ch32v30x_usb.h ------------------------------------------------------------*/
+
+#if defined(CH32V30x)
+
+/*******************************************************************************/
+/* USB Communication Related Macro Definition */
+/* USB Endpoint0 Size */
+#ifndef DEFAULT_ENDP0_SIZE
+    #define DEFAULT_ENDP0_SIZE          8          // default maximum packet size for endpoint 0
+#endif
+
+#ifndef MAX_PACKET_SIZE
+    #define MAX_PACKET_SIZE             64         // maximum packet size
+#endif
+
+/* USB PID */
+#ifndef USB_PID_SETUP
+#define USB_PID_NULL                0x00
+#define USB_PID_SOF                 0x05
+#define USB_PID_SETUP               0x0D
+#define USB_PID_IN                  0x09
+#define USB_PID_OUT                 0x01
+#define USB_PID_NYET                0x06
+#define USB_PID_ACK                 0x02
+#define USB_PID_NAK                 0x0A
+#define USB_PID_STALL               0x0E
+#define USB_PID_DATA0               0x03
+#define USB_PID_DATA1               0x0B
+#define USB_PID_DATA2               0x07
+#define USB_PID_MDATA               0x0F
+#define USB_PID_PRE                 0x0C
+#endif
+
+/* USB standard device request code */
+#ifndef USB_GET_DESCRIPTOR
+#define USB_GET_STATUS              0x00
+#define USB_CLEAR_FEATURE           0x01
+#define USB_SET_FEATURE             0x03
+#define USB_SET_ADDRESS             0x05
+#define USB_GET_DESCRIPTOR          0x06
+#define USB_SET_DESCRIPTOR          0x07
+#define USB_GET_CONFIGURATION       0x08
+#define USB_SET_CONFIGURATION       0x09
+#define USB_GET_INTERFACE           0x0A
+#define USB_SET_INTERFACE           0x0B
+#define USB_SYNCH_FRAME             0x0C
+#endif
+
+#define DEF_STRING_DESC_LANG        0x00
+#define DEF_STRING_DESC_MANU        0x01
+#define DEF_STRING_DESC_PROD        0x02
+#define DEF_STRING_DESC_SERN        0x03
+
+/* USB hub class request code */
+#ifndef HUB_GET_DESCRIPTOR
+#define HUB_GET_STATUS              0x00
+#define HUB_CLEAR_FEATURE           0x01
+#define HUB_GET_STATE               0x02
+#define HUB_SET_FEATURE             0x03
+#define HUB_GET_DESCRIPTOR          0x06
+#define HUB_SET_DESCRIPTOR          0x07
+#endif
+
+/* USB HID class request code */
+#ifndef HID_GET_REPORT
+#define HID_GET_REPORT              0x01
+#define HID_GET_IDLE                0x02
+#define HID_GET_PROTOCOL            0x03
+#define HID_SET_REPORT              0x09
+#define HID_SET_IDLE                0x0A
+#define HID_SET_PROTOCOL            0x0B
+#endif
+
+/* USB CDC Class request code */
+#ifndef CDC_GET_LINE_CODING
+#define CDC_GET_LINE_CODING         0x21                                      /* This request allows the host to find out the currently configured line coding */
+#define CDC_SET_LINE_CODING         0x20                                      /* Configures DTE rate, stop-bits, parity, and number-of-character */
+#define CDC_SET_LINE_CTLSTE         0x22                                      /* This request generates RS-232/V.24 style control signals */
+#define CDC_SEND_BREAK              0x23                                      /* Sends special carrier modulation used to specify RS-232 style break */
+#endif
+
+/* Bit Define for USB Request Type */
+#ifndef USB_REQ_TYP_MASK
+#define USB_REQ_TYP_IN              0x80
+#define USB_REQ_TYP_OUT             0x00
+#define USB_REQ_TYP_READ            0x80
+#define USB_REQ_TYP_WRITE           0x00
+#define USB_REQ_TYP_MASK            0x60
+#define USB_REQ_TYP_STANDARD        0x00
+#define USB_REQ_TYP_CLASS           0x20
+#define USB_REQ_TYP_VENDOR          0x40
+#define USB_REQ_TYP_RESERVED        0x60
+#define USB_REQ_RECIP_MASK          0x1F
+#define USB_REQ_RECIP_DEVICE        0x00
+#define USB_REQ_RECIP_INTERF        0x01
+#define USB_REQ_RECIP_ENDP          0x02
+#define USB_REQ_RECIP_OTHER         0x03
+#define USB_REQ_FEAT_REMOTE_WAKEUP  0x01
+#define USB_REQ_FEAT_ENDP_HALT      0x00
+#endif
+
+/* USB Descriptor Type */
+#ifndef USB_DESCR_TYP_DEVICE
+#define USB_DESCR_TYP_DEVICE        0x01
+#define USB_DESCR_TYP_CONFIG        0x02
+#define USB_DESCR_TYP_STRING        0x03
+#define USB_DESCR_TYP_INTERF        0x04
+#define USB_DESCR_TYP_ENDP          0x05
+#define USB_DESCR_TYP_QUALIF        0x06
+#define USB_DESCR_TYP_SPEED         0x07
+#define USB_DESCR_TYP_OTG           0x09
+#define USB_DESCR_TYP_BOS           0X0F
+#define USB_DESCR_TYP_HID           0x21
+#define USB_DESCR_TYP_REPORT        0x22
+#define USB_DESCR_TYP_PHYSIC        0x23
+#define USB_DESCR_TYP_CS_INTF       0x24
+#define USB_DESCR_TYP_CS_ENDP       0x25
+#define USB_DESCR_TYP_HUB           0x29
+#endif
+
+/* USB Device Class */
+#ifndef USB_DEV_CLASS_HUB
+#define USB_DEV_CLASS_RESERVED      0x00
+#define USB_DEV_CLASS_AUDIO         0x01
+#define USB_DEV_CLASS_COMMUNIC      0x02
+#define USB_DEV_CLASS_HID           0x03
+#define USB_DEV_CLASS_MONITOR       0x04
+#define USB_DEV_CLASS_PHYSIC_IF     0x05
+#define USB_DEV_CLASS_POWER         0x06
+#define USB_DEV_CLASS_IMAGE         0x06
+#define USB_DEV_CLASS_PRINTER       0x07
+#define USB_DEV_CLASS_STORAGE       0x08
+#define USB_DEV_CLASS_HUB           0x09
+#define USB_DEV_CLASS_VEN_SPEC      0xFF
+#endif
+
+/* USB Hub Class Request */
+#ifndef HUB_GET_HUB_DESCRIPTOR
+#define HUB_CLEAR_HUB_FEATURE       0x20
+#define HUB_CLEAR_PORT_FEATURE      0x23
+#define HUB_GET_BUS_STATE           0xA3
+#define HUB_GET_HUB_DESCRIPTOR      0xA0
+#define HUB_GET_HUB_STATUS          0xA0
+#define HUB_GET_PORT_STATUS         0xA3
+#define HUB_SET_HUB_DESCRIPTOR      0x20
+#define HUB_SET_HUB_FEATURE         0x20
+#define HUB_SET_PORT_FEATURE        0x23
+#endif
+
+/* Hub Class Feature Selectors */
+#ifndef HUB_PORT_RESET
+#define HUB_C_HUB_LOCAL_POWER       0
+#define HUB_C_HUB_OVER_CURRENT      1
+#define HUB_PORT_CONNECTION         0
+#define HUB_PORT_ENABLE             1
+#define HUB_PORT_SUSPEND            2
+#define HUB_PORT_OVER_CURRENT       3
+#define HUB_PORT_RESET              4
+#define HUB_PORT_POWER              8
+#define HUB_PORT_LOW_SPEED          9
+#define HUB_C_PORT_CONNECTION       16
+#define HUB_C_PORT_ENABLE           17
+#define HUB_C_PORT_SUSPEND          18
+#define HUB_C_PORT_OVER_CURRENT     19
+#define HUB_C_PORT_RESET            20
+#endif
+
+/* USB UDisk */
+#ifndef USB_BO_CBW_SIZE
+#define USB_BO_CBW_SIZE             0x1F
+#define USB_BO_CSW_SIZE             0x0D
+#endif
+#ifndef USB_BO_CBW_SIG0
+#define USB_BO_CBW_SIG0             0x55
+#define USB_BO_CBW_SIG1             0x53
+#define USB_BO_CBW_SIG2             0x42
+#define USB_BO_CBW_SIG3             0x43
+#define USB_BO_CSW_SIG0             0x55
+#define USB_BO_CSW_SIG1             0x53
+#define USB_BO_CSW_SIG2             0x42
+#define USB_BO_CSW_SIG3             0x53
+#endif
+
+
+/******************************************************************************/
+/* USBHS Clock Configuration Related Macro Definition */
+#define USB_CLK_SRC                 0x80000000
+#define USBHS_PLL_ALIVE             0x40000000
+#define USBHS_PLL_CKREF_MASK        0x30000000
+#define USBHS_PLL_CKREF_3M          0x00000000
+#define USBHS_PLL_CKREF_4M          0x10000000
+#define USBHS_PLL_CKREF_8M          0x20000000
+#define USBHS_PLL_CKREF_5M          0x30000000
+#define USBHS_PLL_SRC               0x08000000
+#define USBHS_PLL_SRC_PRE_MASK      0x07000000
+#define USBHS_PLL_SRC_PRE_DIV1      0x00000000
+#define USBHS_PLL_SRC_PRE_DIV2      0x01000000
+#define USBHS_PLL_SRC_PRE_DIV3      0x02000000
+#define USBHS_PLL_SRC_PRE_DIV4      0x03000000
+#define USBHS_PLL_SRC_PRE_DIV5      0x04000000
+#define USBHS_PLL_SRC_PRE_DIV6      0x05000000
+#define USBHS_PLL_SRC_PRE_DIV7      0x06000000
+#define USBHS_PLL_SRC_PRE_DIV8      0x07000000
+
+
+/*******************************************************************************/
+/* USBHS Related Register Macro Definition */
+
+/* R8_USB_CTRL */
+#define USBHS_UC_HOST_MODE          0x80
+#define USBHS_UC_SPEED_TYPE         0x60
+#define USBHS_UC_SPEED_LOW          0x40
+#define USBHS_UC_SPEED_FULL         0x00
+#define USBHS_UC_SPEED_HIGH         0x20
+#define USBHS_UC_DEV_PU_EN          0x10
+#define USBHS_UC_INT_BUSY           0x08
+#define USBHS_UC_RESET_SIE          0x04
+#define USBHS_UC_CLR_ALL            0x02
+#define USBHS_UC_DMA_EN             0x01
+
+/* R8_USB_INT_EN */
+#define USBHS_UIE_DEV_NAK           0x80
+#define USBHS_UIE_ISO_ACT           0x40
+#define USBHS_UIE_SETUP_ACT         0x20
+#define USBHS_UIE_FIFO_OV           0x10
+#define USBHS_UIE_SOF_ACT           0x08
+#define USBHS_UIE_SUSPEND           0x04
+#define USBHS_UIE_TRANSFER          0x02
+#define USBHS_UIE_DETECT            0x01
+#define USBHS_UIE_BUS_RST           0x01
+
+/* R16_USB_DEV_AD */
+#define USBHS_MASK_USB_ADDR         0x7F
+
+/* R16_USB_FRAME_NO */
+#define USBHS_MICRO_FRAME_NUM       0xE000
+#define USBHS_SOF_FRAME_NUM         0x07FF
+
+/* R8_USB_SUSPEND */
+#define USBHS_USB_LINESTATE         0x30
+#define USBHS_USB_WAKEUP_ST         0x04
+#define USBHS_USB_SYS_MOD           0x03
+
+/* R8_USB_SPEED_TYPE */
+#define USBHS_USB_SPEED_TYPE        0x03
+#define USBHS_USB_SPEED_LOW         0x02
+#define USBHS_USB_SPEED_FULL        0x00
+#define USBHS_USB_SPEED_HIGH        0x01
+
+/* R8_USB_MIS_ST */
+#define USBHS_UMS_SOF_PRES          0x80
+#define USBHS_UMS_SOF_ACT           0x40
+#define USBHS_UMS_SIE_FREE          0x20
+#define USBHS_UMS_R_FIFO_RDY        0x10
+#define USBHS_UMS_BUS_RESET         0x08
+#define USBHS_UMS_SUSPEND           0x04
+#define USBHS_UMS_DEV_ATTACH        0x02
+#define USBHS_UMS_SPLIT_CAN         0x01
+
+/* R8_USB_INT_FG */
+#define USBHS_UIF_ISO_ACT           0x40
+#define USBHS_UIF_SETUP_ACT         0x20
+#define USBHS_UIF_FIFO_OV           0x10
+#define USBHS_UIF_HST_SOF           0x08
+#define USBHS_UIF_SUSPEND           0x04
+#define USBHS_UIF_TRANSFER          0x02
+#define USBHS_UIF_DETECT            0x01
+#define USBHS_UIF_BUS_RST           0x01
+
+/* R8_USB_INT_ST */
+#define USBHS_UIS_IS_NAK            0x80
+#define USBHS_UIS_TOG_OK            0x40
+#define USBHS_UIS_TOKEN_MASK        0x30
+#define USBHS_UIS_TOKEN_OUT         0x00
+#define USBHS_UIS_TOKEN_SOF         0x10
+#define USBHS_UIS_TOKEN_IN          0x20
+#define USBHS_UIS_TOKEN_SETUP       0x30
+#define USBHS_UIS_ENDP_MASK         0x0F
+#define USBHS_UIS_H_RES_MASK        0x0F
+
+/* R16_USB_RX_LEN */
+#define USBHS_USB_RX_LEN            0xFFFF
+
+/* R32_UEP_CONFIG */
+#define USBHS_UEP15_R_EN            0x80000000
+#define USBHS_UEP14_R_EN            0x40000000
+#define USBHS_UEP13_R_EN            0x20000000
+#define USBHS_UEP12_R_EN            0x10000000
+#define USBHS_UEP11_R_EN            0x08000000
+#define USBHS_UEP10_R_EN            0x04000000
+#define USBHS_UEP9_R_EN             0x02000000
+#define USBHS_UEP8_R_EN             0x01000000
+#define USBHS_UEP7_R_EN             0x00800000
+#define USBHS_UEP6_R_EN             0x00400000
+#define USBHS_UEP5_R_EN             0x00200000
+#define USBHS_UEP4_R_EN             0x00100000
+#define USBHS_UEP3_R_EN             0x00080000
+#define USBHS_UEP2_R_EN             0x00040000
+#define USBHS_UEP1_R_EN             0x00020000
+#define USBHS_UEP0_R_EN             0x00010000
+#define USBHS_UEP15_T_EN            0x00008000
+#define USBHS_UEP14_T_EN            0x00004000
+#define USBHS_UEP13_T_EN            0x00002000
+#define USBHS_UEP12_T_EN            0x00001000
+#define USBHS_UEP11_T_EN            0x00000800
+#define USBHS_UEP10_T_EN            0x00000400
+#define USBHS_UEP9_T_EN             0x00000200
+#define USBHS_UEP8_T_EN             0x00000100
+#define USBHS_UEP7_T_EN             0x00000080
+#define USBHS_UEP6_T_EN             0x00000040
+#define USBHS_UEP5_T_EN             0x00000020
+#define USBHS_UEP4_T_EN             0x00000010
+#define USBHS_UEP3_T_EN             0x00000008
+#define USBHS_UEP2_T_EN             0x00000004
+#define USBHS_UEP1_T_EN             0x00000002
+#define USBHS_UEP0_T_EN             0x00000001
+
+/* R32_UEP_TYPE */
+#define USBHS_UEP15_R_TYPE          0x80000000
+#define USBHS_UEP14_R_TYPE          0x40000000
+#define USBHS_UEP13_R_TYPE          0x20000000
+#define USBHS_UEP12_R_TYPE          0x10000000
+#define USBHS_UEP11_R_TYPE          0x08000000
+#define USBHS_UEP10_R_TYPE          0x04000000
+#define USBHS_UEP9_R_TYPE           0x02000000
+#define USBHS_UEP8_R_TYPE           0x01000000
+#define USBHS_UEP7_R_TYPE           0x00800000
+#define USBHS_UEP6_R_TYPE           0x00400000
+#define USBHS_UEP5_R_TYPE           0x00200000
+#define USBHS_UEP4_R_TYPE           0x00100000
+#define USBHS_UEP3_R_TYPE           0x00080000
+#define USBHS_UEP2_R_TYPE           0x00040000
+#define USBHS_UEP1_R_TYPE           0x00020000
+#define USBHS_UEP0_R_TYPE           0x00010000
+#define USBHS_UEP15_T_TYPE          0x00008000
+#define USBHS_UEP14_T_TYPE          0x00004000
+#define USBHS_UEP13_T_TYPE          0x00002000
+#define USBHS_UEP12_T_TYPE          0x00001000
+#define USBHS_UEP11_T_TYPE          0x00000800
+#define USBHS_UEP10_T_TYPE          0x00000400
+#define USBHS_UEP9_T_TYPE           0x00000200
+#define USBHS_UEP8_T_TYPE           0x00000100
+#define USBHS_UEP7_T_TYPE           0x00000080
+#define USBHS_UEP6_T_TYPE           0x00000040
+#define USBHS_UEP5_T_TYPE           0x00000020
+#define USBHS_UEP4_T_TYPE           0x00000010
+#define USBHS_UEP3_T_TYPE           0x00000008
+#define USBHS_UEP2_T_TYPE           0x00000004
+#define USBHS_UEP1_T_TYPE           0x00000002
+#define USBHS_UEP0_T_TYPE           0x00000001
+
+/* R32_UEP_BUF_MOD */
+#define USBHS_UEP15_ISO_BUF_MOD     0x80000000
+#define USBHS_UEP14_ISO_BUF_MOD     0x40000000
+#define USBHS_UEP13_ISO_BUF_MOD     0x20000000
+#define USBHS_UEP12_ISO_BUF_MOD     0x10000000
+#define USBHS_UEP11_ISO_BUF_MOD     0x08000000
+#define USBHS_UEP10_ISO_BUF_MOD     0x04000000
+#define USBHS_UEP9_ISO_BUF_MOD      0x02000000
+#define USBHS_UEP8_ISO_BUF_MOD      0x01000000
+#define USBHS_UEP7_ISO_BUF_MOD      0x00800000
+#define USBHS_UEP6_ISO_BUF_MOD      0x00400000
+#define USBHS_UEP5_ISO_BUF_MOD      0x00200000
+#define USBHS_UEP4_ISO_BUF_MOD      0x00100000
+#define USBHS_UEP3_ISO_BUF_MOD      0x00080000
+#define USBHS_UEP2_ISO_BUF_MOD      0x00040000
+#define USBHS_UEP1_ISO_BUF_MOD      0x00020000
+#define USBHS_UEP0_ISO_BUF_MOD      0x00010000
+#define USBHS_UEP15_BUF_MOD         0x00008000
+#define USBHS_UEP14_BUF_MOD         0x00004000
+#define USBHS_UEP13_BUF_MOD         0x00002000
+#define USBHS_UEP12_BUF_MOD         0x00001000
+#define USBHS_UEP11_BUF_MOD         0x00000800
+#define USBHS_UEP10_BUF_MOD         0x00000400
+#define USBHS_UEP9_BUF_MOD          0x00000200
+#define USBHS_UEP8_BUF_MOD          0x00000100
+#define USBHS_UEP7_BUF_MOD          0x00000080
+#define USBHS_UEP6_BUF_MOD          0x00000040
+#define USBHS_UEP5_BUF_MOD          0x00000020
+#define USBHS_UEP4_BUF_MOD          0x00000010
+#define USBHS_UEP3_BUF_MOD          0x00000008
+#define USBHS_UEP2_BUF_MOD          0x00000004
+#define USBHS_UEP1_BUF_MOD          0x00000002
+#define USBHS_UEP0_BUF_MOD          0x00000001
+
+/* R32_UEP0_DMA */
+#define USBHS_UEP0_DMA              0x0000FFFF
+
+/* R32_UEPn_TX_DMA, n=1-15 */
+#define USBHS_UEPn_TX_DMA           0x0000FFFF
+
+/* R32_UEPn_RX_DMA, n=1-15 */
+#define USBHS_UEPn_RX_DMA           0x0000FFFF
+
+/* R16_UEPn_MAX_LEN, n=0-15 */
+#define USBHS_UEPn_MAX_LEN          0x07FF
+
+/* R16_UEPn_T_LEN, n=0-15 */
+#define USBHS_UEPn_T_LEN            0x07FF
+
+/* R8_UEPn_TX_CTRL, n=0-15 */
+#define USBHS_UEP_T_TOG_AUTO        0x20
+#define USBHS_UEP_T_TOG_MASK        0x18
+#define USBHS_UEP_T_TOG_DATA0       0x00
+#define USBHS_UEP_T_TOG_DATA1       0x08
+#define USBHS_UEP_T_TOG_DATA2       0x10
+#define USBHS_UEP_T_TOG_MDATA       0x18
+#define USBHS_UEP_T_RES_MASK        0x03
+#define USBHS_UEP_T_RES_ACK         0x00
+#define USBHS_UEP_T_RES_NYET        0x01
+#define USBHS_UEP_T_RES_NAK         0x02
+#define USBHS_UEP_T_RES_STALL       0x03
+
+/* R8_UEPn_TX_CTRL, n=0-15 */
+#define USBHS_UEP_R_TOG_AUTO        0x20
+#define USBHS_UEP_R_TOG_MASK        0x18
+#define USBHS_UEP_R_TOG_DATA0       0x00
+#define USBHS_UEP_R_TOG_DATA1       0x08
+#define USBHS_UEP_R_TOG_DATA2       0x10
+#define USBHS_UEP_R_TOG_MDATA       0x18
+#define USBHS_UEP_R_RES_MASK        0x03
+#define USBHS_UEP_R_RES_ACK         0x00
+#define USBHS_UEP_R_RES_NYET        0x01
+#define USBHS_UEP_R_RES_NAK         0x02
+#define USBHS_UEP_R_RES_STALL       0x03
+
+/* R8_UHOST_CTRL */
+#define USBHS_UH_SOF_EN             0x80
+#define USBHS_UH_SOF_FREE           0x40
+#define USBHS_UH_PHY_SUSPENDM       0x10
+#define USBHS_UH_REMOTE_WKUP        0x08
+#define USBHS_UH_TX_BUS_RESUME      0x04
+#define USBHS_UH_TX_BUS_SUSPEND     0x02
+#define USBHS_UH_TX_BUS_RESET       0x01
+
+/* R32_UH_CONFIG */
+#define USBHS_UH_EP_RX_EN           0x00040000
+#define USBHS_UH_EP_TX_EN           0x00000008
+
+/* R32_UH_EP_TYPE */
+#define USBHS_UH_EP_RX_TYPE         0x00040000
+#define USBHS_UH_EP_TX_TYPE         0x00000008
+
+/* R32_UH_RX_DMA */
+#define USBHS_UH_RX_DMA             0x0000FFFC
+
+/* R32_UH_TX_DMA */
+#define USBHS_UH_TX_DMA             0x0000FFFF
+
+/* R16_UH_RX_MAX_LEN */
+#define USBHS_UH_RX_MAX_LEN         0x07FF
+
+/* R8_UH_EP_PID */
+#define USBHS_UH_TOKEN_MASK         0xF0
+#define USBHS_UH_ENDP_MASK          0x0F
+
+/* R8_UH_RX_CTRL */
+#define USBHS_UH_R_DATA_NO          0x40
+#define USBHS_UH_R_TOG_AUTO         0x20
+#define USBHS_UH_R_TOG_MASK         0x18
+#define USBHS_UH_R_TOG_DATA0        0x00
+#define USBHS_UH_R_TOG_DATA1        0x08
+#define USBHS_UH_R_TOG_DATA2        0x10
+#define USBHS_UH_R_TOG_MDATA        0x18
+#define USBHS_UH_R_RES_NO           0x04
+#define USBHS_UH_R_RES_MASK         0x03
+#define USBHS_UH_R_RES_ACK          0x00
+#define USBHS_UH_R_RES_NYET         0x01
+#define USBHS_UH_R_RES_NAK          0x02
+#define USBHS_UH_R_RES_STALL        0x03
+
+/* R16_UH_TX_LEN */
+#define USBHS_UH_TX_LEN             0x07FF
+
+/* R8_UH_TX_CTRL */
+#define USBHS_UH_T_DATA_NO          0x40
+#define USBHS_UH_T_AUTO_TOG         0x20
+#define USBHS_UH_T_TOG_MASK         0x18
+#define USBHS_UH_T_TOG_DATA0        0x00
+#define USBHS_UH_T_TOG_DATA1        0x08
+#define USBHS_UH_T_TOG_DATA2        0x10
+#define USBHS_UH_T_TOG_MDATA        0x18
+#define USBHS_UH_T_RES_NO           0x04
+#define USBHS_UH_T_RES_MASK         0x03
+#define USBHS_UH_T_RES_ACK          0x00
+#define USBHS_UH_T_RES_NYET         0x01
+#define USBHS_UH_T_RES_NAK          0x02
+#define USBHS_UH_T_RES_STALL        0x03
+
+/* R16_UH_SPLIT_DATA */
+#define USBHS_UH_SPLIT_DATA         0x0FFF
+
+/* USBHS Registers from ch32v30x_usbhs_device.h */
+
+#define USBHSD_UEP_CFG_BASE         0x40023410
+#define USBHSD_UEP_BUF_MOD_BASE     0x40023418
+#define USBHSD_UEP_RXDMA_BASE       0x40023420
+#define USBHSD_UEP_TXDMA_BASE       0x4002345C
+#define USBHSD_UEP_TXLEN_BASE       0x400234DC
+#define USBHSD_UEP_TXCTL_BASE       0x400234DE
+#define USBHSD_UEP_TXCTL_BASE       0x400234DE
+#define USBHSD_UEP_TX_EN( N )       ( (uint16_t)( 0x01 << N ) )
+#define USBHSD_UEP_RX_EN( N )       ( (uint16_t)( 0x01 << ( N + 16 ) ) )
+#define USBHSD_UEP_DOUBLE_BUF( N )  ( (uint16_t)( 0x01 << N ) )
+#define DEF_UEP_DMA_LOAD            0 /* Direct the DMA address to the data to be processed */
+#define DEF_UEP_CPY_LOAD            1 /* Use memcpy to move data to a buffer */
+#define USBHSD_UEP_RXDMA( N )       ( *((volatile uint32_t *)( USBHSD_UEP_RXDMA_BASE + ( N - 1 ) * 0x04 ) ) )
+#define USBHSD_UEP_RXBUF( N )       ( (uint8_t *)(*((volatile uint32_t *)( USBHSD_UEP_RXDMA_BASE + ( N - 1 ) * 0x04 ) ) ) + 0x20000000 )
+#define USBHSD_UEP_TXCTRL( N )      ( *((volatile uint8_t *)( USBHSD_UEP_TXCTL_BASE + ( N - 1 ) * 0x04 ) ) )
+#define USBHSD_UEP_RXCTRL( N )      ( *((volatile uint8_t *)( USBHSD_UEP_TXCTL_BASE + ( N - 1 ) * 0x04 + 1 ) ) )
+#define USBHSD_UEP_TXDMA( N )       ( *((volatile uint32_t *)( USBHSD_UEP_TXDMA_BASE + ( N - 1 ) * 0x04 ) ) )
+#define USBHSD_UEP_TXBUF( N )       ( (uint8_t *)(*((volatile uint32_t *)( USBHSD_UEP_TXDMA_BASE + ( N - 1 ) * 0x04 ) ) ) + 0x20000000 )
+#define USBHSD_UEP_TLEN( N )        ( *((volatile uint16_t *)( USBHSD_UEP_TXLEN_BASE + ( N - 1 ) * 0x04 ) ) )
+
+
+/*******************************************************************************/
+/* USBFS Related Register Macro Definition */
+
+/* R8_USB_CTRL */
+#define USBFS_UC_HOST_MODE          0x80
+#define USBFS_UC_LOW_SPEED          0x40
+#define USBFS_UC_DEV_PU_EN          0x20
+#define USBFS_UC_SYS_CTRL_MASK      0x30
+#define USBFS_UC_SYS_CTRL0          0x00
+#define USBFS_UC_SYS_CTRL1          0x10
+#define USBFS_UC_SYS_CTRL2          0x20
+#define USBFS_UC_SYS_CTRL3          0x30
+#define USBFS_UC_INT_BUSY           0x08
+#define USBFS_UC_RESET_SIE          0x04
+#define USBFS_UC_CLR_ALL            0x02
+#define USBFS_UC_DMA_EN             0x01
+
+/* R8_USB_INT_EN */
+#define USBFS_UIE_DEV_SOF           0x80
+#define USBFS_UIE_DEV_NAK           0x40
+#define USBFS_1WIRE_MODE            0x20
+#define USBFS_UIE_FIFO_OV           0x10
+#define USBFS_UIE_HST_SOF           0x08
+#define USBFS_UIE_SUSPEND           0x04
+#define USBFS_UIE_TRANSFER          0x02
+#define USBFS_UIE_DETECT            0x01
+#define USBFS_UIE_BUS_RST           0x01
+
+/* R8_USB_DEV_AD */
+#define USBFS_UDA_GP_BIT            0x80
+#define USBFS_USB_ADDR_MASK         0x7F
+
+/* R8_USB_MIS_ST */
+#define USBFS_UMS_SOF_PRES          0x80
+#define USBFS_UMS_SOF_ACT           0x40
+#define USBFS_UMS_SIE_FREE          0x20
+#define USBFS_UMS_R_FIFO_RDY        0x10
+#define USBFS_UMS_BUS_RESET         0x08
+#define USBFS_UMS_SUSPEND           0x04
+#define USBFS_UMS_DM_LEVEL          0x02
+#define USBFS_UMS_DEV_ATTACH        0x01
+
+/* R8_USB_INT_FG */
+#define USBFS_U_IS_NAK              0x80    // RO, indicate current USB transfer is NAK received
+#define USBFS_U_TOG_OK              0x40    // RO, indicate current USB transfer toggle is OK
+#define USBFS_U_SIE_FREE            0x20    // RO, indicate USB SIE free status
+#define USBFS_UIF_FIFO_OV           0x10    // FIFO overflow interrupt flag for USB, direct bit address clear or write 1 to clear
+#define USBFS_UIF_HST_SOF           0x08    // host SOF timer interrupt flag for USB host, direct bit address clear or write 1 to clear
+#define USBFS_UIF_SUSPEND           0x04    // USB suspend or resume event interrupt flag, direct bit address clear or write 1 to clear
+#define USBFS_UIF_TRANSFER          0x02    // USB transfer completion interrupt flag, direct bit address clear or write 1 to clear
+#define USBFS_UIF_DETECT            0x01    // device detected event interrupt flag for USB host mode, direct bit address clear or write 1 to clear
+#define USBFS_UIF_BUS_RST           0x01    // bus reset event interrupt flag for USB device mode, direct bit address clear or write 1 to clear
+
+/* R8_USB_INT_ST */
+#define USBFS_UIS_IS_NAK            0x80      // RO, indicate current USB transfer is NAK received for USB device mode
+#define USBFS_UIS_TOG_OK            0x40      // RO, indicate current USB transfer toggle is OK
+#define USBFS_UIS_TOKEN_MASK        0x30      // RO, bit mask of current token PID code received for USB device mode
+#define USBFS_UIS_TOKEN_OUT         0x00
+#define USBFS_UIS_TOKEN_SOF         0x10
+#define USBFS_UIS_TOKEN_IN          0x20
+#define USBFS_UIS_TOKEN_SETUP       0x30
+// bUIS_TOKEN1 & bUIS_TOKEN0: current token PID code received for USB device mode
+//   00: OUT token PID received
+//   01: SOF token PID received
+//   10: IN token PID received
+//   11: SETUP token PID received
+#define USBFS_UIS_ENDP_MASK         0x0F      // RO, bit mask of current transfer endpoint number for USB device mode
+#define USBFS_UIS_H_RES_MASK        0x0F      // RO, bit mask of current transfer handshake response for USB host mode: 0000=no response, time out from device, others=handshake response PID received
+
+/* R32_USB_OTG_CR */
+#define USBFS_CR_SESS_VTH           0x20
+#define USBFS_CR_VBUS_VTH           0x10
+#define USBFS_CR_OTG_EN             0x08
+#define USBFS_CR_IDPU               0x04
+#define USBFS_CR_CHARGE_VBUS        0x02
+#define USBFS_CR_DISCHAR_VBUS       0x01
+
+/* R32_USB_OTG_SR */
+#define USBFS_SR_ID_DIG             0x08
+#define USBFS_SR_SESS_END           0x04
+#define USBFS_SR_SESS_VLD           0x02
+#define USBFS_SR_VBUS_VLD           0x01
+
+/* R8_UDEV_CTRL */
+#define USBFS_UD_PD_DIS             0x80      // disable USB UDP/UDM pulldown resistance: 0=enable pulldown, 1=disable
+#define USBFS_UD_DP_PIN             0x20      // ReadOnly: indicate current UDP pin level
+#define USBFS_UD_DM_PIN             0x10      // ReadOnly: indicate current UDM pin level
+#define USBFS_UD_LOW_SPEED          0x04      // enable USB physical port low speed: 0=full speed, 1=low speed
+#define USBFS_UD_GP_BIT             0x02      // general purpose bit
+#define USBFS_UD_PORT_EN            0x01      // enable USB physical port I/O: 0=disable, 1=enable
+
+/* R8_UEP4_1_MOD */
+#define USBFS_UEP1_RX_EN            0x80      // enable USB endpoint 1 receiving (OUT)
+#define USBFS_UEP1_TX_EN            0x40      // enable USB endpoint 1 transmittal (IN)
+#define USBFS_UEP1_BUF_MOD          0x10      // buffer mode of USB endpoint 1
+#define USBFS_UEP4_RX_EN            0x08      // enable USB endpoint 4 receiving (OUT)
+#define USBFS_UEP4_TX_EN            0x04      // enable USB endpoint 4 transmittal (IN)
+#define USBFS_UEP4_BUF_MOD          0x01
+
+/* R8_UEP2_3_MOD */
+#define USBFS_UEP3_RX_EN            0x80      // enable USB endpoint 3 receiving (OUT)
+#define USBFS_UEP3_TX_EN            0x40      // enable USB endpoint 3 transmittal (IN)
+#define USBFS_UEP3_BUF_MOD          0x10      // buffer mode of USB endpoint 3
+#define USBFS_UEP2_RX_EN            0x08      // enable USB endpoint 2 receiving (OUT)
+#define USBFS_UEP2_TX_EN            0x04      // enable USB endpoint 2 transmittal (IN)
+#define USBFS_UEP2_BUF_MOD          0x01      // buffer mode of USB endpoint 2
+
+/* R8_UEP5_6_MOD */
+#define USBFS_UEP6_RX_EN            0x80      // enable USB endpoint 6 receiving (OUT)
+#define USBFS_UEP6_TX_EN            0x40      // enable USB endpoint 6 transmittal (IN)
+#define USBFS_UEP6_BUF_MOD          0x10      // buffer mode of USB endpoint 6
+#define USBFS_UEP5_RX_EN            0x08      // enable USB endpoint 5 receiving (OUT)
+#define USBFS_UEP5_TX_EN            0x04      // enable USB endpoint 5 transmittal (IN)
+#define USBFS_UEP5_BUF_MOD          0x01      // buffer mode of USB endpoint 5
+
+/* R8_UEP7_MOD */
+#define USBFS_UEP7_RX_EN            0x08      // enable USB endpoint 7 receiving (OUT)
+#define USBFS_UEP7_TX_EN            0x04      // enable USB endpoint 7 transmittal (IN)
+#define USBFS_UEP7_BUF_MOD          0x01      // buffer mode of USB endpoint 7
+
+/* R8_UEPn_TX_CTRL */
+#define USBFS_UEP_T_AUTO_TOG        0x08      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBFS_UEP_T_TOG             0x04      // prepared data toggle flag of USB endpoint X transmittal (IN): 0=DATA0, 1=DATA1
+#define USBFS_UEP_T_RES_MASK        0x03      // bit mask of handshake response type for USB endpoint X transmittal (IN)
+#define USBFS_UEP_T_RES_ACK         0x00
+#define USBFS_UEP_T_RES_NONE        0x01
+#define USBFS_UEP_T_RES_NAK         0x02
+#define USBFS_UEP_T_RES_STALL       0x03
+// bUEP_T_RES1 & bUEP_T_RES0: handshake response type for USB endpoint X transmittal (IN)
+//   00: DATA0 or DATA1 then expecting ACK (ready)
+//   01: DATA0 or DATA1 then expecting no response, time out from host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+// host aux setup
+
+/* R8_UEPn_RX_CTRL, n=0-7 */
+#define USBFS_UEP_R_AUTO_TOG        0x08      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBFS_UEP_R_TOG             0x04      // expected data toggle flag of USB endpoint X receiving (OUT): 0=DATA0, 1=DATA1
+#define USBFS_UEP_R_RES_MASK        0x03      // bit mask of handshake response type for USB endpoint X receiving (OUT)
+#define USBFS_UEP_R_RES_ACK         0x00
+#define USBFS_UEP_R_RES_NONE        0x01
+#define USBFS_UEP_R_RES_NAK         0x02
+#define USBFS_UEP_R_RES_STALL       0x03
+// RB_UEP_R_RES1 & RB_UEP_R_RES0: handshake response type for USB endpoint X receiving (OUT)
+//   00: ACK (ready)
+//   01: no response, time out to host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+
+/* R8_UHOST_CTRL */
+#define USBFS_UH_PD_DIS             0x80      // disable USB UDP/UDM pulldown resistance: 0=enable pulldown, 1=disable
+#define USBFS_UH_DP_PIN             0x20      // ReadOnly: indicate current UDP pin level
+#define USBFS_UH_DM_PIN             0x10      // ReadOnly: indicate current UDM pin level
+#define USBFS_UH_LOW_SPEED          0x04      // enable USB port low speed: 0=full speed, 1=low speed
+#define USBFS_UH_BUS_RESET          0x02      // control USB bus reset: 0=normal, 1=force bus reset
+#define USBFS_UH_PORT_EN            0x01      // enable USB port: 0=disable, 1=enable port, automatic disabled if USB device detached
+
+/* R32_UH_EP_MOD */
+#define USBFS_UH_EP_TX_EN           0x40      // enable USB host OUT endpoint transmittal
+#define USBFS_UH_EP_TBUF_MOD        0x10      // buffer mode of USB host OUT endpoint
+// bUH_EP_TX_EN & bUH_EP_TBUF_MOD: USB host OUT endpoint buffer mode, buffer start address is UH_TX_DMA
+//   0 x:  disable endpoint and disable buffer
+//   1 0:  64 bytes buffer for transmittal (OUT endpoint)
+//   1 1:  dual 64 bytes buffer by toggle bit bUH_T_TOG selection for transmittal (OUT endpoint), total=128bytes
+#define USBFS_UH_EP_RX_EN           0x08      // enable USB host IN endpoint receiving
+#define USBFS_UH_EP_RBUF_MOD        0x01      // buffer mode of USB host IN endpoint
+// bUH_EP_RX_EN & bUH_EP_RBUF_MOD: USB host IN endpoint buffer mode, buffer start address is UH_RX_DMA
+//   0 x:  disable endpoint and disable buffer
+//   1 0:  64 bytes buffer for receiving (IN endpoint)
+//   1 1:  dual 64 bytes buffer by toggle bit bUH_R_TOG selection for receiving (IN endpoint), total=128bytes
+
+/* R16_UH_SETUP */
+#define USBFS_UH_PRE_PID_EN         0x0400      // USB host PRE PID enable for low speed device via hub
+#define USBFS_UH_SOF_EN             0x0004      // USB host automatic SOF enable
+
+/* R8_UH_EP_PID */
+#define USBFS_UH_TOKEN_MASK         0xF0      // bit mask of token PID for USB host transfer
+#define USBFS_UH_ENDP_MASK          0x0F      // bit mask of endpoint number for USB host transfer
+
+/* R8_UH_RX_CTRL */
+#define USBFS_UH_R_AUTO_TOG         0x08      // enable automatic toggle after successful transfer completion: 0=manual toggle, 1=automatic toggle
+#define USBFS_UH_R_TOG              0x04      // expected data toggle flag of host receiving (IN): 0=DATA0, 1=DATA1
+#define USBFS_UH_R_RES              0x01      // prepared handshake response type for host receiving (IN): 0=ACK (ready), 1=no response, time out to device, for isochronous transactions
+
+/* R8_UH_TX_CTRL */
+#define USBFS_UH_T_AUTO_TOG         0x08      // enable automatic toggle after successful transfer completion: 0=manual toggle, 1=automatic toggle
+#define USBFS_UH_T_TOG              0x04      // prepared data toggle flag of host transmittal (SETUP/OUT): 0=DATA0, 1=DATA1
+#define USBFS_UH_T_RES              0x01      // expected handshake response type for host transmittal (SETUP/OUT): 0=ACK (ready), 1=no response, time out from device, for isochronous transactions
+
+#endif
+
 /* ch32v00x_wwdg.h -----------------------------------------------------------*/
 
 
@@ -4197,11 +12798,10 @@ typedef struct
 	
 ///////////////////////////////////////////////////////////////////////////////////////////////	
 ///////////////////////////////////////////////////////////////////////////////////////////////
+// Code in this section was originally from __CORE_RISCV_H__
 
 #ifndef __CORE_RISCV_H__
 #define __CORE_RISCV_H__
-
-#include <stdint.h>
 
 /* define compiler specific symbols */
 #if defined(__CC_ARM)
@@ -4222,10 +12822,13 @@ typedef struct
 
 #endif
 
+
 #ifdef __cplusplus
  extern "C" {
 #endif
 	
+#ifndef __ASSEMBLER__
+
 /* Standard Peripheral Library old types (maintained for legacy purpose) */
 typedef __I uint32_t vuc32;  /* Read Only */
 typedef __I uint16_t vuc16;  /* Read Only */
@@ -4258,6 +12861,17 @@ typedef __IO int8_t   vs8;
 typedef int32_t  s32;
 typedef int16_t s16;
 typedef int8_t  s8;
+
+#if defined(CH32V20x) || defined(CH32V30x)
+typedef __I uint64_t vuc64;  /* Read Only */
+typedef const uint64_t uc64;  /* Read Only */
+typedef __I int64_t vsc64;  /* Read Only */
+typedef const int64_t sc64;  /* Read Only */
+typedef __IO uint64_t  vu64;
+typedef uint64_t  u64;
+typedef __IO int64_t  vs64;
+typedef int64_t  s64;
+#endif
 
 typedef enum {NoREADY = 0, READY = !NoREADY} ErrorStatus;
 
@@ -4294,26 +12908,26 @@ typedef struct{
     __IO uint32_t SCTLR;
 }PFIC_Type;
 
-/* memory mapped structure for SysTick */
-typedef struct
-{
-    __IO uint32_t CTLR;
-    __IO uint32_t SR;
-    __IO uint32_t CNT;
-    uint32_t RESERVED0;
-    __IO uint32_t CMP;
-    uint32_t RESERVED1;
-}SysTick_Type;
+#endif
 
+/* some bit definitions for systick regs */
+#define SYSTICK_SR_CNTIF (1<<0)
+#define SYSTICK_CTLR_STE (1<<0)
+#define SYSTICK_CTLR_STIE (1<<1)
+#define SYSTICK_CTLR_STCLK (1<<2)
+#define SYSTICK_CTLR_STRE (1<<3)
+#define SYSTICK_CTLR_SWIE (1<<31)
 
-#define PFIC            ((PFIC_Type *) 0xE000E000 )
+#define PFIC            ((PFIC_Type *) PFIC_BASE )
 #define NVIC            PFIC
 #define NVIC_KEY1       ((uint32_t)0xFA050000)
 #define	NVIC_KEY2	    ((uint32_t)0xBCAF0000)
 #define	NVIC_KEY3		((uint32_t)0xBEEF0000)
 
-#define SysTick         ((SysTick_Type *) 0xE000F000)
 
+#define SysTick         ((SysTick_Type *) SysTick_BASE)
+
+#ifndef __ASSEMBLER__
 
 /*********************************************************************
  * @fn      __enable_irq
@@ -4324,140 +12938,157 @@ typedef struct
  */
 RV_STATIC_INLINE void __enable_irq()
 {
-  uint32_t result;
+	uint32_t result;
 
-  __asm volatile("csrr %0," "mstatus": "=r"(result));
-  result |= 0x88;
-  __asm volatile ("csrw mstatus, %0" : : "r" (result) );
+	__ASM volatile(
+#if __GNUC__ > 10
+		".option arch, +zicsr\n"
+#endif
+		"csrr %0," "mstatus": "=r"(result));
+	result |= 0x88;
+	__ASM volatile ("csrw mstatus, %0" : : "r" (result) );
 }
 
 /*********************************************************************
  * @fn      __disable_irq
- *
  * @brief   Disable Global Interrupt
- *
  * @return  none
  */
 RV_STATIC_INLINE void __disable_irq()
 {
-  uint32_t result;
+	uint32_t result;
 
-  __asm volatile("csrr %0," "mstatus": "=r"(result));
-  result &= ~0x88;
-  __asm volatile ("csrw mstatus, %0" : : "r" (result) );
+    __ASM volatile(
+#if __GNUC__ > 10
+		".option arch, +zicsr\n"
+#endif
+		"csrr %0," "mstatus": "=r"(result));
+	result &= ~0x88;
+	__ASM volatile ("csrw mstatus, %0" : : "r" (result) );
+}
+
+/*********************************************************************
+ * @fn      __isenabled_irq
+ * @brief   Is Global Interrupt enabled
+ * @return  1: yes, 0: no
+ */
+RV_STATIC_INLINE uint8_t __isenabled_irq(void)
+{
+    uint32_t result;
+
+    __ASM volatile(
+#if __GNUC__ > 10
+    ".option arch, +zicsr\n"
+#endif
+    "csrr %0," "mstatus": "=r"(result));
+    return (result & 0x08) != 0u;
+}
+
+/*********************************************************************
+ * @fn      __get_cpu_sp
+ * @brief   Get stack pointer
+ * @return  stack pointer
+ */
+RV_STATIC_INLINE uint32_t __get_cpu_sp(void);
+RV_STATIC_INLINE uint32_t __get_cpu_sp(void)
+{
+	uint32_t result;
+
+	__ASM volatile(
+#if __GNUC__ > 10
+    ".option arch, +zicsr\n"
+#endif
+	"mv %0, sp" : "=r"(result));
+	return result;
 }
 
 /*********************************************************************
  * @fn      __NOP
- *
  * @brief   nop
- *
  * @return  none
  */
 RV_STATIC_INLINE void __NOP()
 {
-  __asm volatile ("nop");
+	__ASM volatile ("nop");
 }
 
 /*********************************************************************
  * @fn       NVIC_EnableIRQ
- *
  * @brief   Disable Interrupt
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  none
  */
 RV_STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
 {
-  NVIC->IENR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+	NVIC->IENR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
 }
 
 /*********************************************************************
  * @fn       NVIC_DisableIRQ
- *
  * @brief   Disable Interrupt
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  none
  */
 RV_STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
-  NVIC->IRER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+	NVIC->IRER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
 }
 
 /*********************************************************************
  * @fn       NVIC_GetStatusIRQ
- *
  * @brief   Get Interrupt Enable State
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  1 - 1: Interrupt Pending Enable
  *                0 - Interrupt Pending Disable
  */
 RV_STATIC_INLINE uint32_t NVIC_GetStatusIRQ(IRQn_Type IRQn)
 {
-  return((uint32_t) ((NVIC->ISR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+	return((uint32_t) ((NVIC->ISR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
 }
 
 /*********************************************************************
  * @fn      NVIC_GetPendingIRQ
- *
  * @brief   Get Interrupt Pending State
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  1 - 1: Interrupt Pending Enable
  *                0 - Interrupt Pending Disable
  */
 RV_STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
 {
-  return((uint32_t) ((NVIC->IPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+	return((uint32_t) ((NVIC->IPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
 }
 
 /*********************************************************************
  * @fn      NVIC_SetPendingIRQ
- *
  * @brief   Set Interrupt Pending
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  none
  */
 RV_STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
 {
-  NVIC->IPSR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+	NVIC->IPSR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
 }
 
 /*********************************************************************
  * @fn      NVIC_ClearPendingIRQ
- *
  * @brief   Clear Interrupt Pending
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  none
  */
 RV_STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
 {
-  NVIC->IPRR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
+	NVIC->IPRR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
 }
 
 /*********************************************************************
  * @fn      NVIC_GetActive
- *
  * @brief   Get Interrupt Active State
- *
  * @param   IRQn - Interrupt Numbers
- *
  * @return  1 - Interrupt Active
- *                0 - Interrupt No Active
  */
 RV_STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
 {
-  return((uint32_t)((NVIC->IACTR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
+	return((uint32_t)((NVIC->IACTR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0));
 }
 
 /*********************************************************************
@@ -4474,27 +13105,64 @@ RV_STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
  */
 RV_STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint8_t priority)
 {
-  NVIC->IPRIOR[(uint32_t)(IRQn)] = priority;
+	NVIC->IPRIOR[(uint32_t)(IRQn)] = priority;
+}
+
+/*********************************************************************
+ * SUSPEND ALL INTERRUPTS EXCEPT
+ * The following 3 functions serve to suspend all interrupts, except for the one you momentarily need.
+ * The purpose of this is to not disturb the one interrupt of interest and let it run unimpeded.
+ * procedure:
+ * 1. save the enabled IRQs: uint32_t IRQ_backup = NVIC_get_enabled_IRQs();
+ * 2. disable all IRQs: NVIC_clear_all_IRQs_except(IRQ_of_interest);
+ * 3. restore the previously enabled IRQs: NVIC_restore_IRQs(IRQ_backup);
+ * 
+ * bit layout of the IRQ backup
+ * bit		0 | 1 | 2  |  3  | 4  |  5  | 6  .. 22 | 23 .. 28
+ * IRQn		2 | 3 | 12 | res | 14 | res | 16 .. 31 | 32 .. 38
+ * IRQn 2 and 3 aren't actually user-settable (see RM).
+ * 
+ * Specifying an invalid IRQn_to_keep like 0 will disable all interrupts.
+ */
+
+RV_STATIC_INLINE uint32_t NVIC_get_enabled_IRQs()
+{
+	return ( ((NVIC->ISR[0] >> 2) & 0b11) | ((NVIC->ISR[0] >> 12) << 2) | ((NVIC->ISR[1] & 0b1111111) << 23) );
+}
+
+RV_STATIC_INLINE void NVIC_clear_all_IRQs_except(uint8_t IRQn_to_keep)
+{
+	if (!(IRQn_to_keep >> 5)) {		// IRQn_to_keep < 32
+		NVIC->IRER[0] = (~0) & (~(1 << IRQn_to_keep));
+		NVIC->IRER[1] = (~0);
+	}
+	else {
+		IRQn_to_keep = IRQn_to_keep >> 5;
+		NVIC->IRER[0] = (~0);
+		NVIC->IRER[1] = (~0) & (~(1 << IRQn_to_keep));
+	}
+}
+
+RV_STATIC_INLINE void NVIC_restore_IRQs(uint32_t old_state)
+{
+	NVIC->IENR[0] = (old_state >> 2) << 12;
+	NVIC->IENR[1] = old_state >> 23;
 }
 
 /*********************************************************************
  * @fn       __WFI
- *
  * @brief   Wait for Interrupt
- *
  * @return  none
  */
 __attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFI(void)
 {
-  NVIC->SCTLR &= ~(1<<3);   // wfi
-  asm volatile ("wfi");
+	NVIC->SCTLR &= ~(1<<3);   // wfi
+	__ASM volatile ("wfi");
 }
 
 /*********************************************************************
  * @fn       __WFE
- *
  * @brief   Wait for Events
- *
  * @return  none
  */
 __attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFE(void)
@@ -4504,15 +13172,13 @@ __attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFE(void)
   t = NVIC->SCTLR;
   NVIC->SCTLR |= (1<<3)|(1<<5);     // (wfi->wfe)+(__sev)
   NVIC->SCTLR = (NVIC->SCTLR & ~(1<<5)) | ( t & (1<<5));
-  asm volatile ("wfi");
-  asm volatile ("wfi");
+  __ASM volatile ("wfi");
+  __ASM volatile ("wfi");
 }
 
 /*********************************************************************
  * @fn      SetVTFIRQ
- *
  * @brief   Set VTF Interrupt
- *
  * @param   addr - VTF interrupt service function base address.
  *                  IRQn - Interrupt Numbers
  *                  num - VTF Interrupt Numbers
@@ -4521,24 +13187,22 @@ __attribute__( ( always_inline ) ) RV_STATIC_INLINE void __WFE(void)
  * @return  none
  */
 RV_STATIC_INLINE void SetVTFIRQ(uint32_t addr, IRQn_Type IRQn, uint8_t num, FunctionalState NewState){
-  if(num > 1)  return ;
+	if(num > 1)  return ;
 
-  if (NewState != DISABLE)
-  {
-      NVIC->VTFIDR[num] = IRQn;
-      NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)|0x1);
-  }
-  else{
-      NVIC->VTFIDR[num] = IRQn;
-      NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)&(~0x1));
-  }
+	if (NewState != DISABLE)
+	{
+		NVIC->VTFIDR[num] = IRQn;
+		NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)|0x1);
+	}
+	else{
+		NVIC->VTFIDR[num] = IRQn;
+		NVIC->VTFADDR[num] = ((addr&0xFFFFFFFE)&(~0x1));
+	}
 }
 
 /*********************************************************************
  * @fn       NVIC_SystemReset
- *
  * @brief   Initiate a system reset request
- *
  * @return  none
  */
 RV_STATIC_INLINE void NVIC_SystemReset(void)
@@ -4546,64 +13210,137 @@ RV_STATIC_INLINE void NVIC_SystemReset(void)
   NVIC->CFGR = NVIC_KEY3|(1<<7);
 }
 
+// For configuring INTSYSCR, for interrupt nesting + hardware stack enable.
+static inline uint32_t __get_INTSYSCR(void)
+{
+	uint32_t result;
+	__ASM volatile("csrr %0, 0x804": "=r"(result));
+	return (result);
+}
 
+static inline void __set_INTSYSCR( uint32_t value )
+{
+    __ASM volatile("csrw 0x804, %0" : : "r"(value));
+}
+
+#if defined(CH32V30x)
+/*********************************************************************
+ * @fn      __get_FFLAGS
+ *
+ * @brief   Return the Floating-Point Accrued Exceptions
+ *
+ * @return  fflags value
+ */
+static inline uint32_t __get_FFLAGS(void)
+{
+	uint32_t result;
+	__ASM volatile ( "csrr %0," "fflags" : "=r" (result) );
+	return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_FFLAGS
+ * @brief   Set the Floating-Point Accrued Exceptions
+ * @param   value  - set FFLAGS value
+ * @return  none
+ */
+static inline void __set_FFLAGS(uint32_t value)
+{
+	__ASM volatile ("csrw fflags, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_FRM
+ * @brief   Return the Floating-Point Dynamic Rounding Mode
+ * @return  frm value
+ */
+static inline uint32_t __get_FRM(void)
+{
+	uint32_t result;
+	__ASM volatile ( "csrr %0," "frm" : "=r" (result) );
+	return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_FRM
+ * @brief   Set the Floating-Point Dynamic Rounding Mode
+ * @param   value  - set frm value
+ * @return  none
+ */
+static inline void __set_FRM(uint32_t value)
+{
+	__ASM volatile ("csrw frm, %0" : : "r" (value) );
+}
+
+/*********************************************************************
+ * @fn      __get_FCSR
+ * @brief   Return the Floating-Point Control and Status Register
+ * @return  fcsr value
+ */
+static inline uint32_t __get_FCSR(void)
+{
+	uint32_t result;
+	__ASM volatile ( "csrr %0," "fcsr" : "=r" (result) );
+	return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_FCSR
+ * @brief   Set the Floating-Point Dynamic Rounding Mode
+ * @param   value  - set fcsr value
+ * @return  none
+ */
+static inline void __set_FCSR(uint32_t value)
+{
+	__ASM volatile ("csrw fcsr, %0" : : "r" (value) );
+}
+
+#endif // CH32V30x
 
 /*********************************************************************
  * @fn      __get_MSTATUS
- *
  * @brief   Return the Machine Status Register
- *
  * @return  mstatus value
  */
 static inline uint32_t __get_MSTATUS(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0," "mstatus": "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0," "mstatus": "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __set_MSTATUS
- *
  * @brief   Set the Machine Status Register
- *
  * @param   value  - set mstatus value
- *
  * @return  none
  */
 static inline void __set_MSTATUS(uint32_t value)
 {
-    __ASM volatile("csrw mstatus, %0" : : "r"(value));
+	__ASM volatile("csrw mstatus, %0" : : "r"(value));
 }
 
 /*********************************************************************
  * @fn      __get_MISA
- *
  * @brief   Return the Machine ISA Register
- *
  * @return  misa value
  */
 static inline uint32_t __get_MISA(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0,""misa" : "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0,""misa" : "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __set_MISA
- *
  * @brief   Set the Machine ISA Register
- *
  * @param   value  - set misa value
- *
  * @return  none
  */
 static inline void __set_MISA(uint32_t value)
 {
-    __ASM volatile("csrw misa, %0" : : "r"(value));
+	__ASM volatile("csrw misa, %0" : : "r"(value));
 }
 
 /*********************************************************************
@@ -4615,185 +13352,176 @@ static inline void __set_MISA(uint32_t value)
  */
 static inline uint32_t __get_MTVEC(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0," "mtvec": "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0," "mtvec": "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __set_MTVEC
- *
  * @brief   Set the Machine Trap-Vector Base-Address Register
- *
  * @param   value  - set mtvec value
- *
  * @return  none
  */
 static inline void __set_MTVEC(uint32_t value)
 {
-    __ASM volatile("csrw mtvec, %0":: "r"(value));
+	__ASM volatile("csrw mtvec, %0":: "r"(value));
 }
 
 /*********************************************************************
  * @fn      __get_MSCRATCH
- *
  * @brief   Return the Machine Seratch Register
- *
  * @return  mscratch value
  */
 static inline uint32_t __get_MSCRATCH(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0," "mscratch" : "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0," "mscratch" : "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __set_MSCRATCH
- *
  * @brief   Set the Machine Seratch Register
- *
  * @param   value  - set mscratch value
- *
  * @return  none
  */
 static inline void __set_MSCRATCH(uint32_t value)
 {
-    __ASM volatile("csrw mscratch, %0" : : "r"(value));
+	__ASM volatile("csrw mscratch, %0" : : "r"(value));
 }
 
 /*********************************************************************
  * @fn      __get_MEPC
- *
  * @brief   Return the Machine Exception Program Register
- *
  * @return  mepc value
  */
 static inline uint32_t __get_MEPC(void)
 {
     uint32_t result;
 
-    __ASM volatile("csrr %0," "mepc" : "=r"(result));
+	__ASM volatile("csrr %0," "mepc" : "=r"(result));
     return (result);
 }
 
 /*********************************************************************
  * @fn      __set_MEPC
- *
  * @brief   Set the Machine Exception Program Register
- *
  * @return  mepc value
  */
 static inline void __set_MEPC(uint32_t value)
 {
-    __ASM volatile("csrw mepc, %0" : : "r"(value));
+	__ASM volatile("csrw mepc, %0" : : "r"(value));
 }
 
 /*********************************************************************
  * @fn      __get_MCAUSE
- *
  * @brief   Return the Machine Cause Register
- *
  * @return  mcause value
  */
 static inline uint32_t __get_MCAUSE(void)
 {
     uint32_t result;
 
-    __ASM volatile("csrr %0," "mcause": "=r"(result));
+	__ASM volatile("csrr %0," "mcause": "=r"(result));
     return (result);
 }
 
 /*********************************************************************
  * @fn      __set_MCAUSE
- *
  * @brief   Set the Machine Cause Register
- *
  * @return  mcause value
  */
 static inline void __set_MCAUSE(uint32_t value)
 {
-    __ASM volatile("csrw mcause, %0":: "r"(value));
+	__ASM volatile("csrw mcause, %0":: "r"(value));
+}
+
+/*********************************************************************
+ * @fn      __get_MTVAL
+ * @brief   Return the Machine Trap Value Register
+ * @return  mtval value
+ */
+static inline uint32_t __get_MTVAL(void)
+{
+	uint32_t result;
+
+	__ASM volatile ( "csrr %0," "mtval" : "=r" (result) );
+	return (result);
+}
+
+/*********************************************************************
+ * @fn      __set_MTVAL
+ * @brief   Set the Machine Trap Value Register
+ * @return  mtval value
+ */
+static inline void __set_MTVAL(uint32_t value)
+{
+	__ASM volatile ("csrw mtval, %0" : : "r" (value) );
 }
 
 /*********************************************************************
  * @fn      __get_MVENDORID
- *
  * @brief   Return Vendor ID Register
- *
  * @return  mvendorid value
  */
 static inline uint32_t __get_MVENDORID(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0,""mvendorid": "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0,""mvendorid": "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __get_MARCHID
- *
  * @brief   Return Machine Architecture ID Register
- *
  * @return  marchid value
  */
 static inline uint32_t __get_MARCHID(void)
 {
-    uint32_t result;
+	uint32_t result;
 
-    __ASM volatile("csrr %0,""marchid": "=r"(result));
-    return (result);
+	__ASM volatile("csrr %0,""marchid": "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __get_MIMPID
- *
  * @brief   Return Machine Implementation ID Register
- *
  * @return  mimpid value
  */
 static inline uint32_t __get_MIMPID(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0,""mimpid": "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0,""mimpid": "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __get_MHARTID
- *
  * @brief   Return Hart ID Register
- *
  * @return  mhartid value
  */
 static inline uint32_t __get_MHARTID(void)
 {
-    uint32_t result;
-
-    __ASM volatile("csrr %0,""mhartid": "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile("csrr %0,""mhartid": "=r"(result));
+	return (result);
 }
 
 /*********************************************************************
  * @fn      __get_SP
- *
  * @brief   Return SP Register
- *
  * @return  SP value
  */
 static inline uint32_t __get_SP(void)
 {
-    uint32_t result;
-
-    __ASM volatile("mv %0,""sp": "=r"(result):);
-    return (result);
+	uint32_t result;
+	__ASM volatile("mv %0,""sp": "=r"(result):);
+	return (result);
 }
 
-
+#endif
 
 #ifdef __cplusplus
 }
@@ -4806,42 +13534,380 @@ static inline uint32_t __get_SP(void)
 ///////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-
-
-#ifndef _CH32V003_MISC
-#define _CH32V003_MISC
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define DELAY_US_TIME (SYSTEM_CORE_CLOCK / 8000000)
-#define DELAY_MS_TIME (SYSTEM_CORE_CLOCK / 8000)
+/* SYSTICK info
+ * time on the ch32v003 is kept by the SysTick counter (32bit)
+ * by default, it will operate at (FUNCONF_SYSTEM_CORE_CLOCK / 8) = 6MHz
+ * more info at https://github.com/cnlohr/ch32v003fun/wiki/Time
+*/
+
+#if defined( FUNCONF_SYSTICK_USE_HCLK ) && FUNCONF_SYSTICK_USE_HCLK && !defined(CH32V10x)
+#define DELAY_US_TIME ((FUNCONF_SYSTEM_CORE_CLOCK)/1000000)
+#define DELAY_MS_TIME ((FUNCONF_SYSTEM_CORE_CLOCK)/1000)
+#else // Use systick = hclk/8
+#define DELAY_US_TIME ((FUNCONF_SYSTEM_CORE_CLOCK)/8000000)
+#define DELAY_MS_TIME ((FUNCONF_SYSTEM_CORE_CLOCK)/8000)
+#endif
+
+#define Delay_Us(n) DelaySysTick( (n) * DELAY_US_TIME )
+#define Delay_Ms(n) DelaySysTick( (n) * DELAY_MS_TIME )
+
+#define Ticks_from_Us(n)	(n * DELAY_US_TIME)
+#define Ticks_from_Ms(n)	(n * DELAY_MS_TIME)
+
+// Add a certain number of nops.  Note: These are usually executed in pairs
+// and take two cycles, so you typically would use 0, 2, 4, etc.
+#define ADD_N_NOPS( n ) asm volatile( ".rept " #n "\nc.nop\n.endr" );
+
+// Arduino-like GPIO Functionality
+#define GpioOf( pin ) ((GPIO_TypeDef *)(GPIOA_BASE + 0x400 * ((pin)>>4)))
+
+#define FUN_HIGH 0x1
+#define FUN_LOW 0x0
+#define FUN_OUTPUT (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)
+#define FUN_INPUT (GPIO_CNF_IN_FLOATING)
+
+#define PA1 1
+#define PA2 2
+#define PC0 32
+#define PC1 33
+#define PC2 34
+#define PC3 35
+#define PC4 36
+#define PC5 37
+#define PC6 38
+#define PC7 39
+#define PD0 48
+#define PD1 49
+#define PD2 50
+#define PD3 51
+#define PD4 52
+#define PD5 53
+#define PD6 54
+#define PD7 55
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined( CH32X03x )
+#define PA0 0
+#define PA3 3
+#define PA4 4
+#define PA5 5
+#define PA6 6
+#define PA7 7
+#define PA8 8
+#define PA9 9
+#define PA10 10
+#define PA11 11
+#define PA12 12
+#define PA13 13
+#define PA14 14
+#define PA15 15
+#define PB0 16
+#define PB1 17
+#define PB2 18
+#define PB3 19
+#define PB4 20
+#define PB5 21
+#define PB6 22
+#define PB7 23
+#define PB8 24
+#define PB9 25
+#define PB10 26
+#define PB11 27
+#define PB12 28
+#define PB13 29
+#define PB14 30
+#define PB15 31
+#define PC8 40
+#define PC9 41
+#define PC10 42
+#define PC11 43
+#define PC12 44
+#define PC13 45
+#define PC14 46
+#define PC15 47
+#endif
+
+
+// For pins, use things like PA8, PB15
+// For configuration, use things like GPIO_CFGLR_OUT_10Mhz_PP
+
+#define funDigitalWrite( pin, value ) { GpioOf( pin )->BSHR = 1<<((!(value))*16 + ((pin) & 0xf)); }
+
+#if defined(CH32X03x)
+#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC ); }
+#define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
+#elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOD ); }
+#define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
+#define funGpioInitB() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOB ); }
+#else
+#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOD ); }
+#define funPinMode( pin, mode ) { GpioOf(pin)->CFGLR = (GpioOf(pin)->CFGLR & (~(0xf<<(4*((pin)&0xf))))) | ((mode)<<(4*((pin)&0xf))); }
+#endif
+
+#define funGpioInitA() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA ); }
+#define funGpioInitC() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOC ); }
+#define funGpioInitD() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOD ); }
+#define funDigitalRead( pin ) ((GpioOf(pin)->INDR >> ((pin)&0xf)) & 1)
+
+
+
+#if defined(__riscv) || defined(__riscv__) || defined( CH32V003FUN_BASE )
+
+// Stuff that can only be compiled on device (not for the programmer, or other host programs)
+
+#ifndef __ASSEMBLER__
+void handle_reset()            __attribute__((naked)) __attribute((section(".text.handle_reset"))) __attribute__((used));
+void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) __attribute__((naked)) __attribute__((used));
+// used to clear the CSS flag in case of clock fail switch
+#if defined(FUNCONF_USE_CLK_SEC) && FUNCONF_USE_CLK_SEC
+	void NMI_RCC_CSS_IRQHandler( void ) __attribute__((section(".text.vector_handler"))) __attribute__((naked)) __attribute__((used));
+#endif
+#endif
+
+// For debug writing to the debug interface.
+#if defined(CH32V003)
+	#define DMDATA0 ((volatile uint32_t*)0xe00000f4)
+	#define DMDATA1 ((volatile uint32_t*)0xe00000f8)
+#else
+	#define DMDATA0 ((volatile uint32_t*)0xe0000380)
+	#define DMDATA1 ((volatile uint32_t*)0xe0000384)
+#endif
+
+#endif
+
+// Determination of PLL multiplication factor for non-V003 chips
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+	#if !defined(FUNCONF_SYSTEM_CORE_CLOCK)
+		#define PLL_MULTIPLICATION ((uint32_t)0)
+	#else
+		#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x_D8)
+			#if FUNCONF_PLL_MULTIPLIER == 2
+				#define PLL_MULTIPLICATION RCC_PLLMULL2
+			#elif FUNCONF_PLL_MULTIPLIER == 3
+				#define PLL_MULTIPLICATION RCC_PLLMULL3
+			#elif FUNCONF_PLL_MULTIPLIER == 4
+				#define PLL_MULTIPLICATION RCC_PLLMULL4
+			#elif FUNCONF_PLL_MULTIPLIER == 5
+				#define PLL_MULTIPLICATION RCC_PLLMULL5
+			#elif FUNCONF_PLL_MULTIPLIER == 6
+				#define PLL_MULTIPLICATION RCC_PLLMULL6
+			#elif FUNCONF_PLL_MULTIPLIER == 7
+				#define PLL_MULTIPLICATION RCC_PLLMULL7
+			#elif FUNCONF_PLL_MULTIPLIER == 8
+				#define PLL_MULTIPLICATION RCC_PLLMULL8
+			#elif FUNCONF_PLL_MULTIPLIER == 9
+				#define PLL_MULTIPLICATION RCC_PLLMULL9
+			#elif FUNCONF_PLL_MULTIPLIER == 10
+				#define PLL_MULTIPLICATION RCC_PLLMULL10
+			#elif FUNCONF_PLL_MULTIPLIER == 11
+				#define PLL_MULTIPLICATION RCC_PLLMULL11
+			#elif FUNCONF_PLL_MULTIPLIER == 12
+				#define PLL_MULTIPLICATION RCC_PLLMULL12
+			#elif FUNCONF_PLL_MULTIPLIER == 13
+				#define PLL_MULTIPLICATION RCC_PLLMULL13
+			#elif FUNCONF_PLL_MULTIPLIER == 14
+				#define PLL_MULTIPLICATION RCC_PLLMULL14
+			#elif FUNCONF_PLL_MULTIPLIER == 15
+				#define PLL_MULTIPLICATION RCC_PLLMULL15
+			#elif FUNCONF_PLL_MULTIPLIER == 16
+				#define PLL_MULTIPLICATION RCC_PLLMULL16
+			#elif defined(CH32V20x) && FUNCONF_PLL_MULTIPLIER == 18
+				#define PLL_MULTIPLICATION RCC_PLLMULL18
+			#else
+				#error "Invalid PLL multiplier"
+			#endif
+		#else
+			#if FUNCONF_PLL_MULTIPLIER == 3
+				#define PLL_MULTIPLICATION RCC_PLLMULL3_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 4
+				#define PLL_MULTIPLICATION RCC_PLLMULL4_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 5
+				#define PLL_MULTIPLICATION RCC_PLLMULL5_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 6
+				#define PLL_MULTIPLICATION RCC_PLLMULL6_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 7
+				#define PLL_MULTIPLICATION RCC_PLLMULL7_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 8
+				#define PLL_MULTIPLICATION RCC_PLLMULL8_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 9
+				#define PLL_MULTIPLICATION RCC_PLLMULL9_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 10
+				#define PLL_MULTIPLICATION RCC_PLLMULL10_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 11
+				#define PLL_MULTIPLICATION RCC_PLLMULL11_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 12
+				#define PLL_MULTIPLICATION RCC_PLLMULL12_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 13
+				#define PLL_MULTIPLICATION RCC_PLLMULL13_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 14
+				#define PLL_MULTIPLICATION RCC_PLLMULL14_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 15
+				#define PLL_MULTIPLICATION RCC_PLLMULL15_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 16
+				#define PLL_MULTIPLICATION RCC_PLLMULL16_EXTEN
+			#elif FUNCONF_PLL_MULTIPLIER == 18
+				#define PLL_MULTIPLICATION RCC_PLLMULL18_EXTEN
+			#else
+				#error "Invalid PLL multiplier"
+			#endif
+		#endif
+	#endif
+#endif
+
+#ifndef __ASSEMBLER__
 
 void DelaySysTick( uint32_t n );
 
-#define Delay_Us(n) DelaySysTick( n * DELAY_US_TIME )
-#define Delay_Ms(n) DelaySysTick( n * DELAY_MS_TIME )
+
+// Depending on a LOT of factors, it's about 6 cycles per n.
+// **DO NOT send it zero or less.**
+#ifndef __MACOSX__
+#ifndef __DELAY_TINY_DEFINED__
+#define __DELAY_TINY_DEFINED__
+static inline void Delay_Tiny( int n ) {
+	__ASM volatile( "\
+		mv a5, %[n]\n\
+		1: \
+		c.addi a5, -1\n\
+		c.bnez a5, 1b" : : [n]"r"(n) : "a5" );
+}
+#endif
+#endif
+
 
 // Tricky: We need to make sure main and SystemInit() are preserved.
 int main() __attribute__((used));
-void SystemInit(void) __attribute__((used));
+void SystemInit(void);
 
-// Useful functions
-void SystemInit48HSI( void );
-
-#define UART_BAUD_RATE 115200
-#define OVER8DIV 4
-#define INTEGER_DIVIDER (((25 * (APB_CLOCK)) / ((OVER8DIV) * (UART_BAUD_RATE))))
-#define FRACTIONAL_DIVIDER ((INTEGER_DIVIDER)%100)
-#define UART_BRR ((((INTEGER_DIVIDER) / 100) << 4) | (((((FRACTIONAL_DIVIDER) * ((OVER8DIV)*2)) + 50)/100)&7))
+#ifdef FUNCONF_UART_PRINTF_BAUD
+	#define UART_BAUD_RATE FUNCONF_UART_PRINTF_BAUD
+#else
+	#define UART_BAUD_RATE 115200
+#endif
+// Debug UART baud rate register calculation. Works assuming HCLK prescaler is off.
+// Computes UART_BRR = CORE_CLOCK / BAUD_RATE with rounding to closest integer
+#define UART_BRR (((FUNCONF_SYSTEM_CORE_CLOCK) + (UART_BAUD_RATE)/2) / (UART_BAUD_RATE))
 // Put an output debug UART on Pin D5.
 // You can write to this with printf(...) or puts(...)
-// Call with SetupUART( UART_BRR )
+
 void SetupUART( int uartBRR );
+
+void WaitForDebuggerToAttach();
+
+// Just a definition to the internal _write function.
+int _write(int fd, const char *buf, int size);
+
+// Call this to busy-wait the polling of input.
+void poll_input();
+
+// Receiving bytes from host.  Override if you wish.
+void handle_debug_input( int numbytes, uint8_t * data );
+
+#endif
+
+#ifdef CH32V003 // CH32V003-only
+
+// xw_ext.inc, thanks to @macyler, @jnk0le, @duk for this reverse engineering.
+
+/*
+Encoder for some of the proprietary 'XW' RISC-V instructions present on the QingKe RV32 processor.
+Examples:
+	XW_C_LBU(a3, a1, 27); // c.xw.lbu a3, 27(a1)
+	XW_C_SB(a0, s0, 13);  // c.xw.sb a0, 13(s0)
+
+	XW_C_LHU(a5, a5, 38); // c.xw.lhu a5, 38(a5)
+	XW_C_SH(a2, s1, 14);  // c.xw.sh a2, 14(s1)
+*/
+
+// Let us do some compile-time error checking.
+#define ASM_ASSERT(COND) .if (!(COND)); .err; .endif
+
+// Integer encodings of the possible compressed registers.
+#define C_s0 0
+#define C_s1 1
+#define C_a0 2
+#define C_a1 3
+#define C_a2 4
+#define C_a3 5
+#define C_a4 6
+#define C_a5 7
+
+// register to encoding
+#define REG2I(X) (C_ ## X)
+
+// XW opcodes
+#define XW_OP_LBUSP 0b1000000000000000
+#define XW_OP_STSP  0b1000000001000000
+
+#define XW_OP_LHUSP 0b1000000000100000
+#define XW_OP_SHSP  0b1000000001100000
+
+#define XW_OP_LBU   0b0010000000000000
+#define XW_OP_SB    0b1010000000000000
+
+#define XW_OP_LHU   0b0010000000000010
+#define XW_OP_SH    0b1010000000000010
+
+// The two different XW encodings supported at the moment.
+#define XW_ENCODE1(OP, R1, R2, IMM) ASM_ASSERT((IMM) >= 0 && (IMM) < 32); .2byte ((OP) | (REG2I(R1) << 2) | (REG2I(R2) << 7) | \
+	(((IMM) & 0b1) << 12) | (((IMM) & 0b110) << (5 - 1)) | (((IMM) & 0b11000) << (10 - 3)))
+
+#define XW_ENCODE2(OP, R1, R2, IMM) ASM_ASSERT((IMM) >= 0 && (IMM) < 32); .2byte ((OP) | (REG2I(R1) << 2) | (REG2I(R2) << 7) | \
+	(((IMM) & 0b11) << 5) | (((IMM) & 0b11100) << (10 - 2))
+
+// Compressed load byte, zero-extend result
+#define XW_C_LBU(RD, RS, IMM) XW_ENCODE1(XW_OP_LBU, RD, RS, IMM)
+
+// Compressed store byte
+#define XW_C_SB(RS1, RS2, IMM) XW_ENCODE1(XW_OP_SB, RS1, RS2, IMM)
+
+// Compressed load half, zero-extend result
+#define XW_C_LHU(RD, RS, IMM) ASM_ASSERT(((IMM) & 1) == 0); XW_ENCODE2(XW_OP_LHU, RD, RS, ((IMM) >> 1)))
+
+// Compressed store half
+#define XW_C_SH(RS1, RS2, IMM)  ASM_ASSERT(((IMM) & 1) == 0); XW_ENCODE2(XW_OP_SH, RS1, RS2, ((IMM) >> 1)))
+
+#endif
+
+/*
+ * This file contains various parts of the official WCH EVT Headers which
+ * were originally under a restrictive license.
+ * 
+ * The collection of this file was generated by cnlohr, 2023-02-18 and
+ * AlexanderMandera, 2023-06-23
+ *
+ * While originally under a restrictive copyright, WCH has approved use
+ * under MIT-licensed use, because of inclusion in Zephyr, as well as other
+ * open-source licensed projects.
+ *
+ * These copies of the headers from WCH are available now under:
+ *
+ * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
 
 #ifdef __cplusplus
 };
 #endif
 
-#endif

--- a/example/funconfig.h
+++ b/example/funconfig.h
@@ -1,0 +1,9 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define CH32V003          1
+#define SYSTEM_CORE_CLOCK 48000000
+#define FUNCONF_USE_HSI   1
+#define FUNCONF_USE_PLL   1
+
+#endif


### PR DESCRIPTION
* Uses last stable 1.5.1 Pico-SDK instead of bleeding edge `master`, with which this firmware does not build
* Update ch32v003fun firmware to latest https://github.com/cnlohr/ch32v003fun/tree/master/ch32v003fun (plus `funconfig.h` requirements)
  * can be built with newer RISC-V toolchains, `+ziscr` fixes in inline assembly 
* Update MacOS runner to MacOS 14 (gets faster and updated precompiled RISC-V toolchained)