### PR TITLE
Download Pico SDK v1.5.1 instead of master branch

### DIFF
--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -34,14 +34,14 @@ if (NOT PICO_SDK_PATH)
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
                     GIT_SUBMODULES_RECURSE FALSE
             )
         else ()
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
             )
         endif ()
 


### PR DESCRIPTION
If PICO_SDK_PATH is not set, the cmake script will download branch master of the Pico SDK, which is not compatible with the code in this project at the moment (as mentioned in #15 ).
Fixes #16.