### PR TITLE
Fix build on debian

### DIFF
--- a/example/build.sh
+++ b/example/build.sh
@@ -8,9 +8,9 @@ mkdir -p obj
 #riscv64-unknown-elf-g++ -g -O0 -flto -ffunction-sections -static-libgcc -lgcc -march=rv32ec_zicsr -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -c blink.cpp -o obj/blink.o
 #riscv64-unknown-elf-g++ -g -O0 -flto -ffunction-sections -static-libgcc -lgcc -march=rv32ec_zicsr -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -T ch32v003fun.ld  -Wl,--gc-sections -L. -o bin/blink.elf obj/ch32v003fun.o obj/blink.o -lgcc
 
-riscv64-unknown-elf-gcc -g -O0 -flto -ffunction-sections -static-libgcc -lgcc -march=rv32ec -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -c ch32v003fun.c -o obj/ch32v003fun.o
-riscv64-unknown-elf-g++ -g -O0 -flto -ffunction-sections -static-libgcc -lgcc -march=rv32ec -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -c blink.cpp -o obj/blink.o
-riscv64-unknown-elf-g++ -g -O0 -flto -ffunction-sections -static-libgcc -lgcc -march=rv32ec -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -T ch32v003fun.ld  -Wl,--gc-sections -L. -o bin/blink.elf obj/ch32v003fun.o obj/blink.o -lgcc
+riscv64-unknown-elf-gcc -g -O0 -ffunction-sections -static-libgcc -lgcc -march=rv32ec_zicsr -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -c ch32v003fun.c -o obj/ch32v003fun.o
+riscv64-unknown-elf-g++ -g -O0 -ffunction-sections -static-libgcc -lgcc -march=rv32ec_zicsr -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -c blink.cpp -o obj/blink.o
+riscv64-unknown-elf-g++ -g -O0 -ffunction-sections -static-libgcc -lgcc -march=rv32ec_zicsr -mabi=ilp32e -I/usr/include/newlib -nostdlib -I. -Wall -T ch32v003fun.ld  -Wl,--gc-sections -L. -o bin/blink.elf obj/ch32v003fun.o obj/blink.o -lgcc
 
 riscv64-unknown-elf-size bin/blink.elf
 riscv64-unknown-elf-objdump -S bin/blink.elf > bin/blink.lst

--- a/src/PicoSWIO.cpp
+++ b/src/PicoSWIO.cpp
@@ -58,10 +58,10 @@ void PicoSWIO::reset(int pin) {
   // If we use the sdk functions to do this we get jitter :/
   sio_hw->gpio_clr    = (1 << pin);
   sio_hw->gpio_oe_set = (1 << pin);
-  iobank0_hw->io[pin].ctrl = GPIO_FUNC_SIO << IO_BANK0_GPIO0_CTRL_FUNCSEL_LSB;
+  io_bank0_hw->io[pin].ctrl = GPIO_FUNC_SIO << IO_BANK0_GPIO0_CTRL_FUNCSEL_LSB;
   busy_wait(100); // ~8 usec
   sio_hw->gpio_oe_clr = (1 << pin);
-  iobank0_hw->io[pin].ctrl = GPIO_FUNC_PIO0 << IO_BANK0_GPIO0_CTRL_FUNCSEL_LSB;
+  io_bank0_hw->io[pin].ctrl = GPIO_FUNC_PIO0 << IO_BANK0_GPIO0_CTRL_FUNCSEL_LSB;
 
   // Enable debug output pin on target
   put(WCH_DM_SHDWCFGR, 0x5AA50400);


### PR DESCRIPTION
Some more fixes for modern debian
  * gcc/g++ fails if LTO is enabled
  * gcc/g++ need zicsr extension be enabled explicitly
  * fix old problem with renamed iobank0_hw to io_bank0_hw
